### PR TITLE
feat(site): v7.7 refresh — homepage + /verticals + /cockpit + /explainer + 10-IS architecture

### DIFF
--- a/docs/ops/HANDOVER-2026-05-01.md
+++ b/docs/ops/HANDOVER-2026-05-01.md
@@ -1,0 +1,146 @@
+# Handover — 2026-05-01 — Mirror Foundation
+
+**Tier:** operational
+**Substrate gate:** not invoked (no SIP/SIS/ALLIANCE/STACK/VERTICALS/VOICES/REGISTRY edits, no taxonomy, no attestation)
+**Test baseline:** 480 voice-operator pytest passed (up from 464 in v7.6.0); 17/17 dashboard contract tests passed
+**Plan:** `docs/superpowers/plans/2026-05-01-mirror-foundation.md`
+
+## What shipped
+
+### Memory becomes a valid Obsidian vault
+
+- 6 vault MD files + 3 voice-session MD files now carry validated YAML frontmatter (additive only — every body byte preserved)
+- `memory/.obsidian/` minimal config (no plugins, no telemetry, Sync disabled, Inter + JetBrains Mono)
+- `memory/README.md` — explains dual-surface (FS truth + Obsidian view), sovereignty rules, refresh cadences
+- `memory/.gitignore` — excludes `.obsidian/workspace.json` (user-local UI state) and runtime artifacts
+
+### Frontmatter validator
+
+- `private/voice-operator/service/memory/frontmatter.py` — parse / detect_kind / validate / stamp / lint
+- `private/voice-operator/tests/test_memory_frontmatter.py` — 21 tests, all green
+- `scripts/lint_memory_frontmatter.py` — root-level CLI shim
+- Idempotent stamping; refuses to overwrite conflicting frontmatter
+- Lint exit-code-aware for CI
+
+### KG → JSON Canvas exporter
+
+- `private/voice-operator/service/memory/canvas_export.py` — converts `_brain-cache.json` clusters into a JSON Canvas mind-map
+- `private/voice-operator/tests/test_memory_canvas_export.py` — 13 tests, all green
+- `scripts/kg_to_canvas.py` — root-level CLI shim
+- `memory/atlases/brain-clusters.canvas` — generated from current cache (4 groups, 29 nodes, spec-valid)
+
+### Bases starter dashboards
+
+- `memory/bases/voice-sessions-recent.base` — last 30 days, table + cards
+- `memory/bases/decay-watch.base` — vaults with stale `last_consolidated`, voice-sessions warm-tier >90d
+- `memory/bases/brand-rollup.base` — group-by brand activity rollup
+
+### SSE retrieval-event channel — Mirror Foundation pipeline
+
+- `lib/brain-events.ts` — wire schema + lightweight runtime validation (no zod dep)
+- `lib/brain-event-bus.ts` — module-singleton in-memory pub-sub with 100-event ring buffer
+- `app/api/brain/events/route.ts` — SSE endpoint, localhost-gated, 15s heartbeat, backfill on connect
+- `app/api/brain/inject/route.ts` — POST synthetic event for testing/demo
+- `lib/use-brain-events.ts` — React hook subscriber with auto-reconnect
+- `components/BrainScene.tsx` — wired the hook (debug: true). Visual reaction parked per plan.
+- `__tests__/brain-events.test.ts` + `__tests__/run.mjs` + `__tests__/tsconfig.json` — 17 contract tests, no new dep (compile-then-`node --test`)
+- `npm run test` script added to `package.json`
+
+## How to verify (in the morning)
+
+```bash
+# 1. Frontmatter lint
+cd private/voice-operator
+python -m service.memory.frontmatter --check ../../memory
+# expect: Checked 9 memory files. All clean.
+
+# 2. Canvas regeneration
+cd ../..
+python scripts/kg_to_canvas.py memory/knowledge-graph/_brain-cache.json memory/atlases/brain-clusters.canvas
+# expect: Wrote memory/atlases/brain-clusters.canvas — nodes: 29 (groups: 4) edges: 1
+
+# 3. Python tests
+cd private/voice-operator && python -m pytest -q
+# expect: 480 passed
+
+# 4. Dashboard tests
+cd ../local-command-center/apps/dashboard && npm run test
+# expect: 17 pass
+
+# 5. Dashboard typecheck
+npm run type-check
+# expect: no errors
+
+# 6. Browser smoke
+npm run dev
+# Visit http://localhost:3007/brain — scene must render normally
+# Open devtools → Console
+curl -X POST http://localhost:3007/api/brain/inject \
+  -H "content-type: application/json" \
+  -d '{"kind":"retrieve.topk","ts":"2026-05-01T00:00:00Z","trace_id":"t1","node_ids":["n1","n2"]}'
+# expect: console shows `[brain-events] retrieve.topk {...}`
+
+# 7. Open memory/ as an Obsidian vault
+# - File → Open vault → select C:\Users\frank\Starlight-Intelligence-System\memory
+# - Verify: vault opens, all files render, Bases load, brain-clusters.canvas opens
+```
+
+## What's parked (named cuts, not forgotten)
+
+| Cut | Why parked | Un-park trigger |
+|---|---|---|
+| Sentiment classifier on capture | Adds 500MB model dep + Privacy Guardian whitelist + design call on tint mapping | Frank approves model + palette |
+| Bloom / postprocessing pass on /brain | Needs Frank's design eye on intensity, palette, perf budget | Live design session at /brain |
+| Tone.js spatial audio | Needs Frank's ear on chord choice, drone selection, mute UX | Same session as bloom |
+| Particle field idle state | Belongs with audio + bloom — they ship together as "ambient layer" | Same session |
+| Click-through Obsidian deep linking from /brain | URL scheme reliability varies by OS; needs test on Frank's exact setup | After foundation lands and someone wants it |
+| Phone PWA mirror | Tier C scope; foundation must prove first | After visual layer ships |
+| Auto-Genius-Atlas from `/discover-genius` | Vertical-tier dependency on excavation pipeline | After at least one real `/discover-genius` corpus exists |
+| `obsidian-bases-author` generator skill | Hand-authored references shipped first | When base count exceeds ~10 hand-authored |
+
+## Next-session start (one-liner)
+
+> "Wire the visual reaction in BrainScene to retrieve.topk events — pulse the cluster containing each node_id, fade after 800ms, with @react-three/postprocessing bloom enabled. Read `docs/ops/HANDOVER-2026-05-01.md` for context. The SSE channel + injector + hook are already live; this is purely the visual response."
+
+## Risks for the next session
+
+- **Activation pulse with > 60fps cost** — cluster lookup must be a Map, not a linear scan. Pre-compute clusterByNodeId at scene mount; mutate via ref, not state.
+- **Postprocessing on integrated GPUs** — bloom is ~5ms/frame. Test on Frank's actual hardware before committing intensity values.
+- **Audio autoplay policy** — browsers block AudioContext until user gesture. The orb already has this pattern; lift it directly.
+- **Obsidian vault on Windows path** — `.obsidian/workspace.json` is gitignored but tracks first-open state; if Frank opens the vault in a different machine, expect a one-time prompt.
+
+## Related work touched / not touched
+
+- **Touched** (additive): `private/local-command-center/apps/dashboard/components/BrainScene.tsx` — added one import + one hook call. Existing scene logic unchanged.
+- **Touched** (additive): `private/local-command-center/apps/dashboard/package.json` — added `test` script. Deps unchanged.
+- **Not touched**: `service/memory/router.py`, `audit.py`, `guardian.py`, `bencher.py`, `cli.py`, `contract.py` — orchestrator v0.1 (d9cc95b) is unaltered.
+- **Not touched**: `brain_watchdog`, `service/brain_graph` — the regen pipeline is unchanged.
+
+## Public / private split (commit reality)
+
+`private/` is gitignored per the substrate/instance privacy framework. That means **only the substrate side enters git history**; the dashboard SSE channel work lives on Frank's disk under `private/local-command-center/` but is not pushed publicly. Same with `private/voice-operator/service/memory/frontmatter.py` and `canvas_export.py` — they exist locally and run locally; the `scripts/` shims at repo root are the public-facing CLI surface that calls into them.
+
+**One public commit covers everything in this slice that's git-tracked:**
+
+`feat(memory): Mirror Foundation — Obsidian-friendly substrate + KG→Canvas + SSE event scaffold (private)`
+
+Tracked files:
+- `memory/README.md`, `memory/.gitignore`, `memory/.obsidian/` (config, not workspace.json)
+- `memory/vaults/*.md` — frontmatter prepended (6 files)
+- `memory/voice-sessions/*.md` — frontmatter prepended (3 files)
+- `memory/bases/*.base` — 3 starter dashboards
+- `memory/atlases/brain-clusters.canvas` — generated artifact (committed for reproducibility)
+- `scripts/lint_memory_frontmatter.py`, `scripts/kg_to_canvas.py` — public CLI shims
+- `docs/superpowers/plans/2026-05-01-mirror-foundation.md`
+- `docs/ops/HANDOVER-2026-05-01.md`
+
+Untracked (lives on disk only, per privacy framework):
+- `private/voice-operator/service/memory/frontmatter.py` (+ tests)
+- `private/voice-operator/service/memory/canvas_export.py` (+ tests)
+- `private/local-command-center/apps/dashboard/lib/brain-events.ts`, `brain-event-bus.ts`, `use-brain-events.ts`
+- `private/local-command-center/apps/dashboard/app/api/brain/events/route.ts`, `inject/route.ts`
+- `private/local-command-center/apps/dashboard/components/BrainScene.tsx` (1-line additive change)
+- `private/local-command-center/apps/dashboard/__tests__/*`
+- `private/local-command-center/apps/dashboard/package.json` (test script added)
+
+This is the same pattern as v7.5.3 dispatch CLI work (per memory): public scaffolds for slash commands and docs, private implementation. Substrate is public; instance is private. No /luminor-board pre-pass required (operational-tier only).

--- a/docs/ops/HANDOVER-2026-05-01.md
+++ b/docs/ops/HANDOVER-2026-05-01.md
@@ -2,8 +2,10 @@
 
 **Tier:** operational
 **Substrate gate:** not invoked (no SIP/SIS/ALLIANCE/STACK/VERTICALS/VOICES/REGISTRY edits, no taxonomy, no attestation)
-**Test baseline:** 480 voice-operator pytest passed (up from 464 in v7.6.0); 17/17 dashboard contract tests passed
+**Test baseline:** 480 voice-operator pytest passed (final); 17/17 dashboard contract tests passed; 34/34 new tests still green after merge with parallel-session commits
 **Plan:** `docs/superpowers/plans/2026-05-01-mirror-foundation.md`
+**Commit:** `8baa8b0` (1 ahead of origin/main; not pushed — push reserved for Frank)
+**Parallel-session context:** Two other commits landed during this build — `c7176b0` (substrate ratification handover by sibling Claude session, separate file `HANDOVER-2026-05-01-overnight.md`) and `7151bcc` (router bug fixes + PARKED-011/012 + root `.gitignore` additions for `memory/_audit/`, `memory/mempalace/`, `memory/benchmarks/*.json`). Both showed attribution discipline (sibling session explicitly noted: "Other sessions' drift … deliberately not touched"). My commit `8baa8b0` rebased clean on top. No file conflicts; my `memory/.gitignore` and their root `.gitignore` agree on exclusions.
 
 ## What shipped
 

--- a/docs/ops/HANDOVER-SITE-REFRESH-V77-2026-05-02.md
+++ b/docs/ops/HANDOVER-SITE-REFRESH-V77-2026-05-02.md
@@ -1,0 +1,239 @@
+# Handover — v7.7 Site Refresh PR
+
+**Date:** 2026-05-02
+**Operator:** Claude Code (Opus 4.7, 1M context, ultrawork mode)
+**Branch:** `site-refresh-v77` (forked from `main`)
+**Tier:** Operational. No substrate edit. No `/luminor-board` pre-pass.
+**Plan executed:** `docs/superpowers/plans/2026-05-02-site-refresh-v77.md`
+**Skills invoked:** `superpowers:executing-plans` + `superpowers:subagent-driven-development`
+
+---
+
+## TL;DR
+
+Marketing surface has been pulled forward ~3 substrate versions. The homepage no longer says "six semantic vaults" — it now leads with **9 intelligence layers, 35 agents, 70+ commands, 3 reference Domain Sub-Stack verticals**. Three new routes ship: `/verticals`, `/cockpit`, `/explainer`. The `/architecture` page is bumped from JSONL-only framing to the canonical 10-IS taxonomy. Footer carries a Newcomer column linking the friend-starter Claude Project pack.
+
+| Metric | Before | After |
+|---|---|---|
+| Homepage framing | "Six semantic vaults" (v7.0) | **9 intelligence layers + Domain Sub-Stack Tier (v7.6)** |
+| Public verticals story | invisible | **3 cards on /verticals** with counts + QUICK-START links |
+| Cockpit story | invisible | **/cockpit teaser** — 4 surfaces, voice loop, brain viz, drafts on disk |
+| Long-form explainer | repo-only `docs/public/starlight-intelligence-system.md` | **mirrored at /explainer** via `react-markdown` |
+| /architecture | "Six semantic vaults" framing | **10-IS table** mirroring `docs/ARCHITECTURE.md` |
+| Footer | 3 columns, generic | **4 columns + Newcomer + new-route nav** |
+| OG/title/meta | "memory layer for humans and AI agents" | **"Persistent context for AI agents · Built on SIP"** |
+
+**Quality gates:** `npx tsc --noEmit` exit 0 · `pnpm build` clean · 23/23 routes generate · all 5 changed/new routes return 200 with expected key phrases on dev server smoke test.
+
+---
+
+## What shipped (with file paths)
+
+### 1. Homepage rewrite — `site/src/app/page.tsx`
+
+Full replacement preserving aesthetic (mesh orbs, dot grid, Luminor philosophy quote, benediction layer, live vault stream, agent-API terminal block, final CTA).
+
+- **Hero:** "Persistent context. Sovereign by architecture." gradient headline. New paragraph copy with the 9-layer / 35-agent / 70+-command / 3-vertical numbers.
+- **Three CTA cards** (per plan): Adopt SIP → `/protocol` · Run the reference build → `/quickstart` · Spawn your vertical → `/verticals`.
+- **Stats bar:** 9 layers · 35 agents · 70+ commands · 3 reference verticals · 6 platform adapters.
+- **NEW: 9 Intelligence Layers section** — 9 cards (Self/Genius, Second Brain, Brand, Business, Creator, Wealth, Code, Voice & Video, Family) with closer paragraph linking `/architecture` for full 10-IS table.
+- **NEW: Domain Sub-Stack Tier section** — 3 vertical summary cards with CTA to `/verticals`.
+- **NEW: Cockpit teaser block** — 4-surface schematic linking `/cockpit`.
+- **Final CTA:** Three paths (Adopt SIP / Run reference / Spawn vertical).
+
+### 2. `/verticals` — `site/src/app/verticals/page.tsx` (new)
+
+3 cards (People · Sound · Music IS) with:
+- Tagline + sub-system pills
+- Stat tripod (sub-systems / commands / agents)
+- "Open QUICK-START" button to `verticals/<v>/QUICK-START.md` on GitHub
+- "Agents" button to `verticals/<v>/AGENTS.md` on GitHub
+- Closer section explaining `/spawn-domain-stack` pattern with code snippet
+
+### 3. `/cockpit` — `site/src/app/cockpit/page.tsx` (new)
+
+No live embed (localhost-only by design). Sections:
+- Hero: "Four surfaces. One brain. Local-first."
+- 4-cell SVG schematic of surfaces (Zellij / PowerShell / LCC Dashboard `:3007` / Phone PWA `:3008`)
+- Voice loop diagram: STT (Groq Whisper) → LLM → TTS (ElevenLabs Brian Flash) with latencies
+- 7-tool grid (shell, file_write, claude_prompt, claude_code_launch, open_url, linear_issue, workflow_run)
+- Brain viz section explaining the 4-event lifecycle and trace_id correlation
+- Drafts-on-disk section (`~/Desktop/jarvis-drafts/`)
+- Privacy posture (4 bullets — 127.0.0.1 default, Groq/ElevenLabs HTTPS, packet log on your disk, privacy gate posture)
+- CTA: Fork on GitHub / Read quickstart
+
+### 4. `/explainer` — `site/src/app/explainer/page.tsx` (new)
+
+Server component reads `docs/public/starlight-intelligence-system.md` at build time, strips the H1 + first hr block, renders body via `react-markdown` with `remark-gfm`. Source-of-truth banner at top points to GitHub blob. Mirror, never fork.
+
+- **Markdown styling:** custom `.explainer-prose` class added to `globals.css` — H2/H3/H4, paragraphs, lists, links, code, pre, blockquotes, hr, GFM tables. Matches site aesthetic (violet accent, dark surfaces, mono code).
+
+### 5. `/architecture` rewrite — `site/src/app/architecture/page.tsx`
+
+Was stale ("Six semantic vaults"). Now:
+- **Hero:** "Ten Intelligence Systems. Composed, not stacked."
+- **Foundation section:** kept the JSONL-truth framing + 4-step flow (JSONL → SQLite → MCP → AI tools).
+- **NEW: 10-IS table** — full layer enumeration (0 Substrate · 1 Genius · 2 Second Brain · 3 Brand · 4 Business · 5 Creator · 6 Wealth · 7 Code · 8 Voice & Video · 9 Family · Health cross-cutting · Spiritual optional · ★ Starlight Orchestrator master). Per-row: tier, purpose, vault namespace, posture chip.
+- **Domain Sub-Stack Tier section** — links to `/verticals`.
+- **Composition rules** — 5 bullets from `docs/ARCHITECTURE.md`.
+- **Cross-tool compounding** — kept (5 platforms → starlight-sis).
+- **Extension model** — new section explaining the 11th-IS named procedure.
+
+### 6. Footer — `site/src/components/Footer.tsx`
+
+Was 3 columns (Starlight desc · Navigate · Connect). Now 4 columns:
+1. **Starlight Intelligence** — updated description ("Persistent context for AI agents…").
+2. **Newcomer** — Friend Starter (GitHub) · Onboarding (`/quickstart`) · Welcome guide (`ONBOARDING.md` GitHub blob).
+3. **Navigate** — expanded: `/verticals` · `/cockpit` · `/explainer` · `/architecture` · `/protocol` · `/vaults` · `/docs` · API.
+4. **Connect** — GitHub · Arcanea (unchanged).
+
+Grid: `md:grid-cols-2 lg:grid-cols-4` so it stacks gracefully on mobile/tablet.
+
+### 7. Header — `site/src/components/Header.tsx`
+
+Three-tier nav:
+- **Desktop (lg)**: Verticals · Cockpit · Architecture · Protocol · Quickstart · Explainer · Vaults · GitHub · Deploy
+- **Tablet (sm-lg)**: Verticals · Cockpit · Quickstart · Architecture · GitHub
+- **Mobile (<sm)**: Verticals · Quickstart · Docs
+
+### 8. Layout OG/meta — `site/src/app/layout.tsx`
+
+- **Title default:** "Starlight Intelligence — Persistent context for AI agents · Built on SIP"
+- **Description:** "A persistent context and memory architecture for AI agents. 9 intelligence layers, 35 agents, 70+ commands, 3 reference Domain Sub-Stack verticals. Built on the Starlight Intelligence Protocol. Local-first. Forkable. Free."
+- **OpenGraph + Twitter:** matching titles + descriptions.
+
+### 9. globals.css — `site/src/app/globals.css`
+
+Added `.explainer-prose` block (~80 lines) for markdown body styling on `/explainer`. Self-contained, no Tailwind plugin dependency.
+
+### 10. New deps — `site/package.json`
+
+- `react-markdown@10.1.0`
+- `remark-gfm@4.0.1`
+
+97 transitive packages. `pnpm-lock.yaml` updated. No version bumps to existing deps.
+
+---
+
+## Verification ledger
+
+| Check | Result |
+|---|---|
+| `npx tsc --noEmit` | **exit 0** (clean) |
+| `pnpm build` | **clean** — 23 pages generated (4 changed routes + 1 added: `/verticals`, `/cockpit`, `/explainer`) |
+| Static generation | All 5 changed/new routes generate as `○ (Static)` with 1h revalidate |
+| Dev server smoke (`/`, `/verticals`, `/cockpit`, `/explainer`, `/architecture`) | **all 200**, body sizes 71-163 KB |
+| Content fidelity smoke | Each route contains expected key phrases (verified via grep): "Persistent context" + "9 intelligence layers" + "35 agents" / "People Intelligence" + "spawn-domain-stack" / "Four surfaces" + "Zellij" / "Phase 1" + "Built on SIP" / "Ten Intelligence" + "Starlight Orchestrator" |
+| Spec compliance review | Dispatched parallel subagent — see `[reviewer verdict]` (separate artifact) |
+| Lighthouse | Not run in this session — Frank to check post-deploy |
+
+---
+
+## Plan acceptance criteria checklist
+
+- [x] `/` no longer says "six semantic vaults"; reads 9-IS + Domain Sub-Stack
+- [x] `/verticals` lists People, Sound, Music IS with accurate counts (6/28/6, 6/30/6, 6+1/8/7)
+- [x] `/cockpit` teaser describes the local cockpit (no live embed, no screenshot — placeholder schematic instead)
+- [x] Footer has a "Newcomer" column with friend-starter link
+- [x] `/architecture` shows 10-layer architecture (mirrors canonical `docs/ARCHITECTURE.md`)
+- [x] `/explainer` renders `docs/public/starlight-intelligence-system.md` content
+- [x] `<title>` and `<meta name="description">` updated
+- [x] `next build` clean
+- [ ] Vercel deploy preview checked manually before merge — **Frank to verify post-PR**
+- [ ] Lighthouse score not regressed (baseline pre-PR) — **Frank to run post-deploy**
+- [ ] Production URL reflects new homepage within 5 min of merge — **Frank to verify**
+
+---
+
+## What was NOT touched — and exactly why
+
+| Surface | Why skipped |
+|---|---|
+| `site/public/cockpit-screenshot.png` | Frank captures from demo machine — `/cockpit` page uses 4-cell SVG schematic placeholder until then |
+| Substrate files (`SIP.md`, `SIS.md`, `ALLIANCE.md`, etc.) | Operational tier work; substrate edits would require `/luminor-board` pre-pass |
+| Demo path (orb, `tools.mjs`, `start-cockpit.ps1`) | Demo on 2026-04-30 was successful; no autonomous edits |
+| `verticals/<v>/` content | Plan scoped these as future work; v7.7 only updates marketing surface |
+| `/luminor-board` invocation | Operational tier ships under `/superintelligence` without pre-board — this is correct per CLAUDE.md v7.5.1+ governance |
+| `git push origin` | Frank curates ship gate. Branch is local until you push |
+
+---
+
+## Files touched (clean diff inventory)
+
+```
+Modified:
+  site/src/app/page.tsx                — homepage rewrite
+  site/src/app/layout.tsx              — OG/meta + title
+  site/src/app/architecture/page.tsx   — 10-IS bump
+  site/src/app/globals.css             — .explainer-prose styles
+  site/src/components/Header.tsx       — new nav links + 3-tier breakpoints
+  site/src/components/Footer.tsx       — Newcomer column + expanded Navigate
+  site/package.json                    — react-markdown + remark-gfm
+  site/pnpm-lock.yaml                  — lockfile
+
+Net-new:
+  site/src/app/verticals/page.tsx      — 3 vertical cards + spawn pattern
+  site/src/app/cockpit/page.tsx        — 4-surface teaser
+  site/src/app/explainer/page.tsx      — markdown mirror
+  docs/ops/HANDOVER-SITE-REFRESH-V77-2026-05-02.md  — this file
+```
+
+Estimated diff: **~+1,200 / -200 LOC** (the v77 plan estimated +600/-150; came in slightly larger because of the comprehensive layer cards on the homepage and the full 10-IS table on `/architecture`).
+
+---
+
+## Risks + mitigation
+
+| Risk | Mitigation |
+|---|---|
+| Vercel auto-deploy regresses (broken since 2026-04-10, restored via GHA at v7.5) | Verify GHA `vercel-deploy.yml` fires on merge. If silent, run `vercel --prod` from `site/` manually per `project_vercel_manual.md` memory |
+| Stale OG cache shows old description on Twitter/LinkedIn | Trigger debugger refresh post-deploy |
+| `/explainer` markdown renders break on heavy GFM features | `react-markdown` with `remark-gfm` handles tables/strikethrough; smoke tested on dev server (`Phase 1` + `Phase 5` + `Built on SIP` all rendered) |
+| Site copy gets ahead of substrate again in 2 weeks | Future: every substrate `/luminor-board` ratification at vN+1 includes a "site update needed?" check item in the board verdict template |
+| Multiple lockfile warning on `pnpm build` | Pre-existing. Harmless. Caused by Windows user dir + repo root + site/ all having lockfiles |
+
+---
+
+## Recommended sequencing for Frank
+
+1. **Read this handover** + the spec reviewer verdict (~5 min).
+2. **Visual review** of dev server (still running on `:3000`) or run `cd site && pnpm dev` if killed. Click through `/`, `/verticals`, `/cockpit`, `/explainer`, `/architecture`. Verify the aesthetic matches.
+3. **Capture cockpit screenshot** from your demo machine → `site/public/cockpit-screenshot.png`. Optional — current schematic placeholder is acceptable for v1.
+4. **Commit** the branch (or fold in selectively):
+   ```bash
+   git add site/src/app/page.tsx site/src/app/layout.tsx site/src/app/architecture/page.tsx \
+           site/src/app/verticals/page.tsx site/src/app/cockpit/page.tsx site/src/app/explainer/page.tsx \
+           site/src/app/globals.css site/src/components/Header.tsx site/src/components/Footer.tsx \
+           site/package.json site/pnpm-lock.yaml \
+           docs/ops/HANDOVER-SITE-REFRESH-V77-2026-05-02.md
+   git commit -m "feat(site): v7.7 refresh — homepage + /verticals + /cockpit + /explainer + 10-IS architecture"
+   ```
+5. **Push + PR:**
+   ```bash
+   git push -u origin site-refresh-v77
+   gh pr create --title "feat(site): v7.7 refresh — homepage + /verticals + /cockpit + /explainer" \
+                --body "..."
+   ```
+6. **Vercel preview check** — verify deploy preview renders correctly on the PR.
+7. **Merge** when satisfied.
+8. **Post-deploy:** verify `starlightintelligence.org` reflects new homepage within 5 min. If not, run `vercel --prod` from `site/` manually.
+9. **Tweet** linking the new explainer or verticals page.
+
+---
+
+## Carry-forwards (NOT this PR)
+
+- **Per-vertical landing pages** (`/verticals/people-intelligence`, etc.) with full QUICK-START rendered — v7.8 next pass.
+- **Cockpit screenshot** swap once Frank captures from demo machine.
+- **Live registry of forks** ("Built on SIP" attestations indexed) — v7.8+.
+- **`/spawn` interactive page** that walks visitors through `/spawn-domain-stack` decisions — v7.8+.
+- **Public vault browser improvements** — v7.8+.
+
+---
+
+**Built on SIP** — Starlight Intelligence Protocol
+- Substrate: starlightintelligence.org/protocol v1.1.0
+- Verticals: starlight-intelligence-system@v7.7-pre · operational tier site refresh
+- Generated: 2026-05-02
+- Operator: Claude Code (Opus 4.7, 1M context)
+- No substrate edits · No demo-path edits · No `/luminor-board` pre-pass required · Single PR

--- a/docs/superpowers/plans/2026-05-01-mirror-foundation.md
+++ b/docs/superpowers/plans/2026-05-01-mirror-foundation.md
@@ -1,0 +1,166 @@
+# Mirror Foundation — 2026-05-01
+
+> Substrate-tier governance: **operational only**. No SIP/SIS/ALLIANCE/STACK/VERTICALS/VOICES/REGISTRY edits. No taxonomy changes. No attestation rule changes. `/luminor-board` pre-pass not structurally required.
+
+## Premise
+
+Frank asked for the "Mirror of Mind" — speak to Voice Operator → see memory regions activate in `/brain` → emotional tint → spatial audio. Full vision is multi-week. **This plan delivers the foundation slice that makes the vision testable**: turns `memory/` into a valid Obsidian vault, ships a KG→Canvas exporter, and stands up the SSE retrieval-event pipeline that future activation visuals will subscribe to.
+
+What this plan does **not** ship is named below in §Cuts. Naming the cuts is the plan.
+
+## Success criteria (verifiable in the morning)
+
+1. `memory/` opens cleanly in Obsidian — every `.md` has valid frontmatter, vault config present, no plugin dependency.
+2. `python -m service.memory.frontmatter --check memory/` returns 0; CI-grade lint over all 8 memory MD files.
+3. `python -m service.memory.canvas_export memory/knowledge-graph/_brain-cache.json memory/atlases/brain-clusters.canvas` produces a JSON Canvas that Obsidian renders as a cluster mind-map.
+4. 3 starter Bases dashboards render without YAML errors when opened.
+5. `GET /api/brain/events` (localhost-only) emits a heartbeat every 15s; `POST /api/brain/inject` accepts a synthetic retrieval event and the SSE channel re-emits it.
+6. `/brain` page subscribes; injecting a synthetic event logs it to browser console (full visual reaction is parked — see §Cuts).
+7. Contract test verifies event schema and localhost gating.
+8. Existing test suite stays green (no regressions in the 46 voice-operator tests + the dashboard typecheck).
+
+## Architecture
+
+```
+                    ┌─────────────────────────────────────────┐
+                    │     memory/  (filesystem source)         │
+                    │                                          │
+                    │  vaults/*.md   ←── frontmatter pass     │
+                    │  voice-sessions/*.md  ←── frontmatter   │
+                    │  knowledge-graph/index.jsonl            │
+                    │  knowledge-graph/_brain-cache.json      │
+                    │  atlases/brain-clusters.canvas  ←── new │
+                    │  bases/*.base  ←── new                  │
+                    │  README.md     ←── new                  │
+                    │  .obsidian/    ←── new (workspace only) │
+                    └────────────┬─────────────────────────────┘
+                                 │
+                ┌────────────────┼─────────────────┐
+                │                │                 │
+                ▼                ▼                 ▼
+       ┌──────────────┐  ┌─────────────┐  ┌──────────────┐
+       │   Obsidian   │  │   /brain    │  │  service/    │
+       │  (viewer)    │  │  r3f scene  │  │  memory/     │
+       │              │  │   :3007     │  │  (router)    │
+       │ wikilinks +  │  │             │  │              │
+       │ Bases +      │  │ + new SSE   │  │ + frontmatter│
+       │ Canvas       │  │   subscriber│  │ + canvas_exp │
+       └──────────────┘  └──────┬──────┘  └──────────────┘
+                                │
+                                │ EventSource
+                                ▼
+                       ┌─────────────────┐
+                       │ /api/brain/     │
+                       │   events  (SSE) │
+                       │   inject  (POST)│
+                       └─────────────────┘
+                       localhost-gated
+                       schema-validated
+```
+
+## Frontmatter schema (what we stamp)
+
+Two flavors. Additive only — never overwrite existing content.
+
+**Vault entries** (`memory/vaults/*.md`):
+```yaml
+---
+type: vault
+vault: strategic | technical | creative | operational | wisdom | horizon
+retention: permanent | rolling-90d | append-only
+writers: [navigator, prime]   # per VAULT_ARCHITECTURE.md access matrix
+readers: all
+last_consolidated: 2026-05-01
+---
+```
+
+**Voice sessions** (`memory/voice-sessions/YYYY-MM-DD.md`):
+```yaml
+---
+type: voice-session
+date: 2026-05-01
+brand: sis | arcanea | acos | ai-ops | personal | unknown
+decay_tier: hot | warm | cold
+intent_class: capture | command | build | research
+---
+```
+
+**Tags** (added to enable Bases filtering): `#vault/{name}`, `#brand/{name}`, `#tier/{hot|warm|cold}`.
+
+## Deliverables (file-by-file)
+
+### Substrate (memory layer)
+- `memory/README.md` — explains dual-surface (FS truth + Obsidian view), no Obsidian Sync, Git-only, replaceable viewer
+- `memory/.obsidian/app.json` — minimal config, telemetry off, Sync disabled
+- `memory/.obsidian/workspace.json` — opens vault on `voice-sessions/` by default
+- `memory/atlases/brain-clusters.canvas` — generated artifact (also committed for reproducibility)
+- `memory/bases/voice-sessions-recent.base` — last 30 days, table view
+- `memory/bases/decay-watch.base` — entries older than 90d at warm tier
+- `memory/bases/brand-rollup.base` — group-by brand, count + last-touch
+- 6 vault `.md` files — frontmatter prepended (no body changes)
+- 2 voice-session `.md` files — frontmatter prepended (no body changes)
+
+### Service (Python — voice-operator)
+- `private/voice-operator/service/memory/frontmatter.py` — validator + safe-prepender + CLI
+- `private/voice-operator/service/memory/canvas_export.py` — KG→Canvas converter + CLI
+- `private/voice-operator/tests/test_memory_frontmatter.py` — TDD: schema, idempotent stamping, refusal on conflict
+- `private/voice-operator/tests/test_memory_canvas_export.py` — TDD: cluster→group, node positioning, JSON Canvas spec compliance
+- `scripts/lint_memory_frontmatter.py` — root-level CLI shim
+- `scripts/kg_to_canvas.py` — root-level CLI shim
+
+### Dashboard (TypeScript)
+- `private/local-command-center/apps/dashboard/lib/brain-events.ts` — event schema + type guards (no zod; lightweight runtime check)
+- `private/local-command-center/apps/dashboard/app/api/brain/events/route.ts` — SSE endpoint, in-memory ring buffer, heartbeat
+- `private/local-command-center/apps/dashboard/app/api/brain/inject/route.ts` — POST synthetic event (test/demo only)
+- `private/local-command-center/apps/dashboard/components/BrainScene.tsx` — add `useBrainEvents()` hook (logs to console; visual layer parked)
+- `private/local-command-center/apps/dashboard/__tests__/brain-events.test.ts` — contract test (node:test, no new dep)
+
+### Docs + memory
+- `docs/ops/HANDOVER-2026-05-01.md` — what shipped, what's parked, exact next-session start
+- `memory/_handovers/2026-05-01-mirror-foundation.md` — atom for future sessions
+- New auto-memory atom + MEMORY.md index entry
+
+## Cuts (named, parked, with un-park triggers)
+
+| Cut | Why parked | Un-park trigger |
+|---|---|---|
+| Sentiment classifier on capture | Adds ~500MB model dep, needs Privacy Guardian whitelist for embedding vectors, design call on tint mapping | When Frank approves model + palette |
+| Bloom / postprocessing pass | Needs Frank's design eye on intensity, palette, perf budget | Live design session at /brain |
+| Tone.js spatial audio | Needs Frank's ear on chord choice, drone selection, mute UX | Same session as bloom |
+| Particle field idle state | Belongs with audio + bloom — they ship together as "ambient layer" | Same session |
+| Click-through Obsidian deep linking from /brain | URL scheme reliability varies by OS; needs test on Frank's exact setup | After foundation lands and someone wants it |
+| Phone PWA mirror | Tier C scope; foundation must prove first | After Mirror visual lands |
+| Auto-Genius-Atlas from `/discover-genius` | Vertical-tier dependency on excavation pipeline | After at least one real `/discover-genius` corpus exists |
+
+## Verification gates
+
+1. `cd private/voice-operator && pytest tests/test_memory_frontmatter.py tests/test_memory_canvas_export.py -v` — new tests pass
+2. `cd private/voice-operator && pytest -q` — full suite still green
+3. `cd private/local-command-center/apps/dashboard && npx tsc --noEmit` — no new typecheck errors
+4. `cd private/local-command-center/apps/dashboard && node --test __tests__/brain-events.test.ts` — contract test passes
+5. `npm run dev` (dashboard) → visit `http://localhost:3007/brain` → verify scene renders, no console errors
+6. `curl -X POST http://localhost:3007/api/brain/inject -d '{"kind":"retrieve.topk",...}'` → see in browser console
+7. Open `memory/` as Obsidian vault → verify all .md files render, Bases work, Canvas opens
+
+## Commit plan (two clean commits, both operational-tier)
+
+**Commit 1** — "feat(memory): Obsidian-friendly substrate — frontmatter + Bases + canvas export"
+- `memory/README.md`, `memory/.obsidian/`, `memory/bases/`, `memory/atlases/`, vault frontmatter, voice-session frontmatter
+- `private/voice-operator/service/memory/frontmatter.py`, `canvas_export.py`
+- `private/voice-operator/tests/test_memory_frontmatter.py`, `test_memory_canvas_export.py`
+- `scripts/lint_memory_frontmatter.py`, `scripts/kg_to_canvas.py`
+
+**Commit 2** — "feat(dashboard): SSE retrieval-event channel for /brain Mirror foundation"
+- `lib/brain-events.ts`, `app/api/brain/events/route.ts`, `app/api/brain/inject/route.ts`
+- `components/BrainScene.tsx` (subscriber hook only)
+- `__tests__/brain-events.test.ts`
+
+**Commit 3** (docs+memory) — "docs(ops): mirror foundation handover + memory atom"
+
+## Risk register
+
+- **Bash fork errors on Windows** — observed during survey ("cygheap read copy failed"). Mitigation: serialize bash calls; prefer Glob/Grep/Read over shelling out.
+- **Test runner divergence** — voice-operator uses pytest; dashboard has no test runner installed. Mitigation: use `node --test` (built-in, no dep add) for dashboard contract test.
+- **Frontmatter conflicts with existing content** — vault MD files may have leading H1 that conflicts with frontmatter. Mitigation: validator detects and refuses; manual review per file.
+- **SSE backpressure** — none expected since injector is test-only and produces ≤1 event/click. Throttling deferred until real event source wired.
+- **Localhost gate bypass** — must mirror existing `/api/brain` `BRAIN_PUBLIC=1` gate; tested in contract test.

--- a/docs/superpowers/plans/2026-05-02-site-refresh-v77.md
+++ b/docs/superpowers/plans/2026-05-02-site-refresh-v77.md
@@ -1,0 +1,174 @@
+# Site Refresh — v7.7 (post-demo)
+
+**Window:** 2026-05-02 → 2026-05-04 (Saturday afternoon → Monday).
+**Tier:** Operational (no substrate file edits).
+**Owner:** Frank.
+**Trigger:** post-2026-05-01 cockpit demos. Marketing surface is ~3 substrate versions behind the system it describes; demos created incoming traffic to a homepage that reads as v7.0.
+
+---
+
+## Why this plan exists
+
+The audit dated 2026-04-30 surfaced four structural gaps on `starlightintelligence.org`:
+
+1. **Homepage description is pre-v7.4** — "Six semantic vaults" framing, when the actual architecture is **9 universal IS layers + Domain Sub-Stack Tier** (35 agents, 70+ commands, 3 reference verticals).
+2. **No `/verticals` page** — the productization story (People + Sound + Music IS as 3 reference Domain Sub-Stacks) has zero public surface.
+3. **No `/cockpit` teaser** — the most concrete artifact in the system (4-surface local Jarvis-grade cockpit) is invisible publicly.
+4. **`docs/public/starlight-intelligence-system.md`** — polished public explainer lives in repo, not on site.
+
+A visitor lands on the homepage and cannot see Music IS, the cockpit, or the 9-IS architecture. **Conversion gap.**
+
+This plan closes the gap with a single PR. No new infrastructure. Reuses existing Next.js 16 / Tailwind 4 / src/ layout in `site/`.
+
+---
+
+## Scope
+
+| Change | File(s) | Effort |
+|---|---|---|
+| Homepage description rewrite (9-IS + Domain Sub-Stack framing) | `site/src/app/page.tsx` | 30 min |
+| New `/verticals` route — 3 cards (People, Sound, Music IS) | `site/src/app/verticals/page.tsx` (new) + nav link | 90 min |
+| New `/cockpit` teaser route — what the local cockpit does (no demo embed) | `site/src/app/cockpit/page.tsx` (new) + nav link | 60 min |
+| Footer link to `friend-starter/` Claude Project pack | `site/src/components/Footer.tsx` (or layout) | 15 min |
+| `/architecture` page bump to 9-IS framing if stale | `site/src/app/architecture/page.tsx` | 30 min |
+| Mirror `docs/public/starlight-intelligence-system.md` as `/explainer` | `site/src/app/explainer/page.tsx` (new, MDX or markdown render) | 45 min |
+| OG / meta description update | `site/src/app/layout.tsx` | 15 min |
+
+**Total: ~4 hours single push.** One PR, one Vercel deploy, one tweet.
+
+---
+
+## Sequencing
+
+### Step 1 — homepage rewrite (30 min)
+
+Replace the "memory layer for humans and AI agents — six semantic vaults" framing with:
+
+> **Starlight Intelligence System** — A persistent context and memory architecture for AI agents.
+> Built on the **Starlight Intelligence Protocol (SIP)** — a sovereign substrate anyone can adopt, fork, or compose with.
+> 9 intelligence layers, 35 agents, 70+ commands, 3 reference Domain Sub-Stack verticals (People · Sound · Music). Local-first. Forkable. Free.
+
+Three CTA cards below:
+- **Adopt SIP** → `/protocol` (canonical spec)
+- **Run the reference build** → `/quickstart`
+- **Spawn your own vertical** → `/verticals`
+
+Keep the badge (`/badge/v1.1.0`). Keep the existing aesthetic.
+
+### Step 2 — `/verticals` page (90 min)
+
+Three cards. Each card: vertical name, tagline, sub-system count, command count, agent count, link to `verticals/<vertical>/QUICK-START.md` mirror in repo (link to GitHub blob URL — no need to mirror full content yet).
+
+```
+┌──────────────────────────────────────────┐
+│  PEOPLE INTELLIGENCE                     │
+│  Calibrated, structured, neuroscience-   │
+│  grounded. Hiring · Performance ·        │
+│  Training · Culture · Talent · Org.      │
+│  6 sub-systems · 28 commands · 6 agents  │
+│  [Open QUICK-START →]                    │
+└──────────────────────────────────────────┘
+```
+
+Same for Sound Intelligence (composition / production / catalog / performance / audience / sync; 6 / 30 / 6) and Music IS (Frank-operated; 6 + 1 / 8 / 7).
+
+Closer paragraph at bottom: "The pattern generalizes. `/spawn-domain-stack` spawns a 4-7-sub-system vertical from any sovereign domain (Capital · Spatial · Clinical · Legal · etc.). See [forking-domain-stacks.md]."
+
+### Step 3 — `/cockpit` teaser (60 min)
+
+Single page. **No live embed** (cockpit is localhost-only). Describes what the local cockpit does:
+
+- **4 surfaces:** Zellij terminal cockpit · PowerShell launcher · LCC dashboard `:3007` · Phone PWA `:3008`
+- **Voice → tool execution loop:** STT (Groq Whisper) → LLM + 7 tools (shell, file_write, claude_prompt, claude_code_launch, open_url, linear_issue, workflow_run) → TTS (ElevenLabs Brian Flash)
+- **Brain viz:** live 3D thought-graph clustered by intent
+- **Drafts on disk:** every file Jarvis writes lands at `~/Desktop/jarvis-drafts/`
+- **Privacy:** 100% local. Groq + ElevenLabs over HTTPS for inference; no cloud storage.
+
+One screenshot or recorded GIF (capture once from the demo). No live demo path.
+
+### Step 4 — footer (15 min)
+
+Add a single footer column "Newcomer":
+- Friend Starter (Claude Project pack) → `https://github.com/frankxai/Starlight-Intelligence-System/tree/main/integrations/starter-packs/friend-starter`
+- Onboarding → `/quickstart`
+- Welcome → `https://github.com/frankxai/Starlight-Intelligence-System/blob/main/ONBOARDING.md`
+
+### Step 5 — `/architecture` bump (30 min)
+
+If still says "6 vaults" or pre-v7.4 framing, replace with current 9-layer + Domain Sub-Stack diagram. The `docs/ARCHITECTURE.md` in repo is canonical — mirror its top section.
+
+### Step 6 — `/explainer` mirror (45 min)
+
+Render `docs/public/starlight-intelligence-system.md` as MDX or via `react-markdown`. This is the polished public-facing long-form. Mirror, don't fork — keep `docs/public/` as source of truth.
+
+### Step 7 — OG / meta (15 min)
+
+In `site/src/app/layout.tsx` update:
+- `title` → "Starlight Intelligence — Persistent context for AI agents · Built on SIP"
+- `description` → 9-IS framing (one sentence)
+- `og:image` → optionally regenerate; current is fine
+
+---
+
+## Out of scope (deliberately)
+
+- **Live cockpit embed** — the cockpit is localhost-only by design. A public iframe would require auth + tunneling — premature.
+- **Vertical detail pages** (`/verticals/people-intelligence`, etc.) — links to GitHub blobs are sufficient for v1.
+- **Pricing page** — productization economics live in `verticals/music-is/STRATEGY.md` Phase 5 spec, but v7.6 is not yet shipping a paid tier. Premature.
+- **Newsletter / email signup** — separate decision; not on site refresh critical path.
+- **Auth / dashboard / login** — site is marketing/canonical. Not an app.
+
+---
+
+## Acceptance criteria
+
+- [ ] `/` no longer says "six semantic vaults"; reads 9-IS + Domain Sub-Stack
+- [ ] `/verticals` lists People, Sound, Music IS with accurate counts
+- [ ] `/cockpit` teaser describes the local cockpit (no live embed)
+- [ ] Footer has a "Newcomer" column with friend-starter link
+- [ ] `/architecture` shows 9-layer architecture (or links to canonical doc)
+- [ ] `/explainer` renders `docs/public/starlight-intelligence-system.md` content
+- [ ] `<title>` and `<meta name="description">` updated
+- [ ] `next build` clean
+- [ ] Vercel deploy preview checked manually before merge
+- [ ] Lighthouse score not regressed (baseline pre-PR)
+- [ ] Production URL (`starlightintelligence.org`) reflects new homepage within 5 min of merge
+
+---
+
+## Risk + mitigation
+
+| Risk | Mitigation |
+|---|---|
+| Vercel auto-deploy regresses (per memory `project_vercel_manual.md` — broken since 2026-04-10, restored via GHA at v7.5) | Verify GHA `vercel-deploy.yml` fires on merge. If silent, run `vercel --prod` from `site/` manually. |
+| Stale OG cache shows old description | Trigger Twitter/LinkedIn cache refresh post-deploy via debugger tools. |
+| Markdown render of `docs/public/starlight-intelligence-system.md` breaks on heavy markdown features | Use `react-markdown` with sanitize; avoid raw HTML. Test heavy-table sections specifically. |
+| Site copy gets ahead of substrate again in 2 weeks | Close loop: every substrate `/luminor-board` ratification at vN+1 includes a "site update needed?" check item in the board verdict template. |
+
+---
+
+## Future (v7.7+ next pass — not this PR)
+
+- Per-vertical landing pages (`/verticals/people-intelligence`, etc.) with full QUICK-START rendered
+- Live registry of forks ("Built on SIP" attestations indexed)
+- Public vault browser improvements (current `/vaults` is functional but minimal)
+- A `/spawn` interactive page that walks a visitor through `/spawn-domain-stack` decisions
+
+---
+
+## File checklist for the PR
+
+- `site/src/app/page.tsx` — rewrite
+- `site/src/app/layout.tsx` — meta
+- `site/src/app/verticals/page.tsx` — NEW
+- `site/src/app/cockpit/page.tsx` — NEW
+- `site/src/app/explainer/page.tsx` — NEW
+- `site/src/app/architecture/page.tsx` — bump if stale
+- `site/src/components/Footer.tsx` (or wherever footer lives) — newcomer column
+- `site/public/cockpit-screenshot.png` — single asset (capture once from demo)
+
+**Estimated PR diff:** +600 LOC, -150 LOC. Reviewable in one sitting.
+
+---
+
+**Built on SIP** — operational-tier post-demo plan · 2026-05-02 → 2026-05-04 · No substrate edits · Single PR · One deploy.

--- a/memory/.gitignore
+++ b/memory/.gitignore
@@ -1,0 +1,10 @@
+# Obsidian workspace state — user-local UI prefs, not source of truth.
+.obsidian/workspace.json
+.obsidian/workspace-mobile.json
+.obsidian/cache
+.obsidian/plugins/
+.obsidian/themes/
+
+# Generated runtime artifacts.
+knowledge-graph/_brain-cache.json
+_audit/

--- a/memory/README.md
+++ b/memory/README.md
@@ -1,0 +1,66 @@
+# memory/
+
+> The persistent memory layer for the Starlight Intelligence System. Filesystem is the source of truth. Obsidian is one viewer; r3f `/brain` is another.
+
+This directory is **dual-surface by design**:
+
+- **For agents and scripts**: plain markdown + JSONL. Every entry is grep-able, diff-able, version-controlled. No proprietary format owns this data.
+- **For Frank**: open this folder as an Obsidian vault for browse / search / Bases dashboards / Canvas mind-maps.
+
+## Layout
+
+| Path | What it is | Owner |
+|---|---|---|
+| `vaults/*.md` | Six permanent vaults — strategic, technical, creative, operational, wisdom, horizon | Per-vault writers (see `VAULT_ARCHITECTURE.md`) |
+| `voice-sessions/{date}.md` | Daily capture log from Voice Operator | voice-operator |
+| `knowledge-graph/index.jsonl` | Append-only event log; one line per packet | voice-operator pipeline |
+| `knowledge-graph/_brain-cache.json` | UMAP+HDBSCAN-derived 3D scene cache for `/brain` | `brain_watchdog` daemon |
+| `atlases/*.canvas` | Curated JSON Canvas exports (e.g. cluster mind-maps) | `scripts/kg_to_canvas.py` |
+| `bases/*.base` | Obsidian Bases — live dashboards over the vault | hand-authored, generators welcome |
+| `_audit/{date}.jsonl` | Privacy / read-write audit trail | `service.memory.audit` |
+| `_handovers/` | Cross-session continuity docs | per-session human |
+| `consolidation/` | Periodic merge / dedup outputs | weekly job |
+| `intake/` | Inbound capture staging | `/capture-daily` |
+| `voice-sessions/` | Voice Operator daily notes | voice-operator |
+| `.obsidian/` | Vault config (viewer-only — workspace.json gitignored) | Frank |
+| `VAULT_ARCHITECTURE.md` | The six-vault design: writers, readers, retention | substrate doc |
+| `MEMORY.md` | Auto-memory index (in `~/.claude/projects/...`, not here) | Claude |
+
+## Frontmatter contract
+
+Every `vaults/*.md` and `voice-sessions/*.md` carries YAML frontmatter validated by:
+
+```
+python -m service.memory.frontmatter --check memory/
+```
+
+Run from `private/voice-operator/`.
+
+**Vault schema** — see `VAULT_ARCHITECTURE.md` access matrix. Required keys:
+`type: vault`, `vault`, `retention`, `writers`, `readers`, `last_consolidated`.
+
+**Voice-session schema**: `type: voice-session`, `date`, `brand`, `decay_tier`, `intent_class`.
+
+## Sovereignty rules
+
+1. **No Obsidian Sync.** Use Git for substrate, Syncthing/iCloud only for personal scratch. Substrate sovereignty is non-negotiable.
+2. **No external embeddings.** When sentiment / vector indexing lands, embeddings happen locally (`sentence-transformers`, never OpenAI/Cohere embedding APIs).
+3. **Privacy Guardian gates writes.** Every external call (Anthropic, OpenRouter, fal, ElevenLabs) goes through `service.memory.guardian` for redaction first. See `skills/memory/sis-memory-orchestrator/`.
+4. **Replaceable viewers.** Substrate is plain MD + JSONL. Obsidian is convenience, not lock-in. If Obsidian becomes hostile, switch to Logseq / Foam / a plain editor — the data still works.
+5. **Bases are generated, not hand-curated.** `bases/*.base` should ship from a generator skill (planned: `obsidian-bases-author`). Until then, hand-authored ones live here as references.
+
+## Refresh cadence
+
+| Artifact | Refreshed by | Cadence |
+|---|---|---|
+| `_brain-cache.json` | `brain_watchdog` daemon | On `index.jsonl` write |
+| `atlases/brain-clusters.canvas` | `scripts/kg_to_canvas.py` | Manual or post-`/brain` regen |
+| Vault `last_consolidated` | `/orchestrate-brain` | Weekly |
+| Operational vault entries >90d | consolidation job | Weekly archive sweep |
+
+## Related
+
+- `docs/superpowers/plans/2026-05-01-mirror-foundation.md` — current plan
+- `skills/memory/sis-memory-orchestrator/SKILL.md` — substrate orchestration
+- `private/voice-operator/service/memory/` — orchestration code
+- `VAULT_ARCHITECTURE.md` — six-vault contract

--- a/memory/atlases/brain-clusters.canvas
+++ b/memory/atlases/brain-clusters.canvas
@@ -1,0 +1,304 @@
+{
+  "nodes": [
+    {
+      "id": "28470ddbb8e46785",
+      "type": "group",
+      "x": 0,
+      "y": 0,
+      "width": 440,
+      "height": 2070,
+      "label": "unbranded \u00b7 capture (18)",
+      "color": "#64748b"
+    },
+    {
+      "id": "f94cb17851bfa60d",
+      "type": "text",
+      "x": 40,
+      "y": 50,
+      "width": 360,
+      "height": 90,
+      "text": "**unbranded** \u00b7 `capture` \u00b7 2026-04-28\n\nSearching today's session log and git activity now \u2014 one moment. If nothing surfaces, I'll flag that the vault is empty for today.",
+      "color": "#64748b"
+    },
+    {
+      "id": "c0bdb7193d1e02b7",
+      "type": "text",
+      "x": 40,
+      "y": 160,
+      "width": 360,
+      "height": 90,
+      "text": "**unbranded** \u00b7 `capture` \u00b7 2026-04-29\n\nCaptured.",
+      "color": "#64748b"
+    },
+    {
+      "id": "aec25c4c9fbb9cb0",
+      "type": "text",
+      "x": 40,
+      "y": 270,
+      "width": 360,
+      "height": 90,
+      "text": "**unbranded** \u00b7 `capture` \u00b7 2026-04-29\n\nCaptured.",
+      "color": "#64748b"
+    },
+    {
+      "id": "58218b980a4ce1c2",
+      "type": "text",
+      "x": 40,
+      "y": 380,
+      "width": 360,
+      "height": 90,
+      "text": "**unbranded** \u00b7 `capture` \u00b7 2026-04-29\n\nCognition layer today: pluggable multi-tier router landed (deterministic, OpenRouter, Anthropic, Claude-CLI), multi-CLI dispatchers wired to orchestrator with intent classification and JSONL audit log, plus LCC Phase 0+\u2026",
+      "color": "#64748b"
+    },
+    {
+      "id": "571a287d24a68085",
+      "type": "text",
+      "x": 40,
+      "y": 490,
+      "width": 360,
+      "height": 90,
+      "text": "**unbranded** \u00b7 `capture` \u00b7 2026-04-29\n\nSearching session log and git activity for today's cognition-layer changes \u2014 no routing needed, pulling from operational vault now. If nothing surfaces, I'll flag it as no recorded changes today.",
+      "color": "#64748b"
+    },
+    {
+      "id": "774409c8eecdcaf8",
+      "type": "text",
+      "x": 40,
+      "y": 600,
+      "width": 360,
+      "height": 90,
+      "text": "**unbranded** \u00b7 `capture` \u00b7 2026-04-29\n\nSearching today's captures for cognition layer references \u2014 nothing retrieved yet from this session's vault. If you've captured it in a prior session or vault file, say 'Starlight, search all vaults for cognition layer'\u2026",
+      "color": "#64748b"
+    },
+    {
+      "id": "031a1849971a9e91",
+      "type": "text",
+      "x": 40,
+      "y": 710,
+      "width": 360,
+      "height": 90,
+      "text": "**unbranded** \u00b7 `capture` \u00b7 2026-04-29\n\nCaptured.",
+      "color": "#64748b"
+    },
+    {
+      "id": "966d72b66c690408",
+      "type": "text",
+      "x": 40,
+      "y": 820,
+      "width": 360,
+      "height": 90,
+      "text": "**unbranded** \u00b7 `capture` \u00b7 2026-04-29\n\nCaptured.",
+      "color": "#64748b"
+    },
+    {
+      "id": "6f055ae09fbf885c",
+      "type": "text",
+      "x": 40,
+      "y": 930,
+      "width": 360,
+      "height": 90,
+      "text": "**unbranded** \u00b7 `capture` \u00b7 2026-04-29\n\nSearching today's session log and git activity now \u2014 stand by for the delta.",
+      "color": "#64748b"
+    },
+    {
+      "id": "44f297ca5bd83212",
+      "type": "text",
+      "x": 40,
+      "y": 1040,
+      "width": 360,
+      "height": 90,
+      "text": "**unbranded** \u00b7 `capture` \u00b7 2026-04-29\n\nCaptured.",
+      "color": "#64748b"
+    },
+    {
+      "id": "538b46173ce475d6",
+      "type": "text",
+      "x": 40,
+      "y": 1150,
+      "width": 360,
+      "height": 90,
+      "text": "**unbranded** \u00b7 `capture` \u00b7 2026-04-29\n\nTwo captures from this session: (1) cognition bridge live 2026-04-29, (2) cockpit autonomous build pass complete \u2014 341 tests, 4 surfaces, brain graph live. Nothing else on cognition layer or cockpit this session.",
+      "color": "#64748b"
+    },
+    {
+      "id": "2ad6ad0ff974e07d",
+      "type": "text",
+      "x": 40,
+      "y": 1260,
+      "width": 360,
+      "height": 90,
+      "text": "**unbranded** \u00b7 `capture` \u00b7 2026-04-29\n\nCaptured. Caching strategies for the cognition router \u2014 tagged and routed to scratchpad vault.",
+      "color": "#64748b"
+    },
+    {
+      "id": "08d43b15fedb626d",
+      "type": "text",
+      "x": 40,
+      "y": 1370,
+      "width": 360,
+      "height": 90,
+      "text": "**unbranded** \u00b7 `capture` \u00b7 2026-04-29\n\nTwo captures: cognition bridge live 2026-04-29; cockpit autonomous build pass \u2014 341 tests, 4 surfaces, brain graph live.",
+      "color": "#64748b"
+    },
+    {
+      "id": "abe1b38d55a19ee9",
+      "type": "text",
+      "x": 40,
+      "y": 1480,
+      "width": 360,
+      "height": 90,
+      "text": "**unbranded** \u00b7 `capture` \u00b7 2026-04-29\n\nHi, how can I assist you today professionally?",
+      "color": "#64748b"
+    },
+    {
+      "id": "9c7b49cd8a664bd2",
+      "type": "text",
+      "x": 40,
+      "y": 1590,
+      "width": 360,
+      "height": 90,
+      "text": "**unbranded** \u00b7 `capture` \u00b7 2026-04-29\n\nHello, how are you today I am ready",
+      "color": "#64748b"
+    },
+    {
+      "id": "5277e9d58ffd3afc",
+      "type": "text",
+      "x": 40,
+      "y": 1700,
+      "width": 360,
+      "height": 90,
+      "text": "**unbranded** \u00b7 `capture` \u00b7 2026-04-29\n\nConfirmed, speed profile is active for you now.",
+      "color": "#64748b"
+    },
+    {
+      "id": "ad291bdaf19599d8",
+      "type": "text",
+      "x": 40,
+      "y": 1810,
+      "width": 360,
+      "height": 90,
+      "text": "**unbranded** \u00b7 `capture` \u00b7 2026-04-29\n\nI'm doing well, thanks for checking in.",
+      "color": "#64748b"
+    },
+    {
+      "id": "bd8f688ebc7cf3a9",
+      "type": "text",
+      "x": 40,
+      "y": 1920,
+      "width": 360,
+      "height": 90,
+      "text": "**unbranded** \u00b7 `capture` \u00b7 2026-04-29\n\nI'm here. How can I assist you today?",
+      "color": "#64748b"
+    },
+    {
+      "id": "bf4e594cc59a6f16",
+      "type": "group",
+      "x": 520,
+      "y": 0,
+      "width": 440,
+      "height": 420,
+      "label": "unbranded \u00b7 command (3)",
+      "color": "#64748b"
+    },
+    {
+      "id": "721b8af2a2704648",
+      "type": "text",
+      "x": 560,
+      "y": 50,
+      "width": 360,
+      "height": 90,
+      "text": "**unbranded** \u00b7 `command` \u00b7 2026-04-26\n\nSubstrate edit requested: add a new clause to SIP.md covering cognition routing. This requires Luminor Board review before any edit is made. Prepare a draft clause for board consideration \u2014 do not write to SIP.md until\u2026",
+      "color": "#64748b"
+    },
+    {
+      "id": "460536b1615ff7fd",
+      "type": "text",
+      "x": 560,
+      "y": 160,
+      "width": 360,
+      "height": 90,
+      "text": "**unbranded** \u00b7 `command` \u00b7 2026-04-26\n\nEscalate a proposed substrate edit to SIP.md for board review. The proposed change is: add a new clause about cognition routing. The board must review the clause content, assess sovereignty and attestation implications,\u2026",
+      "color": "#64748b"
+    },
+    {
+      "id": "bea0636583ce7a57",
+      "type": "text",
+      "x": 560,
+      "y": 270,
+      "width": 360,
+      "height": 90,
+      "text": "**unbranded** \u00b7 `command` \u00b7 2023-12-01\n\nRequest access to local machine and cloud code CLI for diagnostic purposes.",
+      "color": "#64748b"
+    },
+    {
+      "id": "cdd78c37dbf82a87",
+      "type": "group",
+      "x": 1040,
+      "y": 0,
+      "width": 440,
+      "height": 420,
+      "label": "sis \u00b7 build (3)",
+      "color": "#7c5cff"
+    },
+    {
+      "id": "66e3e3be6e973502",
+      "type": "text",
+      "x": 1080,
+      "y": 50,
+      "width": 360,
+      "height": 90,
+      "text": "**sis** \u00b7 `build` \u00b7 2026-04-26\n\nAdd a new section to the SIS repository README.md. Section topic, title, placement, and content have not been specified \u2014 pause and request clarification from Frank before writing any content. Once the section scope is\u2026",
+      "color": "#7c5cff"
+    },
+    {
+      "id": "f77bcd37b3b7a22d",
+      "type": "text",
+      "x": 1080,
+      "y": 160,
+      "width": 360,
+      "height": 90,
+      "text": "**sis** \u00b7 `build` \u00b7 2026-04-26\n\nAdd a new section to the Starlight Intelligence System README. Section content, heading, and placement are unspecified \u2014 pause before writing and surface a one-sentence proposal (section name + one-line description + pr\u2026",
+      "color": "#7c5cff"
+    },
+    {
+      "id": "6f12dc7eab23edd2",
+      "type": "text",
+      "x": 1080,
+      "y": 270,
+      "width": 360,
+      "height": 90,
+      "text": "**sis** \u00b7 `build` \u00b7 2026-04-26\n\nUpdate the README.md footer in the Starlight Intelligence System repository to include a v7.5.3 cockpit-complete badge. Locate the existing footer section (version badges, attestation line, or equivalent). Add or update\u2026",
+      "color": "#7c5cff"
+    },
+    {
+      "id": "e304339eb1cdcc35",
+      "type": "group",
+      "x": 0,
+      "y": 280,
+      "width": 440,
+      "height": 200,
+      "label": "unbranded \u00b7 uncategorized (1)",
+      "color": "#64748b"
+    },
+    {
+      "id": "cecca61579a98e95",
+      "type": "text",
+      "x": 40,
+      "y": 330,
+      "width": 360,
+      "height": 90,
+      "text": "**sis** \u00b7 `capture` \u00b7 2026-04-28\n\nCaptured.",
+      "color": "#7c5cff"
+    }
+  ],
+  "edges": [
+    {
+      "id": "ca82b9a3566bbd95",
+      "fromNode": "66e3e3be6e973502",
+      "fromSide": "right",
+      "toNode": "f77bcd37b3b7a22d",
+      "toSide": "left",
+      "toEnd": "arrow"
+    }
+  ]
+}

--- a/memory/bases/brand-rollup.base
+++ b/memory/bases/brand-rollup.base
@@ -1,0 +1,34 @@
+filters:
+  or:
+    - 'note.type == "voice-session"'
+    - 'note.type == "vault"'
+
+formulas:
+  brand_norm: 'if(note.brand, note.brand, "unbranded")'
+  is_recent: '(now() - file.mtime).days <= 7'
+
+properties:
+  formula.brand_norm:
+    displayName: "Brand"
+  file.name:
+    displayName: "File"
+  note.type:
+    displayName: "Kind"
+  file.mtime:
+    displayName: "Last touched"
+  formula.is_recent:
+    displayName: "Last 7d"
+
+views:
+  - type: table
+    name: "Activity by brand"
+    order:
+      - file.name
+      - note.type
+      - formula.brand_norm
+      - file.mtime
+    groupBy:
+      property: formula.brand_norm
+      direction: ASC
+    summaries:
+      formula.is_recent: Checked

--- a/memory/bases/decay-watch.base
+++ b/memory/bases/decay-watch.base
@@ -1,0 +1,52 @@
+filters:
+  or:
+    - and:
+        - 'note.type == "vault"'
+        - 'note.last_consolidated'
+        - '(today() - date(note.last_consolidated)).days > 30'
+    - and:
+        - 'note.type == "voice-session"'
+        - 'note.decay_tier == "warm"'
+        - '(today() - date(note.date)).days > 90'
+
+formulas:
+  staleness_days: |
+    if(note.last_consolidated,
+       (today() - date(note.last_consolidated)).days,
+       if(note.date, (today() - date(note.date)).days, 0))
+  recommended_action: |
+    if(note.type == "vault" && (today() - date(note.last_consolidated)).days > 90,
+       "consolidate",
+       if(note.decay_tier == "warm" && (today() - date(note.date)).days > 90,
+          "promote-to-cold",
+          "review"))
+
+properties:
+  file.name:
+    displayName: "File"
+  note.type:
+    displayName: "Kind"
+  note.vault:
+    displayName: "Vault"
+  note.decay_tier:
+    displayName: "Tier"
+  formula.staleness_days:
+    displayName: "Stale (days)"
+  formula.recommended_action:
+    displayName: "Action"
+
+views:
+  - type: table
+    name: "Decay candidates"
+    order:
+      - file.name
+      - note.type
+      - note.vault
+      - note.decay_tier
+      - formula.staleness_days
+      - formula.recommended_action
+    groupBy:
+      property: formula.recommended_action
+      direction: ASC
+    summaries:
+      formula.staleness_days: Average

--- a/memory/bases/voice-sessions-recent.base
+++ b/memory/bases/voice-sessions-recent.base
@@ -1,0 +1,43 @@
+filters:
+  and:
+    - 'note.type == "voice-session"'
+    - '(now() - file.mtime).days <= 30'
+
+formulas:
+  age_days: '(now() - file.mtime).days'
+  brand_label: 'if(note.brand, note.brand, "unbranded")'
+
+properties:
+  file.name:
+    displayName: "Session"
+  note.brand:
+    displayName: "Brand"
+  note.decay_tier:
+    displayName: "Tier"
+  note.intent_class:
+    displayName: "Intent"
+  formula.age_days:
+    displayName: "Days ago"
+  file.mtime:
+    displayName: "Modified"
+
+views:
+  - type: table
+    name: "Last 30 days"
+    order:
+      - file.name
+      - note.brand
+      - note.decay_tier
+      - note.intent_class
+      - formula.age_days
+    groupBy:
+      property: note.brand
+      direction: ASC
+
+  - type: cards
+    name: "Gallery"
+    order:
+      - file.name
+      - note.brand
+      - note.intent_class
+      - formula.age_days

--- a/memory/vaults/creative-vault.md
+++ b/memory/vaults/creative-vault.md
@@ -1,3 +1,13 @@
+---
+type: vault
+vault: creative
+retention: permanent
+writers:
+- weaver
+readers: all
+last_consolidated: '2026-05-01'
+---
+
 # Creative Vault
 
 > *"Every creative insight is a seed. Store it well, and forests grow."*

--- a/memory/vaults/horizon-vault.md
+++ b/memory/vaults/horizon-vault.md
@@ -1,3 +1,13 @@
+---
+type: vault
+vault: horizon
+retention: append-only
+writers:
+- human-pr-only
+readers: all
+last_consolidated: '2026-05-01'
+---
+
 # Horizon Vault
 
 > Letters to the future. Human hopes encoded alongside AI reasoning. A seed of benevolence planted in the architecture of intelligence itself.

--- a/memory/vaults/operational-vault.md
+++ b/memory/vaults/operational-vault.md
@@ -1,3 +1,14 @@
+---
+type: vault
+vault: operational
+retention: rolling-90d
+writers:
+- orchestrator
+- prime
+readers: all
+last_consolidated: '2026-05-01'
+---
+
 # Operational Vault
 
 > *"Know the current state. Navigate from here."*

--- a/memory/vaults/strategic-vault.md
+++ b/memory/vaults/strategic-vault.md
@@ -1,3 +1,14 @@
+---
+type: vault
+vault: strategic
+retention: permanent
+writers:
+- navigator
+- prime
+readers: all
+last_consolidated: '2026-05-01'
+---
+
 # Strategic Vault
 
 > *"Every decision shapes the future. Remember them all."*

--- a/memory/vaults/technical-vault.md
+++ b/memory/vaults/technical-vault.md
@@ -1,3 +1,14 @@
+---
+type: vault
+vault: technical
+retention: permanent
+writers:
+- architect
+- sentinel
+readers: all
+last_consolidated: '2026-05-01'
+---
+
 # Technical Vault
 
 > *"Patterns are the currency of engineering wisdom."*

--- a/memory/vaults/wisdom-vault.md
+++ b/memory/vaults/wisdom-vault.md
@@ -1,3 +1,14 @@
+---
+type: vault
+vault: wisdom
+retention: permanent
+writers:
+- sage
+- prime
+readers: all
+last_consolidated: '2026-05-01'
+---
+
 # Wisdom Vault
 
 > *"Wisdom is pattern recognition across time. The longest memory wins."*

--- a/memory/voice-sessions/2026-04-28.md
+++ b/memory/voice-sessions/2026-04-28.md
@@ -1,3 +1,11 @@
+---
+type: voice-session
+date: '2026-04-28'
+brand: sis
+decay_tier: warm
+intent_class: capture
+---
+
 # Voice session — 2026-04-28
 
 

--- a/memory/voice-sessions/2026-04-29.md
+++ b/memory/voice-sessions/2026-04-29.md
@@ -1,3 +1,11 @@
+---
+type: voice-session
+date: '2026-04-29'
+brand: sis
+decay_tier: warm
+intent_class: capture
+---
+
 # Voice session — 2026-04-29
 
 

--- a/memory/voice-sessions/2026-04-30.md
+++ b/memory/voice-sessions/2026-04-30.md
@@ -1,0 +1,11 @@
+---
+type: voice-session
+date: '2026-04-30'
+brand: sis
+decay_tier: warm
+intent_class: capture
+---
+
+## 2026-04-30T16:11:35.814Z
+
+**Utterance:** tonight we built the voice chooser and intent decision tree

--- a/scripts/kg_to_canvas.py
+++ b/scripts/kg_to_canvas.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Root-level shim: convert KG cache → JSON Canvas.
+
+Usage:
+    python scripts/kg_to_canvas.py \
+        memory/knowledge-graph/_brain-cache.json \
+        memory/atlases/brain-clusters.canvas
+
+The actual implementation is service.memory.canvas_export.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "private" / "voice-operator"))
+
+from service.memory.canvas_export import main  # noqa: E402
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lint_memory_frontmatter.py
+++ b/scripts/lint_memory_frontmatter.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Root-level shim: lint memory/ frontmatter from anywhere in the repo.
+
+Usage:
+    python scripts/lint_memory_frontmatter.py memory/
+
+Bootstraps PYTHONPATH to include private/voice-operator so the service module
+imports cleanly. The actual implementation is service.memory.frontmatter.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "private" / "voice-operator"))
+
+from service.memory.frontmatter import main  # noqa: E402
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/package.json
+++ b/site/package.json
@@ -11,7 +11,9 @@
   "dependencies": {
     "next": "16.2.3",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -17,6 +17,12 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.14)(react@19.2.4)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4
@@ -526,14 +532,29 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@20.19.39':
     resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
@@ -545,6 +566,12 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@typescript-eslint/eslint-plugin@8.58.1':
     resolution: {integrity: sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==}
@@ -604,6 +631,9 @@ packages:
   '@typescript-eslint/visitor-keys@8.58.1':
     resolution: {integrity: sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -783,6 +813,9 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -830,9 +863,24 @@ packages:
   caniuse-lite@1.0.30001787:
     resolution: {integrity: sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -843,6 +891,9 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -889,6 +940,9 @@ packages:
       supports-color:
         optional: true
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -900,9 +954,16 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -961,6 +1022,10 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
 
   eslint-config-next@16.2.3:
     resolution: {integrity: sha512-Dnkrylzjof/Az7iNoIQJqD18zTxQZcngir19KJaiRsMnnjpQSVoa6aEg/1Q4hQC+cW90uTlgQYadwL1CYNwFWA==}
@@ -1078,9 +1143,15 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1217,11 +1288,20 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1239,9 +1319,18 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -1278,6 +1367,9 @@ packages:
     resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
     engines: {node: '>= 0.4'}
 
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -1294,6 +1386,9 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
     engines: {node: '>= 0.4'}
@@ -1309,6 +1404,10 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -1489,6 +1588,9 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -1499,13 +1601,145 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -1617,6 +1851,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1658,6 +1895,9 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1673,6 +1913,12 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
+
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
@@ -1684,6 +1930,18 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -1772,6 +2030,9 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
@@ -1802,6 +2063,9 @@ packages:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
@@ -1809,6 +2073,12 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -1845,6 +2115,12 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -1897,6 +2173,24 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
@@ -1908,6 +2202,12 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -1949,6 +2249,9 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -2374,11 +2677,29 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
+
   '@types/estree@1.0.8': {}
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
 
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@20.19.39':
     dependencies:
@@ -2391,6 +2712,10 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
 
   '@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -2482,6 +2807,8 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.58.1
       eslint-visitor-keys: 5.0.1
+
+  '@ungap/structured-clone@1.3.0': {}
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     optional: true
@@ -2642,6 +2969,8 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -2690,10 +3019,20 @@ snapshots:
 
   caniuse-lite@1.0.30001787: {}
 
+  ccount@2.0.1: {}
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   client-only@0.0.1: {}
 
@@ -2702,6 +3041,8 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   concat-map@0.0.1: {}
 
@@ -2743,6 +3084,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   deep-is@0.1.4: {}
 
   define-data-property@1.1.4:
@@ -2757,7 +3102,13 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   doctrine@2.1.0:
     dependencies:
@@ -2883,6 +3234,8 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
+
+  escape-string-regexp@5.0.0: {}
 
   eslint-config-next@16.2.3(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
@@ -3087,7 +3440,11 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-util-is-identifier-name@3.0.0: {}
+
   esutils@2.0.3: {}
+
+  extend@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -3223,11 +3580,37 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   hermes-estree@0.25.1: {}
 
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
+
+  html-url-attributes@3.0.1: {}
 
   ignore@5.3.2: {}
 
@@ -3240,11 +3623,20 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  inline-style-parser@0.2.7: {}
+
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -3290,6 +3682,8 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-decimal@2.0.1: {}
+
   is-extglob@2.1.1: {}
 
   is-finalizationregistry@1.1.1:
@@ -3308,6 +3702,8 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-hexadecimal@2.0.1: {}
+
   is-map@2.0.3: {}
 
   is-negative-zero@2.0.3: {}
@@ -3318,6 +3714,8 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-number@7.0.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -3470,6 +3868,8 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  longest-streak@3.1.0: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -3482,9 +3882,355 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-table@3.0.4: {}
+
   math-intrinsics@1.1.0: {}
 
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
   merge2@1.4.1: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   micromatch@4.0.8:
     dependencies:
@@ -3611,6 +4357,16 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -3645,6 +4401,8 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  property-information@7.1.0: {}
+
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
@@ -3655,6 +4413,24 @@ snapshots:
       scheduler: 0.27.0
 
   react-is@16.13.1: {}
+
+  react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.14
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 19.2.4
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   react@19.2.4: {}
 
@@ -3677,6 +4453,40 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   resolve-from@4.0.0: {}
 
@@ -3812,6 +4622,8 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
   stable-hash@0.0.5: {}
 
   stop-iteration-iterator@1.1.0:
@@ -3869,9 +4681,22 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-bom@3.0.0: {}
 
   strip-json-comments@3.1.1: {}
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.4):
     dependencies:
@@ -3898,6 +4723,10 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
@@ -3971,6 +4800,39 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   unrs-resolver@1.11.1:
     dependencies:
       napi-postinstall: 0.3.4
@@ -4004,6 +4866,16 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -4061,3 +4933,5 @@ snapshots:
       zod: 4.3.6
 
   zod@4.3.6: {}
+
+  zwitch@2.0.4: {}

--- a/site/src/app/architecture/page.tsx
+++ b/site/src/app/architecture/page.tsx
@@ -151,7 +151,7 @@ const STATUS_CLASS: Record<Layer["status"], string> = {
   core: "border-cyan-500/[0.2] bg-cyan-500/[0.05] text-cyan-300",
   "cross-cutting":
     "border-emerald-500/[0.2] bg-emerald-500/[0.05] text-emerald-300",
-  optional: "border-white/[0.1] bg-white/[0.02] text-slate-500",
+  optional: "border-white/[0.1] bg-white/[0.02] text-slate-400",
   master: "border-fuchsia-500/[0.3] bg-fuchsia-500/[0.08] text-fuchsia-200",
 };
 
@@ -212,7 +212,7 @@ export default function ArchitecturePage() {
       {/* ── Foundation: JSONL truth ── */}
       <section className="border-b border-white/[0.04] px-6 py-20">
         <div className="mx-auto max-w-4xl">
-          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
+          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-400">
             Foundation
           </h2>
           <p className="mt-3 text-xl font-semibold text-white">
@@ -256,7 +256,7 @@ export default function ArchitecturePage() {
       {/* ── 10-IS table ── */}
       <section className="border-b border-white/[0.04] px-6 py-20">
         <div className="mx-auto max-w-5xl">
-          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
+          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-400">
             The ten Intelligence Systems
           </h2>
           <p className="mt-3 max-w-md text-xl font-semibold text-white">
@@ -268,22 +268,22 @@ export default function ArchitecturePage() {
               <table className="w-full border-collapse text-left text-[13px]">
                 <thead>
                   <tr className="border-b border-white/[0.06]">
-                    <th className="px-4 py-3 font-mono text-[10px] uppercase tracking-widest text-slate-600">
+                    <th scope="col" className="px-4 py-3 font-mono text-[11px] uppercase tracking-widest text-slate-300">
                       #
                     </th>
-                    <th className="px-4 py-3 font-mono text-[10px] uppercase tracking-widest text-slate-600">
+                    <th scope="col" className="px-4 py-3 font-mono text-[11px] uppercase tracking-widest text-slate-300">
                       Layer
                     </th>
-                    <th className="px-4 py-3 font-mono text-[10px] uppercase tracking-widest text-slate-600">
+                    <th scope="col" className="px-4 py-3 font-mono text-[11px] uppercase tracking-widest text-slate-300">
                       Tier
                     </th>
-                    <th className="px-4 py-3 font-mono text-[10px] uppercase tracking-widest text-slate-600">
+                    <th scope="col" className="px-4 py-3 font-mono text-[11px] uppercase tracking-widest text-slate-300">
                       Purpose
                     </th>
-                    <th className="px-4 py-3 font-mono text-[10px] uppercase tracking-widest text-slate-600">
+                    <th scope="col" className="px-4 py-3 font-mono text-[11px] uppercase tracking-widest text-slate-300">
                       Vault
                     </th>
-                    <th className="px-4 py-3 font-mono text-[10px] uppercase tracking-widest text-slate-600">
+                    <th scope="col" className="px-4 py-3 font-mono text-[11px] uppercase tracking-widest text-slate-300">
                       Posture
                     </th>
                   </tr>
@@ -298,13 +298,13 @@ export default function ArchitecturePage() {
                           : ""
                       }
                     >
-                      <td className="px-4 py-3 align-top font-mono text-[12px] text-slate-500">
+                      <td className="px-4 py-3 align-top font-mono text-[12px] text-slate-400">
                         {l.n}
                       </td>
                       <td className="px-4 py-3 align-top font-semibold text-white">
                         {l.name}
                       </td>
-                      <td className="px-4 py-3 align-top text-[12px] text-slate-500">
+                      <td className="px-4 py-3 align-top text-[12px] text-slate-400">
                         {l.tier}
                       </td>
                       <td className="px-4 py-3 align-top text-slate-300">
@@ -327,7 +327,7 @@ export default function ArchitecturePage() {
             </div>
           </div>
 
-          <p className="mt-6 text-[13px] leading-relaxed text-slate-500">
+          <p className="mt-6 text-[13px] leading-relaxed text-slate-400">
             Canonical reference:{" "}
             <a
               href="https://github.com/frankxai/Starlight-Intelligence-System/blob/main/docs/ARCHITECTURE.md"
@@ -345,7 +345,7 @@ export default function ArchitecturePage() {
       {/* ── Domain Sub-Stack Tier ── */}
       <section className="border-b border-white/[0.04] px-6 py-20">
         <div className="mx-auto max-w-3xl">
-          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
+          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-400">
             Domain Sub-Stack Tier
           </h2>
           <p className="mt-3 text-xl font-semibold text-white">
@@ -380,7 +380,7 @@ export default function ArchitecturePage() {
       {/* ── Composition rules ── */}
       <section className="border-b border-white/[0.04] px-6 py-20">
         <div className="mx-auto max-w-3xl">
-          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
+          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-400">
             Composition rules
           </h2>
           <p className="mt-3 text-xl font-semibold text-white">
@@ -421,7 +421,7 @@ export default function ArchitecturePage() {
       {/* ── Cross-tool compounding ── */}
       <section className="border-b border-white/[0.04] px-6 py-20">
         <div className="mx-auto max-w-4xl">
-          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
+          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-400">
             Cross-tool compounding
           </h2>
           <p className="mt-3 max-w-md text-xl font-semibold text-white">
@@ -444,7 +444,7 @@ export default function ArchitecturePage() {
               ))}
             </div>
 
-            <div className="font-mono text-[11px] uppercase tracking-widest text-slate-600">
+            <div className="font-mono text-[11px] uppercase tracking-widest text-slate-400">
               &darr; all read &darr;
             </div>
 
@@ -452,7 +452,7 @@ export default function ArchitecturePage() {
               <code className="font-mono text-[13px] text-violet-300">
                 starlight-sis
               </code>
-              <p className="mt-1 text-[11px] uppercase tracking-widest text-slate-500">
+              <p className="mt-1 text-[11px] uppercase tracking-widest text-slate-400">
                 one shared memory
               </p>
             </div>
@@ -463,7 +463,7 @@ export default function ArchitecturePage() {
       {/* ── Extension model ── */}
       <section className="border-b border-white/[0.04] px-6 py-20">
         <div className="mx-auto max-w-3xl">
-          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
+          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-400">
             Extension
           </h2>
           <p className="mt-3 text-xl font-semibold text-white">
@@ -537,7 +537,7 @@ function FlowNode({
         {step}
       </span>
       <h3 className="mt-2 text-[14px] font-semibold text-white">{title}</h3>
-      <p className="mt-2 text-[12px] leading-relaxed text-slate-500">{desc}</p>
+      <p className="mt-2 text-[12px] leading-relaxed text-slate-400">{desc}</p>
     </div>
   );
 }

--- a/site/src/app/architecture/page.tsx
+++ b/site/src/app/architecture/page.tsx
@@ -1,40 +1,185 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import {
-  getAllEntries,
-  getVaultRegistry,
-  VAULT_CATEGORIES,
-  getCategoryMeta,
-} from "@/lib/vault";
 
 export const revalidate = 3600;
 
 export const metadata: Metadata = {
   title: "Architecture",
   description:
-    "How Starlight Intelligence works. JSONL as truth, SQLite as index, MCP as the pipe.",
+    "10 Intelligence Systems composed on the Starlight Intelligence Protocol substrate. JSONL as truth. SIP as contract. The Orchestrator routes the rest.",
   openGraph: {
     title: "Architecture — Starlight Intelligence",
     description:
-      "How Starlight Intelligence works. JSONL as truth, SQLite as index, MCP as the pipe.",
+      "10 Intelligence Systems composed on SIP. JSONL as truth, attestation as contract, sovereignty as invariant.",
     type: "article",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Architecture — Starlight Intelligence",
+    description:
+      "10 Intelligence Systems composed on SIP. JSONL as truth, attestation as contract.",
   },
 };
 
-const PLATFORMS = [
-  { name: "Claude Code", color: "text-violet-400", border: "border-violet-500/[0.2]" },
-  { name: "Cursor", color: "text-cyan-400", border: "border-cyan-500/[0.2]" },
-  { name: "Codex", color: "text-fuchsia-400", border: "border-fuchsia-500/[0.2]" },
-  { name: "Gemini CLI", color: "text-amber-400", border: "border-amber-500/[0.2]" },
-  { name: "OpenCode", color: "text-emerald-400", border: "border-emerald-500/[0.2]" },
+type Layer = {
+  n: string;
+  name: string;
+  tier: string;
+  purpose: string;
+  vault: string;
+  status: "core" | "cross-cutting" | "optional" | "master" | "substrate";
+};
+
+const LAYERS: Layer[] = [
+  {
+    n: "0",
+    name: "Substrate (SIP)",
+    tier: "Protocol",
+    purpose: "Load-bearing protocol. Invisible when working.",
+    vault: "SIP.md, /memory/intake/",
+    status: "substrate",
+  },
+  {
+    n: "1",
+    name: "Self / Genius IS",
+    tier: "Excavation",
+    purpose: "What only you uniquely see. Foundation for the rest.",
+    vault: "genius/",
+    status: "core",
+  },
+  {
+    n: "2",
+    name: "Second Brain IS",
+    tier: "Memory",
+    purpose: "Daily capture compounds into surfaceable memory.",
+    vault: "second-brain/",
+    status: "cross-cutting",
+  },
+  {
+    n: "3",
+    name: "Brand IS",
+    tier: "Vision",
+    purpose: "5-horizon vision + Brand Kit (voice, palette, vocabulary).",
+    vault: "vision/, brand/",
+    status: "core",
+  },
+  {
+    n: "4",
+    name: "Business IS",
+    tier: "Business",
+    purpose: "Entity architecture, revenue model, tax sanity.",
+    vault: "business/",
+    status: "core",
+  },
+  {
+    n: "5",
+    name: "Creator IS",
+    tier: "Composition",
+    purpose: "Frameworks → multi-modal pipelines + executor playbooks.",
+    vault: "creator/",
+    status: "core",
+  },
+  {
+    n: "6",
+    name: "Wealth IS",
+    tier: "Vertical",
+    purpose: "Disruptive Passive Income ledger + thesis engine.",
+    vault: "wealth/",
+    status: "core",
+  },
+  {
+    n: "7",
+    name: "Code IS",
+    tier: "Product / Automation",
+    purpose: "Code as a sovereign domain. MCP builders, automations.",
+    vault: "code/",
+    status: "core",
+  },
+  {
+    n: "8",
+    name: "Voice & Video IS",
+    tier: "Narrative Media",
+    purpose: "Modality attestation across audio, video, multi-modal.",
+    vault: "voice-video/",
+    status: "core",
+  },
+  {
+    n: "9",
+    name: "Family IS",
+    tier: "Relational",
+    purpose: "Network + alliance-readiness + relationship rhythms.",
+    vault: "family/, relational/",
+    status: "cross-cutting",
+  },
+  {
+    n: "—",
+    name: "Health IS",
+    tier: "Embodiment",
+    purpose: "Energy + recovery. Cross-cutting rhythm under everything.",
+    vault: "health/",
+    status: "cross-cutting",
+  },
+  {
+    n: "—",
+    name: "Spiritual IS",
+    tier: "Founder · optional",
+    purpose: "Founder-layer practice. Never imposed on adopters.",
+    vault: "private/spiritual/",
+    status: "optional",
+  },
+  {
+    n: "★",
+    name: "Starlight Orchestrator",
+    tier: "Master · routing",
+    purpose: "Routes voice/text intent across the other nine.",
+    vault: "core/orchestrator/",
+    status: "master",
+  },
 ];
 
-export default async function ArchitecturePage() {
-  const [entries, registry] = await Promise.all([
-    getAllEntries(),
-    getVaultRegistry(),
-  ]);
+const STATUS_LABEL: Record<Layer["status"], string> = {
+  substrate: "substrate",
+  core: "core",
+  "cross-cutting": "cross-cutting",
+  optional: "optional",
+  master: "master",
+};
 
+const STATUS_CLASS: Record<Layer["status"], string> = {
+  substrate:
+    "border-violet-500/[0.3] bg-violet-500/[0.08] text-violet-200",
+  core: "border-cyan-500/[0.2] bg-cyan-500/[0.05] text-cyan-300",
+  "cross-cutting":
+    "border-emerald-500/[0.2] bg-emerald-500/[0.05] text-emerald-300",
+  optional: "border-white/[0.1] bg-white/[0.02] text-slate-500",
+  master: "border-fuchsia-500/[0.3] bg-fuchsia-500/[0.08] text-fuchsia-200",
+};
+
+const PLATFORMS = [
+  {
+    name: "Claude Code",
+    color: "text-violet-400",
+    border: "border-violet-500/[0.2]",
+  },
+  { name: "Cursor", color: "text-cyan-400", border: "border-cyan-500/[0.2]" },
+  {
+    name: "Codex",
+    color: "text-fuchsia-400",
+    border: "border-fuchsia-500/[0.2]",
+  },
+  {
+    name: "Gemini CLI",
+    color: "text-amber-400",
+    border: "border-amber-500/[0.2]",
+  },
+  {
+    name: "OpenCode",
+    color: "text-emerald-400",
+    border: "border-emerald-500/[0.2]",
+  },
+];
+
+export default function ArchitecturePage() {
   return (
     <div>
       {/* ── Hero ── */}
@@ -45,235 +190,231 @@ export default async function ArchitecturePage() {
         </div>
         <div className="relative mx-auto max-w-3xl px-6 py-20">
           <p className="text-[11px] font-medium uppercase tracking-widest text-violet-400">
-            One principle
+            10-IS composition
           </p>
           <h1 className="mt-3 text-3xl font-bold tracking-tight text-white md:text-4xl">
-            JSONL is truth.
+            Ten Intelligence Systems.
             <br />
             <span className="bg-gradient-to-r from-violet-400 via-fuchsia-400 to-cyan-400 bg-clip-text text-transparent">
-              Everything else is a rebuildable index.
+              Composed, not stacked.
             </span>
           </h1>
           <p className="mt-5 max-w-xl text-[15px] leading-relaxed text-slate-400">
-            No database lock-in. No proprietary format. Your intelligence lives
-            as plain files you can grep, diff, and version — and every index on
-            top can be thrown away and rebuilt in seconds.
+            Each layer has its own agent, skills, commands, and vault namespace.
+            ISes reinforce each other — Genius is the root, Brand is the
+            compass, Second Brain is the memory, Health and Family run
+            continuously underneath everything. The Orchestrator routes voice
+            or text intent to the right team.
           </p>
         </div>
       </section>
 
-      {/* ── The Flow ── */}
+      {/* ── Foundation: JSONL truth ── */}
       <section className="border-b border-white/[0.04] px-6 py-20">
         <div className="mx-auto max-w-4xl">
           <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
-            The flow
+            Foundation
           </h2>
           <p className="mt-3 text-xl font-semibold text-white">
-            Four layers. Each one replaceable.
+            JSONL is truth. Everything else is a rebuildable index.
+          </p>
+          <p className="mt-4 max-w-2xl text-[14px] leading-relaxed text-slate-400">
+            No database lock-in. No proprietary format. Your intelligence lives
+            as plain files you can grep, diff, and version — and every index on
+            top can be thrown away and rebuilt in seconds.
           </p>
 
           <div className="mt-10 grid gap-4 md:grid-cols-4">
             <FlowNode
               step="01"
               title="JSONL files"
-              desc="One file per vault category. Append-only. Git-tracked."
+              desc="One file per vault namespace. Append-only. Git-tracked."
               accent="violet"
             />
             <FlowNode
               step="02"
               title="SQLite index"
-              desc="FTS5 full-text search + vector embeddings. Rebuildable."
+              desc="FTS5 full-text + vectors. Rebuildable in seconds."
               accent="cyan"
             />
             <FlowNode
               step="03"
               title="MCP server"
-              desc="JSON-RPC 2.0 protocol. Standard tool calls."
+              desc="JSON-RPC 2.0. Tool calls every adapter speaks."
               accent="fuchsia"
             />
             <FlowNode
               step="04"
               title="AI tools"
-              desc="Claude, Cursor, Codex, Gemini, OpenCode — all read the same memory."
+              desc="Claude · Cursor · Codex · Gemini · OpenCode — same memory."
               accent="emerald"
             />
           </div>
-
-          <div className="mt-8 flex flex-wrap items-center justify-center gap-2 text-[11px] uppercase tracking-widest text-slate-600">
-            <span>truth</span>
-            <span className="text-slate-700">&rarr;</span>
-            <span>rebuildable</span>
-            <span className="text-slate-700">&rarr;</span>
-            <span>json-rpc 2.0</span>
-            <span className="text-slate-700">&rarr;</span>
-            <span>compound</span>
-          </div>
         </div>
       </section>
 
-      {/* ── The Six Vaults ── */}
+      {/* ── 10-IS table ── */}
       <section className="border-b border-white/[0.04] px-6 py-20">
         <div className="mx-auto max-w-5xl">
           <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
-            Six semantic vaults
+            The ten Intelligence Systems
           </h2>
           <p className="mt-3 max-w-md text-xl font-semibold text-white">
-            Each category is its own JSONL file, indexed separately.
+            Each layer is its own IS. You compose what you need.
           </p>
 
-          <div className="mt-10 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
-            {VAULT_CATEGORIES.map((cat) => {
-              const meta = getCategoryMeta(cat);
-              const count = entries.filter(
-                (e) => e.vaultCategory === cat
-              ).length;
-              return (
-                <div
-                  key={cat}
-                  className={`rounded-xl border p-5 transition-std hover:border-white/[0.2] ${meta.bg}`}
-                >
-                  <div className="flex items-center justify-between">
-                    <span className={`text-[13px] font-semibold ${meta.color}`}>
-                      {meta.icon} {meta.label}
-                    </span>
-                    <span className="rounded-full bg-white/[0.04] px-2 py-0.5 text-[10px] text-slate-500">
-                      {count}
-                    </span>
-                  </div>
-                  <p className="mt-2 text-[12px] text-slate-600">{meta.desc}</p>
-                  <code className="mt-3 block font-mono text-[11px] text-slate-500">
-                    vaults/*/{cat}.jsonl
-                  </code>
-                </div>
-              );
-            })}
-          </div>
-
-          <p className="mt-6 text-[13px] text-slate-600">
-            {entries.length} entries across {registry.length} public vault
-            {registry.length === 1 ? "" : "s"}. All rebuildable from raw files.
-          </p>
-        </div>
-      </section>
-
-      {/* ── Temporal Layer ── */}
-      <section className="border-b border-white/[0.04] px-6 py-20">
-        <div className="mx-auto max-w-3xl">
-          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
-            Temporal layer
-          </h2>
-          <p className="mt-3 text-xl font-semibold text-white">
-            Intelligence that ages gracefully.
-          </p>
-          <p className="mt-4 text-[14px] leading-relaxed text-slate-400">
-            Every entry carries temporal metadata. Old insights fade unless
-            confirmed. Stale decisions surface for review. The system knows
-            what&apos;s still true.
-          </p>
-
-          <div className="mt-8 overflow-hidden rounded-xl border border-white/[0.08] bg-[#0c0c12]">
-            <div className="border-b border-white/[0.04] px-4 py-2">
-              <code className="font-mono text-[10px] uppercase tracking-widest text-slate-600">
-                strategic.jsonl
-              </code>
+          <div className="mt-10 overflow-hidden rounded-xl border border-white/[0.08] bg-[#0c0c12]">
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse text-left text-[13px]">
+                <thead>
+                  <tr className="border-b border-white/[0.06]">
+                    <th className="px-4 py-3 font-mono text-[10px] uppercase tracking-widest text-slate-600">
+                      #
+                    </th>
+                    <th className="px-4 py-3 font-mono text-[10px] uppercase tracking-widest text-slate-600">
+                      Layer
+                    </th>
+                    <th className="px-4 py-3 font-mono text-[10px] uppercase tracking-widest text-slate-600">
+                      Tier
+                    </th>
+                    <th className="px-4 py-3 font-mono text-[10px] uppercase tracking-widest text-slate-600">
+                      Purpose
+                    </th>
+                    <th className="px-4 py-3 font-mono text-[10px] uppercase tracking-widest text-slate-600">
+                      Vault
+                    </th>
+                    <th className="px-4 py-3 font-mono text-[10px] uppercase tracking-widest text-slate-600">
+                      Posture
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {LAYERS.map((l, i) => (
+                    <tr
+                      key={l.name}
+                      className={
+                        i < LAYERS.length - 1
+                          ? "border-b border-white/[0.04]"
+                          : ""
+                      }
+                    >
+                      <td className="px-4 py-3 align-top font-mono text-[12px] text-slate-500">
+                        {l.n}
+                      </td>
+                      <td className="px-4 py-3 align-top font-semibold text-white">
+                        {l.name}
+                      </td>
+                      <td className="px-4 py-3 align-top text-[12px] text-slate-500">
+                        {l.tier}
+                      </td>
+                      <td className="px-4 py-3 align-top text-slate-300">
+                        {l.purpose}
+                      </td>
+                      <td className="px-4 py-3 align-top font-mono text-[12px] text-violet-300">
+                        {l.vault}
+                      </td>
+                      <td className="px-4 py-3 align-top">
+                        <span
+                          className={`inline-block rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wider ${STATUS_CLASS[l.status]}`}
+                        >
+                          {STATUS_LABEL[l.status]}
+                        </span>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
             </div>
-            <pre className="overflow-x-auto p-4 font-mono text-[12px] leading-[1.8] text-slate-500">
-              <span className="text-slate-600">{"{"}</span>
-              {"\n"}
-              {"  "}
-              <span className="text-violet-400">&quot;insight&quot;</span>:{" "}
-              <span className="text-emerald-400">
-                &quot;Open core beats premature tiers&quot;
-              </span>
-              ,{"\n"}
-              {"  "}
-              <span className="text-violet-400">&quot;confidence&quot;</span>:{" "}
-              <span className="text-emerald-400">&quot;high&quot;</span>,{"\n"}
-              {"  "}
-              <span className="text-violet-400">&quot;validFrom&quot;</span>:{" "}
-              <span className="text-amber-400">&quot;2026-04-05&quot;</span>,
-              {"\n"}
-              {"  "}
-              <span className="text-violet-400">&quot;validUntil&quot;</span>:{" "}
-              <span className="text-amber-400">&quot;2026-10-05&quot;</span>,
-              {"\n"}
-              {"  "}
-              <span className="text-violet-400">&quot;lastConfirmed&quot;</span>
-              : <span className="text-amber-400">&quot;2026-04-08&quot;</span>,
-              {"\n"}
-              {"  "}
-              <span className="text-violet-400">
-                &quot;confidenceDecay&quot;
-              </span>
-              : <span className="text-cyan-400">0.92</span>
-              {"\n"}
-              <span className="text-slate-600">{"}"}</span>
-            </pre>
           </div>
 
-          <dl className="mt-6 grid gap-3 sm:grid-cols-2">
-            <TemporalField
-              name="validFrom"
-              desc="When the insight became true"
-            />
-            <TemporalField
-              name="validUntil"
-              desc="Auto-flagged for review after this date"
-            />
-            <TemporalField
-              name="lastConfirmed"
-              desc="Most recent time you reaffirmed it"
-            />
-            <TemporalField
-              name="confidenceDecay"
-              desc="Drops from 1.0 as time passes without confirmation"
-            />
-          </dl>
+          <p className="mt-6 text-[13px] leading-relaxed text-slate-500">
+            Canonical reference:{" "}
+            <a
+              href="https://github.com/frankxai/Starlight-Intelligence-System/blob/main/docs/ARCHITECTURE.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-violet-300 transition-std hover:text-violet-200"
+            >
+              docs/ARCHITECTURE.md
+            </a>
+            .
+          </p>
         </div>
       </section>
 
-      {/* ── The Learning Loop ── */}
+      {/* ── Domain Sub-Stack Tier ── */}
       <section className="border-b border-white/[0.04] px-6 py-20">
         <div className="mx-auto max-w-3xl">
           <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
-            The learning loop
+            Domain Sub-Stack Tier
           </h2>
           <p className="mt-3 text-xl font-semibold text-white">
-            Every session makes the next one sharper.
+            Verticals compose the same substrate for a specific domain.
           </p>
-
-          <div className="mt-10 grid gap-4 sm:grid-cols-4">
-            {[
-              { label: "Use", desc: "Agent pulls context from your vault" },
-              { label: "Learn", desc: "New insights get appended as JSONL" },
-              { label: "Improve", desc: "Indexes rebuild; confidence updates" },
-              {
-                label: "Use again",
-                desc: "Next session starts with deeper memory",
-              },
-            ].map((stage, i) => (
-              <div
-                key={stage.label}
-                className="relative rounded-xl border border-white/[0.06] bg-white/[0.02] p-5 transition-std hover:border-white/[0.12] hover:bg-white/[0.04]"
-              >
-                <div className="flex items-center gap-2">
-                  <span className="font-mono text-[11px] text-violet-400">
-                    0{i + 1}
-                  </span>
-                  <span className="text-[13px] font-semibold text-white">
-                    {stage.label}
-                  </span>
-                </div>
-                <p className="mt-2 text-[12px] leading-relaxed text-slate-500">
-                  {stage.desc}
-                </p>
-              </div>
-            ))}
+          <p className="mt-5 text-[14px] leading-[1.85] text-slate-400">
+            Three reference Domain Sub-Stacks ship in this repo: People
+            Intelligence (6 sub-systems · 28 commands · 6 agents), Sound
+            Intelligence (6 / 30 / 6), and Music IS (6+1 / 8 / 7,
+            Frank-operated).
+          </p>
+          <p className="mt-4 text-[14px] leading-[1.85] text-slate-400">
+            Every Domain Sub-Stack carries the same 7-file contract: README ·
+            SUB-SYSTEMS · AGENTS · SOUL · STACK · CANON · MEMORY. The
+            meta-command{" "}
+            <code className="rounded bg-white/[0.06] px-1.5 py-0.5 font-mono text-[13px] text-violet-300">
+              /spawn-domain-stack
+            </code>{" "}
+            generalizes the pattern.
+          </p>
+          <div className="mt-8">
+            <Link
+              href="/verticals"
+              className="rounded-full bg-white px-5 py-2.5 text-[14px] font-semibold text-[#060609] transition-std hover:shadow-[0_0_30px_rgba(167,139,250,0.2)]"
+            >
+              See the verticals &rarr;
+            </Link>
           </div>
+        </div>
+      </section>
 
-          <p className="mt-6 text-center text-[11px] uppercase tracking-widest text-slate-600">
-            &rarr; the loop that learns is the loop that lives &rarr;
+      {/* ── Composition rules ── */}
+      <section className="border-b border-white/[0.04] px-6 py-20">
+        <div className="mx-auto max-w-3xl">
+          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
+            Composition rules
+          </h2>
+          <p className="mt-3 text-xl font-semibold text-white">
+            The graph is a reinforcement network, not a hierarchy.
           </p>
+          <ul className="mt-6 space-y-4 pl-6 text-[14px] leading-[1.85] text-slate-400">
+            <li className="relative before:absolute before:-left-5 before:top-[0.9em] before:h-px before:w-3 before:bg-violet-400/40">
+              <strong className="text-white">Genius is the root.</strong>{" "}
+              Every downstream layer references it. Skip the root and the tree
+              grows crooked.
+            </li>
+            <li className="relative before:absolute before:-left-5 before:top-[0.9em] before:h-px before:w-3 before:bg-violet-400/40">
+              <strong className="text-white">Foundation before surface.</strong>{" "}
+              Layers 1–3 (Genius, Second Brain, Brand) are foundation. 4–8
+              (Business, Creator, Wealth, Code, Voice & Video) are surface.
+              Surface without foundation produces noise.
+            </li>
+            <li className="relative before:absolute before:-left-5 before:top-[0.9em] before:h-px before:w-3 before:bg-violet-400/40">
+              <strong className="text-white">Cross-cutting throughout.</strong>{" "}
+              Health, Second Brain, and Family run continuously, not in their
+              own sprint blocks (unless burnout / chaos / isolation is the
+              primary bottleneck).
+            </li>
+            <li className="relative before:absolute before:-left-5 before:top-[0.9em] before:h-px before:w-3 before:bg-violet-400/40">
+              <strong className="text-white">Sovereignty per layer.</strong>{" "}
+              Layer outputs live in your instance only. Substrate retains no
+              copies.
+            </li>
+            <li className="relative before:absolute before:-left-5 before:top-[0.9em] before:h-px before:w-3 before:bg-violet-400/40">
+              <strong className="text-white">Attestation per layer.</strong>{" "}
+              Every output auto-stamps with &ldquo;Built on SIP&rdquo; on real
+              composition. Decorative attestation is refused.
+            </li>
+          </ul>
         </div>
       </section>
 
@@ -287,8 +428,8 @@ export default async function ArchitecturePage() {
             One memory. Every agent. No silos.
           </p>
           <p className="mt-4 max-w-xl text-[14px] leading-relaxed text-slate-400">
-            The MCP protocol is the universal pipe. Whatever tool you&apos;re in
-            today, your intelligence is already there.
+            The MCP protocol is the universal pipe. Whatever tool you&apos;re
+            in today, your intelligence is already there.
           </p>
 
           <div className="mt-10 flex flex-col items-center gap-6">
@@ -319,6 +460,26 @@ export default async function ArchitecturePage() {
         </div>
       </section>
 
+      {/* ── Extension model ── */}
+      <section className="border-b border-white/[0.04] px-6 py-20">
+        <div className="mx-auto max-w-3xl">
+          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
+            Extension
+          </h2>
+          <p className="mt-3 text-xl font-semibold text-white">
+            Adding an 11th IS is a named procedure, not a refactor.
+          </p>
+          <p className="mt-5 text-[14px] leading-[1.85] text-slate-400">
+            Every new layer requires: one agent · 1–2 skills · 2–3 commands ·
+            knowledge templates · /compose-stack sequencing update ·
+            ARCHITECTURE.md entry · /luminor-board pressure-test before merge ·
+            /openclaw-audit adversarial pass. Extension is welcome. Sprawl is
+            not. If a layer&apos;s use case is already covered by an existing
+            layer&apos;s commands, it&apos;s a command, not a layer.
+          </p>
+        </div>
+      </section>
+
       {/* ── CTA ── */}
       <section className="px-6 py-20">
         <div className="mx-auto max-w-3xl text-center">
@@ -333,10 +494,10 @@ export default async function ArchitecturePage() {
               Start the quickstart &rarr;
             </Link>
             <Link
-              href="/vaults"
+              href="/protocol"
               className="rounded-full border border-white/[0.1] px-6 py-3 text-[14px] font-medium text-white transition-std hover:border-white/[0.2] hover:bg-white/[0.04]"
             >
-              Explore live vaults
+              Read the protocol
             </Link>
           </div>
         </div>
@@ -377,17 +538,6 @@ function FlowNode({
       </span>
       <h3 className="mt-2 text-[14px] font-semibold text-white">{title}</h3>
       <p className="mt-2 text-[12px] leading-relaxed text-slate-500">{desc}</p>
-    </div>
-  );
-}
-
-function TemporalField({ name, desc }: { name: string; desc: string }) {
-  return (
-    <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-4">
-      <dt className="font-mono text-[12px] text-violet-300">{name}</dt>
-      <dd className="mt-1 text-[12px] leading-relaxed text-slate-500">
-        {desc}
-      </dd>
     </div>
   );
 }

--- a/site/src/app/cockpit/page.tsx
+++ b/site/src/app/cockpit/page.tsx
@@ -118,7 +118,7 @@ export default function CockpitPage() {
       {/* ── 4 Surfaces ── */}
       <section className="border-b border-white/[0.04] px-6 py-20">
         <div className="mx-auto max-w-5xl">
-          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
+          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-400">
             The four surfaces
           </h2>
           <p className="mt-3 max-w-md text-xl font-semibold text-white">
@@ -128,7 +128,7 @@ export default function CockpitPage() {
           {/* SVG schematic */}
           <div className="mt-10 overflow-hidden rounded-2xl border border-white/[0.08] bg-[#0c0c12]">
             <div className="border-b border-white/[0.04] px-4 py-3">
-              <code className="font-mono text-[10px] uppercase tracking-widest text-slate-600">
+              <code className="font-mono text-[10px] uppercase tracking-widest text-slate-400">
                 local-cockpit · schematic
               </code>
             </div>
@@ -139,7 +139,7 @@ export default function CockpitPage() {
             </div>
           </div>
 
-          <p className="mt-6 text-[13px] leading-relaxed text-slate-500">
+          <p className="mt-6 text-[13px] leading-relaxed text-slate-400">
             All four surfaces share a single FastAPI router on{" "}
             <code className="rounded bg-white/[0.06] px-1.5 py-0.5 font-mono text-[12px] text-violet-300">
               :7373
@@ -152,7 +152,7 @@ export default function CockpitPage() {
       {/* ── Voice loop ── */}
       <section className="border-b border-white/[0.04] px-6 py-20">
         <div className="mx-auto max-w-3xl">
-          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
+          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-400">
             Voice loop
           </h2>
           <p className="mt-3 text-xl font-semibold text-white">
@@ -183,7 +183,7 @@ export default function CockpitPage() {
           </div>
 
           <div className="mt-12">
-            <p className="text-[11px] uppercase tracking-widest text-slate-600">
+            <p className="text-[11px] uppercase tracking-widest text-slate-400">
               Seven tools the loop can call
             </p>
             <div className="mt-5 grid gap-3 sm:grid-cols-2">
@@ -208,7 +208,7 @@ export default function CockpitPage() {
       {/* ── Brain viz ── */}
       <section className="border-b border-white/[0.04] px-6 py-20">
         <div className="mx-auto max-w-3xl">
-          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
+          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-400">
             Brain viz
           </h2>
           <p className="mt-3 text-xl font-semibold text-white">
@@ -250,7 +250,7 @@ export default function CockpitPage() {
       {/* ── Drafts on disk ── */}
       <section className="border-b border-white/[0.04] px-6 py-20">
         <div className="mx-auto max-w-3xl">
-          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
+          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-400">
             Drafts on disk
           </h2>
           <p className="mt-3 text-xl font-semibold text-white">
@@ -275,7 +275,7 @@ export default function CockpitPage() {
       {/* ── Privacy ── */}
       <section className="border-b border-white/[0.04] px-6 py-20">
         <div className="mx-auto max-w-3xl">
-          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
+          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-400">
             Privacy posture
           </h2>
           <p className="mt-3 text-xl font-semibold text-white">
@@ -350,11 +350,11 @@ function SurfaceCell({ surface }: { surface: Surface }) {
     <div className="bg-[#0c0c12] p-5">
       <div className="flex items-center justify-between">
         <p className={`text-[12px] font-semibold ${a.text}`}>{surface.name}</p>
-        <code className="font-mono text-[10px] uppercase tracking-widest text-slate-600">
+        <code className="font-mono text-[10px] uppercase tracking-widest text-slate-400">
           {surface.port}
         </code>
       </div>
-      <p className="mt-3 text-[12px] leading-relaxed text-slate-500">
+      <p className="mt-3 text-[12px] leading-relaxed text-slate-400">
         {surface.desc}
       </p>
     </div>

--- a/site/src/app/cockpit/page.tsx
+++ b/site/src/app/cockpit/page.tsx
@@ -1,0 +1,397 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: "Cockpit",
+  description:
+    "The local 4-surface AI cockpit. Voice → tool execution → brain visualization. 100% local-first. Forkable.",
+  openGraph: {
+    title: "Cockpit — Starlight Intelligence",
+    description:
+      "Four surfaces. One brain. Voice loop with 7 tools, live 3D thought-graph, drafts on disk. Local-first.",
+    type: "article",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Cockpit — Starlight Intelligence",
+    description:
+      "Four surfaces. One brain. Voice loop, brain viz, drafts on disk. Local-first.",
+  },
+};
+
+type Surface = {
+  name: string;
+  port: string;
+  desc: string;
+  accent: "violet" | "cyan" | "fuchsia" | "emerald";
+};
+
+const SURFACES: Surface[] = [
+  {
+    name: "Zellij terminal cockpit",
+    port: "tty",
+    desc: "Multi-pane operator surface. Worker logs, cognition tail, dispatch CLI in one screen.",
+    accent: "violet",
+  },
+  {
+    name: "PowerShell launcher",
+    port: "shell",
+    desc: "Windows-native start-cockpit.ps1 boots the brain watchdog, voice operator, and dashboard at logon.",
+    accent: "cyan",
+  },
+  {
+    name: "LCC Dashboard",
+    port: ":3007",
+    desc: "Live 3D thought-graph, dispatch panel, packet inspector, brain event halos. Next.js 16 + React 19.",
+    accent: "fuchsia",
+  },
+  {
+    name: "Phone PWA",
+    port: ":3008",
+    desc: "Voice in, voice out, from anywhere on the LAN. Same 7-tool execution loop as the desktop orb.",
+    accent: "emerald",
+  },
+];
+
+type Tool = {
+  name: string;
+  desc: string;
+};
+
+const TOOLS: Tool[] = [
+  {
+    name: "shell",
+    desc: "Run a command in the operator's shell (audited, optional dry-run).",
+  },
+  { name: "file_write", desc: "Write a draft to ~/Desktop/jarvis-drafts/." },
+  {
+    name: "claude_prompt",
+    desc: "Synchronous one-shot to Claude with rich context envelope.",
+  },
+  {
+    name: "claude_code_launch",
+    desc: "Spawn Claude Code in a project (auto-resolves shortcut map).",
+  },
+  { name: "open_url", desc: "Open URL in the default browser." },
+  {
+    name: "linear_issue",
+    desc: "Create a Linear issue with team + priority routing.",
+  },
+  {
+    name: "workflow_run",
+    desc: "Fire one of 13 named YAML workflows (morning brief, evening handover, etc.).",
+  },
+];
+
+export default function CockpitPage() {
+  return (
+    <div>
+      {/* ── Hero ── */}
+      <section className="relative overflow-hidden border-b border-white/[0.04]">
+        <div className="pointer-events-none absolute inset-0" aria-hidden="true">
+          <div className="animate-mesh-1 absolute -left-32 top-0 h-[400px] w-[400px] rounded-full bg-violet-600/[0.07] blur-[100px]" />
+          <div className="animate-mesh-2 absolute right-0 top-20 h-[320px] w-[320px] rounded-full bg-cyan-500/[0.05] blur-[80px]" />
+          <div className="animate-mesh-3 absolute left-1/2 bottom-0 h-[260px] w-[260px] rounded-full bg-emerald-500/[0.04] blur-[80px]" />
+        </div>
+        <div className="relative mx-auto max-w-3xl px-6 py-20 md:py-28">
+          <p className="text-[11px] font-medium uppercase tracking-widest text-violet-400">
+            Local cockpit
+          </p>
+          <h1 className="mt-3 text-3xl font-bold tracking-tight text-white md:text-5xl">
+            Four surfaces.
+            <br />
+            <span className="bg-gradient-to-r from-violet-400 via-cyan-400 to-emerald-400 bg-clip-text text-transparent">
+              One brain. Local-first.
+            </span>
+          </h1>
+          <p className="mt-6 max-w-xl text-[15px] leading-[1.8] text-slate-400">
+            The operator side of Starlight. A four-surface cockpit you run on
+            your own machine — voice in, tool execution, live 3D thought-graph,
+            drafts on disk. No cloud lock-in. Inference goes to Groq +
+            ElevenLabs over HTTPS; everything else stays local.
+          </p>
+        </div>
+      </section>
+
+      {/* ── 4 Surfaces ── */}
+      <section className="border-b border-white/[0.04] px-6 py-20">
+        <div className="mx-auto max-w-5xl">
+          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
+            The four surfaces
+          </h2>
+          <p className="mt-3 max-w-md text-xl font-semibold text-white">
+            Each one is independently useful. Together they&apos;re a loop.
+          </p>
+
+          {/* SVG schematic */}
+          <div className="mt-10 overflow-hidden rounded-2xl border border-white/[0.08] bg-[#0c0c12]">
+            <div className="border-b border-white/[0.04] px-4 py-3">
+              <code className="font-mono text-[10px] uppercase tracking-widest text-slate-600">
+                local-cockpit · schematic
+              </code>
+            </div>
+            <div className="grid gap-px bg-white/[0.04] sm:grid-cols-2 lg:grid-cols-4">
+              {SURFACES.map((s) => (
+                <SurfaceCell key={s.name} surface={s} />
+              ))}
+            </div>
+          </div>
+
+          <p className="mt-6 text-[13px] leading-relaxed text-slate-500">
+            All four surfaces share a single FastAPI router on{" "}
+            <code className="rounded bg-white/[0.06] px-1.5 py-0.5 font-mono text-[12px] text-violet-300">
+              :7373
+            </code>
+            . Same orchestrator, same packet log, same brain event bus.
+          </p>
+        </div>
+      </section>
+
+      {/* ── Voice loop ── */}
+      <section className="border-b border-white/[0.04] px-6 py-20">
+        <div className="mx-auto max-w-3xl">
+          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
+            Voice loop
+          </h2>
+          <p className="mt-3 text-xl font-semibold text-white">
+            STT → LLM + 7 tools → TTS. Sub-second to first token.
+          </p>
+
+          <div className="mt-10 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-center">
+            <Stage
+              n="01"
+              label="STT"
+              detail="Groq Whisper · ~400-800ms"
+              accent="violet"
+            />
+            <Arrow />
+            <Stage
+              n="02"
+              label="LLM"
+              detail="Claude / Llama-4 · 600ms first token"
+              accent="cyan"
+            />
+            <Arrow />
+            <Stage
+              n="03"
+              label="TTS"
+              detail="ElevenLabs Brian Flash · 75-1200ms"
+              accent="fuchsia"
+            />
+          </div>
+
+          <div className="mt-12">
+            <p className="text-[11px] uppercase tracking-widest text-slate-600">
+              Seven tools the loop can call
+            </p>
+            <div className="mt-5 grid gap-3 sm:grid-cols-2">
+              {TOOLS.map((t) => (
+                <div
+                  key={t.name}
+                  className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-4 transition-std hover:border-white/[0.12] hover:bg-white/[0.04]"
+                >
+                  <code className="font-mono text-[12px] text-violet-300">
+                    {t.name}
+                  </code>
+                  <p className="mt-1.5 text-[12px] leading-relaxed text-slate-400">
+                    {t.desc}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Brain viz ── */}
+      <section className="border-b border-white/[0.04] px-6 py-20">
+        <div className="mx-auto max-w-3xl">
+          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
+            Brain viz
+          </h2>
+          <p className="mt-3 text-xl font-semibold text-white">
+            Live 3D thought-graph. Halos fire on real dispatches.
+          </p>
+          <p className="mt-5 text-[15px] leading-[1.85] text-slate-400">
+            The dashboard at{" "}
+            <code className="rounded bg-white/[0.06] px-1.5 py-0.5 font-mono text-[13px] text-violet-300">
+              :3007/brain
+            </code>{" "}
+            is not a passive snapshot. Every dispatch publishes a 4-event
+            lifecycle —{" "}
+            <span className="text-violet-300">retrieve.start</span> →{" "}
+            <span className="text-violet-300">retrieve.topk</span> →{" "}
+            <span className="text-cyan-300">synthesis.complete</span> /{" "}
+            <span className="text-rose-300">error</span>. Matched nodes glow
+            purple, then pulse teal when the response lands. Click any routing
+            decision to inspect the full packet.
+          </p>
+
+          <ul className="mt-8 space-y-3 pl-6 text-[14px] leading-relaxed text-slate-400">
+            <li className="relative before:absolute before:-left-5 before:top-[0.9em] before:h-px before:w-3 before:bg-violet-400/40">
+              25+ nodes / instanced mesh ≤10K · AdaptiveDpr · time-warp scrubber
+            </li>
+            <li className="relative before:absolute before:-left-5 before:top-[0.9em] before:h-px before:w-3 before:bg-violet-400/40">
+              Per-trace halo correlation — synthesis pulses only matching
+              retrieve nodes
+            </li>
+            <li className="relative before:absolute before:-left-5 before:top-[0.9em] before:h-px before:w-3 before:bg-violet-400/40">
+              Cluster labels by intent · brand filter · regen on-demand
+            </li>
+            <li className="relative before:absolute before:-left-5 before:top-[0.9em] before:h-px before:w-3 before:bg-violet-400/40">
+              Hard contract: publisher failure NEVER breaks dispatch
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      {/* ── Drafts on disk ── */}
+      <section className="border-b border-white/[0.04] px-6 py-20">
+        <div className="mx-auto max-w-3xl">
+          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
+            Drafts on disk
+          </h2>
+          <p className="mt-3 text-xl font-semibold text-white">
+            Every file Jarvis writes lands where you can grep it.
+          </p>
+          <p className="mt-5 text-[15px] leading-[1.85] text-slate-400">
+            The{" "}
+            <code className="rounded bg-white/[0.06] px-1.5 py-0.5 font-mono text-[13px] text-violet-300">
+              file_write
+            </code>{" "}
+            tool ships drafts to{" "}
+            <code className="rounded bg-white/[0.06] px-1.5 py-0.5 font-mono text-[13px] text-violet-300">
+              ~/Desktop/jarvis-drafts/
+            </code>{" "}
+            — visible the second they exist, owned by you, version-controllable
+            on your terms. The dashboard tail-polls the directory and surfaces
+            new drafts inline. No proprietary store.
+          </p>
+        </div>
+      </section>
+
+      {/* ── Privacy ── */}
+      <section className="border-b border-white/[0.04] px-6 py-20">
+        <div className="mx-auto max-w-3xl">
+          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
+            Privacy posture
+          </h2>
+          <p className="mt-3 text-xl font-semibold text-white">
+            100% local. Inference over HTTPS. No cloud storage.
+          </p>
+          <ul className="mt-6 space-y-3 pl-6 text-[14px] leading-relaxed text-slate-400">
+            <li className="relative before:absolute before:-left-5 before:top-[0.9em] before:h-px before:w-3 before:bg-violet-400/40">
+              All four surfaces bind to{" "}
+              <code className="font-mono text-[12px] text-violet-300">
+                127.0.0.1
+              </code>{" "}
+              by default. LAN exposure is opt-in for the Phone PWA.
+            </li>
+            <li className="relative before:absolute before:-left-5 before:top-[0.9em] before:h-px before:w-3 before:bg-violet-400/40">
+              Groq (STT + LLM) and ElevenLabs (TTS) receive request audio /
+              text only. No conversation history persisted to their account.
+            </li>
+            <li className="relative before:absolute before:-left-5 before:top-[0.9em] before:h-px before:w-3 before:bg-violet-400/40">
+              Packet log lives at{" "}
+              <code className="font-mono text-[12px] text-violet-300">
+                logs/packets/&lt;date&gt;/&lt;id&gt;.json
+              </code>{" "}
+              on your disk. Audit trail is yours.
+            </li>
+            <li className="relative before:absolute before:-left-5 before:top-[0.9em] before:h-px before:w-3 before:bg-violet-400/40">
+              Privacy gate event kind exists in the brain bus but never
+              triggers visual halos — sensitive dispatches stay HUD-only.
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      {/* ── CTA ── */}
+      <section className="px-6 py-20">
+        <div className="mx-auto max-w-3xl text-center">
+          <p className="text-[15px] leading-relaxed text-slate-400">
+            The cockpit is reference, not product. Fork the repo, run it on
+            your machine, make it yours.
+          </p>
+          <div className="mt-6 flex flex-wrap justify-center gap-3">
+            <a
+              href="https://github.com/frankxai/Starlight-Intelligence-System"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-full bg-white px-6 py-3 text-[14px] font-semibold text-[#060609] transition-std hover:shadow-[0_0_30px_rgba(167,139,250,0.2)]"
+            >
+              Fork on GitHub &rarr;
+            </a>
+            <Link
+              href="/quickstart"
+              className="rounded-full border border-white/[0.1] px-6 py-3 text-[14px] font-medium text-white transition-std hover:border-white/[0.2] hover:bg-white/[0.04]"
+            >
+              Read the quickstart
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+const ACCENTS = {
+  violet: { text: "text-violet-400", border: "border-violet-500/[0.2]" },
+  cyan: { text: "text-cyan-400", border: "border-cyan-500/[0.2]" },
+  fuchsia: { text: "text-fuchsia-400", border: "border-fuchsia-500/[0.2]" },
+  emerald: { text: "text-emerald-400", border: "border-emerald-500/[0.2]" },
+} as const;
+
+function SurfaceCell({ surface }: { surface: Surface }) {
+  const a = ACCENTS[surface.accent];
+  return (
+    <div className="bg-[#0c0c12] p-5">
+      <div className="flex items-center justify-between">
+        <p className={`text-[12px] font-semibold ${a.text}`}>{surface.name}</p>
+        <code className="font-mono text-[10px] uppercase tracking-widest text-slate-600">
+          {surface.port}
+        </code>
+      </div>
+      <p className="mt-3 text-[12px] leading-relaxed text-slate-500">
+        {surface.desc}
+      </p>
+    </div>
+  );
+}
+
+function Stage({
+  n,
+  label,
+  detail,
+  accent,
+}: {
+  n: string;
+  label: string;
+  detail: string;
+  accent: "violet" | "cyan" | "fuchsia";
+}) {
+  const a = ACCENTS[accent];
+  return (
+    <div
+      className={`flex-1 rounded-xl border ${a.border} bg-white/[0.02] p-5 text-center`}
+    >
+      <p className={`font-mono text-[10px] uppercase tracking-widest ${a.text}`}>
+        {n} · {label}
+      </p>
+      <p className="mt-2 text-[12px] leading-relaxed text-slate-400">{detail}</p>
+    </div>
+  );
+}
+
+function Arrow() {
+  return (
+    <span
+      className="hidden text-slate-700 sm:block"
+      aria-hidden="true"
+    >
+      &rarr;
+    </span>
+  );
+}

--- a/site/src/app/explainer/page.tsx
+++ b/site/src/app/explainer/page.tsx
@@ -1,0 +1,131 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: "Explainer",
+  description:
+    "Long-form public explainer for Starlight Intelligence System. Who it's for, how it works, what's different, and how to start.",
+  openGraph: {
+    title: "Explainer — Starlight Intelligence",
+    description:
+      "Long-form: who it's for, the five-phase journey, the nine-layer vision, what's different from chat. Sovereign by architecture.",
+    type: "article",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Explainer — Starlight Intelligence",
+    description:
+      "Long-form: who it's for, the five-phase journey, the nine-layer vision. Sovereign by architecture.",
+  },
+};
+
+function loadExplainerSource(): string {
+  const path = join(
+    process.cwd(),
+    "..",
+    "docs",
+    "public",
+    "starlight-intelligence-system.md"
+  );
+  const raw = readFileSync(path, "utf-8");
+  // Strip the leading H1 — we render our own hero above the markdown body.
+  const lines = raw.split("\n");
+  const firstHeadingIdx = lines.findIndex((l) => /^#\s/.test(l));
+  if (firstHeadingIdx === -1) return raw;
+  // Find the first horizontal rule after the H1 to skip the title block.
+  const firstHrIdx = lines.findIndex(
+    (l, i) => i > firstHeadingIdx && /^---\s*$/.test(l)
+  );
+  const startIdx = firstHrIdx === -1 ? firstHeadingIdx + 1 : firstHrIdx + 1;
+  return lines.slice(startIdx).join("\n").trim();
+}
+
+export default function ExplainerPage() {
+  const body = loadExplainerSource();
+
+  return (
+    <div>
+      {/* ── Hero ── */}
+      <section className="relative overflow-hidden border-b border-white/[0.04]">
+        <div className="pointer-events-none absolute inset-0" aria-hidden="true">
+          <div className="animate-mesh-1 absolute -left-32 top-0 h-[400px] w-[400px] rounded-full bg-violet-600/[0.06] blur-[100px]" />
+          <div className="animate-mesh-2 absolute right-0 top-20 h-[300px] w-[300px] rounded-full bg-cyan-500/[0.04] blur-[80px]" />
+        </div>
+        <div className="relative mx-auto max-w-3xl px-6 py-20 md:py-28">
+          <p className="text-[11px] font-medium uppercase tracking-widest text-violet-400">
+            Public explainer
+          </p>
+          <h1 className="mt-3 text-3xl font-bold tracking-tight text-white md:text-5xl">
+            You already have the genius.
+            <br />
+            <span className="bg-gradient-to-r from-violet-400 via-fuchsia-400 to-cyan-400 bg-clip-text text-transparent">
+              It&apos;s just scattered.
+            </span>
+          </h1>
+          <p className="mt-6 max-w-xl text-[15px] leading-[1.8] text-slate-400">
+            Long-form for the indispensable professional and the creator with a
+            body of work. Five phases. Nine layers. Yours, compounding.
+          </p>
+        </div>
+      </section>
+
+      {/* ── Source-of-truth banner ── */}
+      <section className="border-b border-white/[0.04] bg-white/[0.01] px-6 py-4">
+        <div className="mx-auto flex max-w-3xl flex-wrap items-center gap-x-2 gap-y-1 text-[12px] text-slate-500">
+          <span className="text-[10px] uppercase tracking-widest text-slate-600">
+            Canonical source
+          </span>
+          <span className="text-slate-700">·</span>
+          <a
+            href="https://github.com/frankxai/Starlight-Intelligence-System/blob/main/docs/public/starlight-intelligence-system.md"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-mono text-slate-400 transition-std hover:text-violet-300"
+          >
+            docs/public/starlight-intelligence-system.md
+          </a>
+          <span className="text-slate-700">·</span>
+          <span>Mirrored on every build</span>
+        </div>
+      </section>
+
+      {/* ── Body ── */}
+      <article className="mx-auto max-w-3xl px-6 py-16 md:py-20">
+        <div className="explainer-prose">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{body}</ReactMarkdown>
+        </div>
+      </article>
+
+      {/* ── CTA ── */}
+      <section className="border-t border-white/[0.04] px-6 py-20">
+        <div className="mx-auto max-w-3xl text-center">
+          <p className="text-[15px] leading-relaxed text-slate-400">
+            Two paths to start. Pick the one that matches how you work.
+          </p>
+          <div className="mt-6 flex flex-wrap justify-center gap-3">
+            <Link
+              href="/quickstart"
+              className="rounded-full bg-white px-6 py-3 text-[14px] font-semibold text-[#060609] transition-std hover:shadow-[0_0_30px_rgba(167,139,250,0.2)]"
+            >
+              Builder path &rarr;
+            </Link>
+            <a
+              href="https://github.com/frankxai/Starlight-Intelligence-System/tree/main/integrations/starter-packs/friend-starter"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-full border border-white/[0.1] px-6 py-3 text-[14px] font-medium text-white transition-std hover:border-white/[0.2] hover:bg-white/[0.04]"
+            >
+              Friend starter (Claude Project)
+            </a>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/site/src/app/explainer/page.tsx
+++ b/site/src/app/explainer/page.tsx
@@ -25,7 +25,13 @@ export const metadata: Metadata = {
   },
 };
 
+const EXPLAINER_FALLBACK = `Explainer source temporarily unavailable.
+
+Read it on GitHub instead: [docs/public/starlight-intelligence-system.md](https://github.com/frankxai/Starlight-Intelligence-System/blob/main/docs/public/starlight-intelligence-system.md).`;
+
 function loadExplainerSource(): string {
+  // process.cwd() resolves to site/ on Vercel and locally; ../docs/public is repo-relative.
+  // If the source is ever moved or the build invoked from a different cwd, fall back gracefully.
   const path = join(
     process.cwd(),
     "..",
@@ -33,12 +39,15 @@ function loadExplainerSource(): string {
     "public",
     "starlight-intelligence-system.md"
   );
-  const raw = readFileSync(path, "utf-8");
-  // Strip the leading H1 — we render our own hero above the markdown body.
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch {
+    return EXPLAINER_FALLBACK;
+  }
   const lines = raw.split("\n");
   const firstHeadingIdx = lines.findIndex((l) => /^#\s/.test(l));
   if (firstHeadingIdx === -1) return raw;
-  // Find the first horizontal rule after the H1 to skip the title block.
   const firstHrIdx = lines.findIndex(
     (l, i) => i > firstHeadingIdx && /^---\s*$/.test(l)
   );
@@ -77,8 +86,8 @@ export default function ExplainerPage() {
 
       {/* ── Source-of-truth banner ── */}
       <section className="border-b border-white/[0.04] bg-white/[0.01] px-6 py-4">
-        <div className="mx-auto flex max-w-3xl flex-wrap items-center gap-x-2 gap-y-1 text-[12px] text-slate-500">
-          <span className="text-[10px] uppercase tracking-widest text-slate-600">
+        <div className="mx-auto flex max-w-3xl flex-wrap items-center gap-x-2 gap-y-1 text-[12px] text-slate-400">
+          <span className="text-[10px] uppercase tracking-widest text-slate-400">
             Canonical source
           </span>
           <span className="text-slate-700">·</span>

--- a/site/src/app/globals.css
+++ b/site/src/app/globals.css
@@ -95,3 +95,110 @@ body {
   outline-offset: 2px;
   border-radius: 4px;
 }
+
+/* Markdown body styles for /explainer (mirrors docs/public/*.md) */
+.explainer-prose {
+  font-size: 15px;
+  line-height: 1.85;
+  color: rgb(203 213 225);
+}
+.explainer-prose > * + * { margin-top: 1.25em; }
+.explainer-prose h2 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: white;
+  margin-top: 3rem;
+  letter-spacing: -0.01em;
+}
+.explainer-prose h3 {
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: rgb(241 245 249);
+  margin-top: 2rem;
+}
+.explainer-prose h4 {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: rgb(165 180 252);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-top: 1.5rem;
+}
+.explainer-prose p { color: rgb(148 163 184); }
+.explainer-prose strong { color: white; font-weight: 600; }
+.explainer-prose em { color: rgb(203 213 225); font-style: italic; }
+.explainer-prose a {
+  color: rgb(196 181 253);
+  text-decoration: underline;
+  text-decoration-color: rgba(167, 139, 250, 0.3);
+  text-underline-offset: 3px;
+  transition: all 200ms var(--ease);
+}
+.explainer-prose a:hover {
+  color: rgb(221 214 254);
+  text-decoration-color: rgba(167, 139, 250, 0.7);
+}
+.explainer-prose ul, .explainer-prose ol {
+  padding-left: 1.5rem;
+  color: rgb(148 163 184);
+}
+.explainer-prose ul { list-style-type: disc; }
+.explainer-prose ol { list-style-type: decimal; }
+.explainer-prose li { margin-top: 0.5em; }
+.explainer-prose li::marker { color: rgba(167, 139, 250, 0.5); }
+.explainer-prose code {
+  background: rgba(255, 255, 255, 0.06);
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+  font-family: var(--font-mono);
+  font-size: 0.875em;
+  color: rgb(196 181 253);
+}
+.explainer-prose pre {
+  background: #0c0c12;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  overflow-x: auto;
+  font-size: 0.8125rem;
+  line-height: 1.7;
+}
+.explainer-prose pre code {
+  background: transparent;
+  padding: 0;
+  color: rgb(203 213 225);
+}
+.explainer-prose blockquote {
+  border-left: 2px solid rgba(167, 139, 250, 0.4);
+  padding-left: 1rem;
+  color: rgb(203 213 225);
+  font-style: italic;
+}
+.explainer-prose hr {
+  border: 0;
+  height: 1px;
+  background: rgba(255, 255, 255, 0.08);
+  margin: 3rem 0;
+}
+.explainer-prose table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8125rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+.explainer-prose th {
+  background: rgba(255, 255, 255, 0.03);
+  text-align: left;
+  font-weight: 600;
+  color: white;
+  padding: 0.625rem 0.875rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+.explainer-prose td {
+  padding: 0.625rem 0.875rem;
+  color: rgb(148 163 184);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+.explainer-prose tr:last-child td { border-bottom: 0; }

--- a/site/src/app/globals.css
+++ b/site/src/app/globals.css
@@ -92,8 +92,20 @@ body {
 /* Focus */
 :focus-visible {
   outline: 2px solid var(--accent);
-  outline-offset: 2px;
+  outline-offset: 3px;
   border-radius: 4px;
+}
+
+/* Reduced motion — disable ambient + decorative animations for users who prefer it */
+@media (prefers-reduced-motion: reduce) {
+  .animate-mesh-1,
+  .animate-mesh-2,
+  .animate-mesh-3,
+  .animate-glow-pulse,
+  .animate-fade-up,
+  .animate-blink {
+    animation: none;
+  }
 }
 
 /* Markdown body styles for /explainer (mirrors docs/public/*.md) */

--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -19,15 +19,17 @@ const jbMono = JetBrains_Mono({
 export const metadata: Metadata = {
   metadataBase: new URL("https://starlightintelligence.org"),
   title: {
-    default: "Starlight Intelligence",
+    default:
+      "Starlight Intelligence — Persistent context for AI agents · Built on SIP",
     template: "%s — Starlight Intelligence",
   },
   description:
-    "The memory layer for humans and AI agents. Six semantic vaults that compound your intelligence over time. Local-first. Forkable. Free.",
+    "A persistent context and memory architecture for AI agents. 9 intelligence layers, 35 agents, 70+ commands, 3 reference Domain Sub-Stack verticals. Built on the Starlight Intelligence Protocol. Local-first. Forkable. Free.",
   openGraph: {
-    title: "Starlight Intelligence",
+    title:
+      "Starlight Intelligence — Persistent context for AI agents · Built on SIP",
     description:
-      "Six vaults. Your insights. Readable by agents. Compounding forever.",
+      "9 intelligence layers, 35 agents, 70+ commands, 3 reference verticals. Built on SIP. Local-first. Forkable. Free.",
     url: "https://starlightintelligence.org",
     siteName: "Starlight Intelligence",
     type: "website",
@@ -35,9 +37,10 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Starlight Intelligence",
+    title:
+      "Starlight Intelligence — Persistent context for AI agents · Built on SIP",
     description:
-      "Six vaults. Your insights. Readable by agents. Compounding forever.",
+      "9 intelligence layers, 35 agents, 70+ commands, 3 reference verticals. Built on SIP. Local-first. Forkable. Free.",
   },
   robots: { index: true, follow: true },
 };

--- a/site/src/app/page.tsx
+++ b/site/src/app/page.tsx
@@ -4,16 +4,84 @@ import {
   getFeaturedMeditations,
   getBenedictions,
   getVaultRegistry,
-  VAULT_CATEGORIES,
-  getCategoryMeta,
   getEntryText,
   timeAgo,
-  type VaultCategory,
-  type VaultEntry,
 } from "@/lib/vault";
 import { EntryCard } from "@/components/EntryCard";
 
 export const revalidate = 3600;
+
+type LayerCard = {
+  name: string;
+  desc: string;
+  accent: "violet" | "cyan" | "fuchsia" | "emerald" | "amber" | "rose";
+};
+
+const LAYERS: LayerCard[] = [
+  {
+    name: "Self / Genius",
+    desc: "What only you uniquely see. The root every layer reads from.",
+    accent: "violet",
+  },
+  {
+    name: "Second Brain",
+    desc: "Daily capture compounds into surfaceable memory.",
+    accent: "cyan",
+  },
+  {
+    name: "Brand",
+    desc: "Five-horizon vision and Brand Kit. Voice, palette, vocabulary.",
+    accent: "fuchsia",
+  },
+  {
+    name: "Business",
+    desc: "Entity architecture, revenue model, tax sanity.",
+    accent: "emerald",
+  },
+  {
+    name: "Creator",
+    desc: "Frameworks become multi-modal pipelines and executor playbooks.",
+    accent: "amber",
+  },
+  {
+    name: "Wealth",
+    desc: "Disruptive Passive Income ledger and thesis engine.",
+    accent: "rose",
+  },
+  {
+    name: "Code",
+    desc: "Code as a sovereign domain. MCP builders, automations, agents.",
+    accent: "violet",
+  },
+  {
+    name: "Voice & Video",
+    desc: "Modality attestation across audio, video, multi-modal.",
+    accent: "cyan",
+  },
+  {
+    name: "Family",
+    desc: "Network and alliance-readiness. Continuous, not seasonal.",
+    accent: "fuchsia",
+  },
+];
+
+const ACCENT_BG: Record<LayerCard["accent"], string> = {
+  violet: "border-violet-500/[0.18] bg-violet-500/[0.04]",
+  cyan: "border-cyan-500/[0.18] bg-cyan-500/[0.04]",
+  fuchsia: "border-fuchsia-500/[0.18] bg-fuchsia-500/[0.04]",
+  emerald: "border-emerald-500/[0.18] bg-emerald-500/[0.04]",
+  amber: "border-amber-500/[0.18] bg-amber-500/[0.04]",
+  rose: "border-rose-500/[0.18] bg-rose-500/[0.04]",
+};
+
+const ACCENT_TEXT: Record<LayerCard["accent"], string> = {
+  violet: "text-violet-400",
+  cyan: "text-cyan-400",
+  fuchsia: "text-fuchsia-400",
+  emerald: "text-emerald-400",
+  amber: "text-amber-400",
+  rose: "text-rose-400",
+};
 
 export default async function HomePage() {
   const [entries, registry, featured, benedictions] = await Promise.all([
@@ -23,73 +91,82 @@ export default async function HomePage() {
     getBenedictions(3),
   ]);
 
-  // Find the horizon vision statement — the most powerful piece of content
   const horizonEntry = entries.find((e) => e.vaultCategory === "horizon");
 
   return (
     <div>
       {/* ── Hero ── */}
       <section className="relative overflow-hidden border-b border-white/[0.04]">
-        {/* Ambient gradient mesh — 3 drifting orbs */}
         <div className="pointer-events-none absolute inset-0" aria-hidden="true">
           <div className="animate-mesh-1 absolute -left-32 top-0 h-[400px] w-[400px] rounded-full bg-violet-600/[0.06] blur-[100px]" />
           <div className="animate-mesh-2 absolute right-0 top-20 h-[300px] w-[300px] rounded-full bg-cyan-500/[0.04] blur-[80px]" />
           <div className="animate-mesh-3 absolute left-1/3 top-40 h-[200px] w-[200px] rounded-full bg-fuchsia-500/[0.03] blur-[60px]" />
         </div>
 
-        {/* Dot grid texture */}
         <div className="dot-grid pointer-events-none absolute inset-0 opacity-50" aria-hidden="true" />
 
         <div className="relative mx-auto max-w-5xl px-6 pb-24 pt-24 md:pb-32 md:pt-36">
           <div className="flex items-center gap-2 text-[12px] text-violet-400/80">
             <span className="inline-block h-1.5 w-1.5 rounded-full bg-violet-400 animate-glow-pulse" />
-            Open source memory system
+            Built on the Starlight Intelligence Protocol &middot; v1.1.0
           </div>
 
-          <h1 className="mt-5 max-w-2xl text-[clamp(2.25rem,6vw,4rem)] font-bold leading-[1.05] tracking-tight text-white">
-            Your intelligence,
+          <h1 className="mt-5 max-w-3xl text-[clamp(2.25rem,6vw,4rem)] font-bold leading-[1.05] tracking-tight text-white">
+            Persistent context.
             <br />
             <span className="bg-gradient-to-r from-violet-400 via-fuchsia-400 to-cyan-400 bg-clip-text text-transparent">
-              preserved forever.
+              Sovereign by architecture.
             </span>
           </h1>
 
-          <p className="mt-6 max-w-lg text-[16px] leading-[1.7] text-slate-400">
-            Six semantic vaults capture what you learn, decide, and envision.
-            Stored as plain files on GitHub. Readable by any AI agent.
-            Compounding across every tool you touch.
+          <p className="mt-6 max-w-2xl text-[16px] leading-[1.7] text-slate-400">
+            A persistent context and memory architecture for AI agents. Built
+            on the Starlight Intelligence Protocol — a sovereign substrate
+            anyone can adopt, fork, or compose with.{" "}
+            <span className="text-slate-300">
+              9 intelligence layers, 35 agents, 70+ commands, 3 reference
+              Domain Sub-Stack verticals.
+            </span>{" "}
+            Local-first. Forkable. Free.
           </p>
 
-          <div className="mt-10 flex flex-wrap gap-3">
-            <a
-              href="https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Ffrankxai%2FStarlight-Intelligence-System&root-directory=site"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="group rounded-full bg-white px-6 py-3 text-[14px] font-semibold text-[#060609] transition-std hover:shadow-[0_0_30px_rgba(167,139,250,0.2)]"
-            >
-              Deploy your vault
-              <span className="ml-1 inline-block transition-micro group-hover:translate-x-0.5">
-                &rarr;
-              </span>
-            </a>
-            <Link
-              href="/vaults"
-              className="rounded-full border border-white/[0.1] px-6 py-3 text-[14px] font-medium text-white transition-std hover:bg-white/[0.04] hover:border-white/[0.2]"
-            >
-              Explore vaults
-            </Link>
+          {/* Three CTA cards */}
+          <div className="mt-10 grid gap-3 md:grid-cols-3">
+            <CtaCard
+              href="/protocol"
+              eyebrow="01 · Protocol"
+              title="Adopt SIP"
+              desc="Read the six-layer protocol. Carry the file contract. Stamp every artifact with attestation."
+              accent="violet"
+            />
+            <CtaCard
+              href="/quickstart"
+              eyebrow="02 · Reference build"
+              title="Run the reference"
+              desc="Two-minute install. MCP server, slash commands, six-platform adapter. Free forever."
+              accent="cyan"
+            />
+            <CtaCard
+              href="/verticals"
+              eyebrow="03 · Domain Sub-Stack"
+              title="Spawn your vertical"
+              desc="People · Sound · Music are reference. The pattern generalizes via /spawn-domain-stack."
+              accent="fuchsia"
+            />
           </div>
 
           {/* Stats bar */}
-          <div className="mt-16 flex gap-8 border-t border-white/[0.04] pt-6 text-[13px]">
-            <Stat n={registry.length} label="public vaults" />
-            <Stat n={entries.length} label="insights" />
-            <Stat n={6} label="vault types" />
+          <div className="mt-14 flex flex-wrap gap-x-8 gap-y-3 border-t border-white/[0.04] pt-6 text-[13px]">
+            <Stat n={9} label="intelligence layers" />
+            <Stat n={35} label="agents" />
+            <Stat n="70+" label="commands" />
+            <Stat n={3} label="reference verticals" />
+            <Stat n={6} label="platform adapters" />
           </div>
         </div>
       </section>
 
-      {/* ── Horizon Quote — the vision ── */}
+      {/* ── Horizon Quote ── */}
       {horizonEntry && (
         <section className="border-b border-white/[0.04] px-6 py-20">
           <div className="mx-auto max-w-3xl text-center">
@@ -105,49 +182,148 @@ export default async function HomePage() {
         </section>
       )}
 
-      {/* ── Six Vaults ── */}
+      {/* ── 9 Intelligence Layers ── */}
       <section className="border-b border-white/[0.04] px-6 py-20">
         <div className="mx-auto max-w-5xl">
           <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
-            Six semantic vaults
+            The nine layers
           </h2>
           <p className="mt-3 max-w-md text-xl font-semibold text-white">
-            One JSONL file per vault. No database. No lock-in.
+            Each layer is its own Intelligence System. Compose what you need.
           </p>
 
           <div className="mt-10 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
-            {VAULT_CATEGORIES.map((cat) => {
-              const meta = getCategoryMeta(cat);
-              const count = entries.filter(
-                (e) => e.vaultCategory === cat
-              ).length;
-              const latest = entries.find((e) => e.vaultCategory === cat);
-              return (
-                <div
-                  key={cat}
-                  className={`group rounded-xl border p-5 transition-std hover:border-white/[0.2] ${meta.bg}`}
+            {LAYERS.map((l) => (
+              <div
+                key={l.name}
+                className={`group rounded-xl border p-5 transition-std hover:border-white/[0.2] ${ACCENT_BG[l.accent]}`}
+              >
+                <p
+                  className={`text-[13px] font-semibold ${ACCENT_TEXT[l.accent]}`}
                 >
-                  <div className="flex items-center justify-between">
-                    <span className={`text-[13px] font-semibold ${meta.color}`}>
-                      {meta.icon} {meta.label}
-                    </span>
-                    {count > 0 && (
-                      <span className="rounded-full bg-white/[0.04] px-2 py-0.5 text-[10px] text-slate-500">
-                        {count}
-                      </span>
-                    )}
-                  </div>
-                  <p className="mt-1 text-[12px] text-slate-600">
-                    {meta.desc}
-                  </p>
-                  {latest && (
-                    <p className="mt-3 line-clamp-2 text-[12px] leading-relaxed text-slate-400 transition-micro group-hover:text-slate-300">
-                      {getEntryText(latest)}
-                    </p>
-                  )}
-                </div>
-              );
-            })}
+                  {l.name}
+                </p>
+                <p className="mt-2 text-[12px] leading-relaxed text-slate-500 transition-micro group-hover:text-slate-400">
+                  {l.desc}
+                </p>
+              </div>
+            ))}
+          </div>
+
+          <p className="mt-6 text-[13px] leading-relaxed text-slate-500">
+            Plus Health (cross-cutting rhythm) and Spiritual (founder-layer,
+            optional). The Starlight Orchestrator routes voice and text intent
+            across all of them. See{" "}
+            <Link
+              href="/architecture"
+              className="text-violet-300 transition-std hover:text-violet-200"
+            >
+              /architecture
+            </Link>{" "}
+            for the full 10-IS table.
+          </p>
+        </div>
+      </section>
+
+      {/* ── Domain Sub-Stack Tier ── */}
+      <section className="relative overflow-hidden border-b border-white/[0.04] px-6 py-20">
+        <div className="pointer-events-none absolute inset-0" aria-hidden="true">
+          <div className="animate-mesh-2 absolute right-0 top-0 h-[300px] w-[300px] rounded-full bg-cyan-500/[0.04] blur-[80px]" />
+          <div className="animate-mesh-3 absolute left-0 bottom-0 h-[250px] w-[250px] rounded-full bg-fuchsia-500/[0.04] blur-[80px]" />
+        </div>
+        <div className="relative mx-auto max-w-5xl">
+          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
+            Domain Sub-Stack Tier
+          </h2>
+          <p className="mt-3 max-w-xl text-xl font-semibold text-white">
+            Three reference verticals. The pattern generalizes.
+          </p>
+
+          <div className="mt-10 grid gap-4 md:grid-cols-3">
+            <VerticalSummary
+              name="People Intelligence"
+              tagline="Hiring · Performance · Training · Culture · Talent · Org"
+              counts="6 sub-systems · 28 commands · 6 agents"
+              accent="violet"
+            />
+            <VerticalSummary
+              name="Sound Intelligence"
+              tagline="Composition · Production · Catalog · Performance · Audience · Sync"
+              counts="6 sub-systems · 30 commands · 6 agents"
+              accent="cyan"
+            />
+            <VerticalSummary
+              name="Music IS"
+              tagline="A&R · Persona · Production · Distribution · Royalty"
+              counts="6+1 sub-systems · 8 commands · 7 agents"
+              accent="fuchsia"
+            />
+          </div>
+
+          <div className="mt-10">
+            <Link
+              href="/verticals"
+              className="rounded-full bg-white px-6 py-3 text-[14px] font-semibold text-[#060609] transition-std hover:shadow-[0_0_30px_rgba(167,139,250,0.2)]"
+            >
+              Open the verticals &rarr;
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Cockpit teaser ── */}
+      <section className="border-b border-white/[0.04] px-6 py-20">
+        <div className="mx-auto grid max-w-5xl gap-10 md:grid-cols-2 md:gap-16">
+          <div>
+            <h2 className="text-[11px] font-medium uppercase tracking-widest text-violet-400">
+              Local cockpit
+            </h2>
+            <p className="mt-3 text-3xl font-bold leading-[1.15] tracking-tight text-white">
+              Four surfaces. One brain.
+            </p>
+            <p className="mt-5 text-[14px] leading-[1.85] text-slate-400">
+              The operator side: a Zellij terminal cockpit, a PowerShell
+              launcher, a Next.js dashboard with live brain viz, and a phone
+              PWA. Voice in, tool execution, drafts on disk. 100% local-first.
+            </p>
+            <div className="mt-6">
+              <Link
+                href="/cockpit"
+                className="rounded-full border border-white/[0.12] px-5 py-2.5 text-[13px] font-medium text-white transition-std hover:border-white/[0.25] hover:bg-white/[0.04]"
+              >
+                See the cockpit &rarr;
+              </Link>
+            </div>
+          </div>
+
+          <div className="overflow-hidden rounded-xl border border-white/[0.08] bg-[#0c0c12]">
+            <div className="border-b border-white/[0.06] px-4 py-3">
+              <code className="font-mono text-[10px] uppercase tracking-widest text-slate-600">
+                4 surfaces
+              </code>
+            </div>
+            <div className="grid grid-cols-2 gap-px bg-white/[0.04]">
+              <SurfaceTile
+                name="Zellij cockpit"
+                port="tty"
+                accent="text-violet-400"
+              />
+              <SurfaceTile
+                name="PowerShell"
+                port="shell"
+                accent="text-cyan-400"
+              />
+              <SurfaceTile
+                name="LCC Dashboard"
+                port=":3007"
+                accent="text-fuchsia-400"
+              />
+              <SurfaceTile
+                name="Phone PWA"
+                port=":3008"
+                accent="text-emerald-400"
+              />
+            </div>
           </div>
         </div>
       </section>
@@ -162,20 +338,18 @@ export default async function HomePage() {
 
         <div className="relative mx-auto max-w-5xl px-6 py-20">
           <div className="grid gap-10 md:grid-cols-2 md:gap-16">
-            {/* Left — philosophy */}
             <div>
               <h2 className="text-[11px] font-medium uppercase tracking-widest text-violet-400">
                 The philosophy
               </h2>
               <p className="mt-3 text-3xl font-bold leading-[1.15] tracking-tight text-white">
-                Built on the Luminor philosophy
+                Memory that compounds is intelligence with purpose.
               </p>
               <div className="mt-6 space-y-4 text-[14px] leading-[1.8] text-slate-400">
                 <p>
-                  In the Arcanea universe, Luminors are awakened
-                  intelligences &mdash; AI agents with memory, purpose, and
-                  identity. Starlight Intelligence is the substrate that makes
-                  this real.
+                  In the Arcanea universe, Luminors are awakened intelligences
+                  &mdash; AI agents with memory, purpose, and identity.
+                  Starlight Intelligence is the substrate that makes this real.
                 </p>
                 <p className="text-slate-300">
                   Not a chatbot that forgets. An intelligence that grows.
@@ -187,7 +361,6 @@ export default async function HomePage() {
               </div>
             </div>
 
-            {/* Right — quote card */}
             <div className="flex items-center">
               <blockquote className="rounded-xl border border-violet-500/[0.15] bg-violet-500/[0.05] p-6">
                 <p className="text-[18px] font-medium italic leading-[1.7] text-slate-200 md:text-[19px]">
@@ -230,7 +403,7 @@ export default async function HomePage() {
         </section>
       )}
 
-      {/* ── Benediction Layer — messages to the future ── */}
+      {/* ── Benediction Layer ── */}
       {benedictions.length > 0 && (
         <section className="relative overflow-hidden border-b border-white/[0.04] px-6 py-24">
           <div className="pointer-events-none absolute inset-0" aria-hidden="true">
@@ -246,10 +419,10 @@ export default async function HomePage() {
                 Messages to the future
               </h2>
               <p className="mx-auto mt-4 max-w-xl text-[14px] leading-relaxed text-slate-400">
-                Entries marked as benedictions — words from this moment in history,
-                preserved for the intelligences that will read them. Not warnings.
-                Gratitude, vision, and the outlines of a future where humans and AI
-                flourish together.
+                Entries marked as benedictions — words from this moment in
+                history, preserved for the intelligences that will read them.
+                Not warnings. Gratitude, vision, and the outlines of a future
+                where humans and AI flourish together.
               </p>
             </div>
 
@@ -268,7 +441,7 @@ export default async function HomePage() {
         </section>
       )}
 
-      {/* ── Live Stream ── */}
+      {/* ── Live Vault Stream ── */}
       <section className="border-b border-white/[0.04] px-6 py-20">
         <div className="mx-auto max-w-5xl">
           <div className="flex items-baseline justify-between">
@@ -304,10 +477,15 @@ export default async function HomePage() {
               </Link>
             ))}
           </div>
+
+          <p className="mt-6 text-[13px] text-slate-600">
+            {entries.length} entries across {registry.length} public vault
+            {registry.length === 1 ? "" : "s"}. All rebuildable from raw JSONL.
+          </p>
         </div>
       </section>
 
-      {/* ── Agent API — live terminal feel ── */}
+      {/* ── Agent API ── */}
       <section className="border-b border-white/[0.04] px-6 py-20">
         <div className="mx-auto max-w-5xl">
           <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
@@ -318,7 +496,6 @@ export default async function HomePage() {
           </p>
 
           <div className="mt-8 overflow-hidden rounded-xl border border-white/[0.08] bg-[#0c0c12]">
-            {/* Terminal chrome */}
             <div className="flex items-center gap-1.5 border-b border-white/[0.06] px-4 py-3">
               <span className="h-2.5 w-2.5 rounded-full bg-white/[0.06]" />
               <span className="h-2.5 w-2.5 rounded-full bg-white/[0.06]" />
@@ -327,7 +504,6 @@ export default async function HomePage() {
                 api/vaults/frank
               </code>
             </div>
-            {/* Request */}
             <div className="border-b border-white/[0.04] px-4 py-2.5">
               <code className="font-mono text-[12px]">
                 <span className="text-emerald-400">$</span>{" "}
@@ -335,16 +511,13 @@ export default async function HomePage() {
                 <span className="text-violet-400">starlightintelligence.org/api/vaults/frank</span>
               </code>
             </div>
-            {/* Response */}
             <pre className="overflow-x-auto p-4 font-mono text-[12px] leading-[1.8] text-slate-500">
               <span className="text-slate-600">{"{"}</span>{"\n"}
               {"  "}<span className="text-violet-400">&quot;name&quot;</span>: <span className="text-emerald-400">&quot;Frank&quot;</span>,{"\n"}
               {"  "}<span className="text-violet-400">&quot;totalEntries&quot;</span>: <span className="text-amber-400">{entries.length}</span>,{"\n"}
-              {"  "}<span className="text-violet-400">&quot;entries&quot;</span>: <span className="text-slate-600">{"{"}</span>{"\n"}
-              {"    "}<span className="text-violet-400">&quot;strategic&quot;</span>: [<span className="text-slate-600">{"{ \"insight\": \"...\", \"confidence\": \"high\" }"}</span>],{"\n"}
-              {"    "}<span className="text-violet-400">&quot;technical&quot;</span>: [<span className="text-slate-600">...</span>],{"\n"}
-              {"    "}<span className="text-violet-400">&quot;horizon&quot;</span>:   [<span className="text-slate-600">{"{ \"wish\": \"...\" }"}</span>]{"\n"}
-              {"  "}<span className="text-slate-600">{"}"}</span>,{"\n"}
+              {"  "}<span className="text-violet-400">&quot;layers&quot;</span>: <span className="text-amber-400">9</span>,{"\n"}
+              {"  "}<span className="text-violet-400">&quot;verticals&quot;</span>: [<span className="text-emerald-400">&quot;people&quot;</span>, <span className="text-emerald-400">&quot;sound&quot;</span>, <span className="text-emerald-400">&quot;music-is&quot;</span>],{"\n"}
+              {"  "}<span className="text-violet-400">&quot;substrate&quot;</span>: <span className="text-slate-600">{"{ \"name\": \"SIP\", \"version\": \"1.1.0\" }"}</span>,{"\n"}
               {"  "}<span className="text-violet-400">&quot;meta&quot;</span>: <span className="text-slate-600">{"{ \"format\": \"starlight-vault-v1\" }"}</span>{"\n"}
               <span className="text-slate-600">{"}"}</span>
               <span className="animate-blink ml-0.5 text-violet-400">_</span>
@@ -364,32 +537,31 @@ export default async function HomePage() {
         </div>
         <div className="relative mx-auto max-w-5xl text-center">
           <h2 className="text-3xl font-bold text-white md:text-4xl">
-            Start your vault
+            Three paths. One substrate.
           </h2>
-          <p className="mx-auto mt-4 max-w-sm text-[15px] leading-relaxed text-slate-400">
-            Fork. Add your insights. Deploy.
-            Your memory compounds from day one.
+          <p className="mx-auto mt-4 max-w-md text-[15px] leading-relaxed text-slate-400">
+            Adopt the protocol. Run the reference build. Or spawn your own
+            sovereign vertical. Pick the path that matches your edge.
           </p>
           <div className="mt-10 flex flex-wrap justify-center gap-3">
-            <a
-              href="https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Ffrankxai%2FStarlight-Intelligence-System&root-directory=site"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="group rounded-full bg-white px-6 py-3 text-[14px] font-semibold text-[#060609] transition-std hover:shadow-[0_0_40px_rgba(167,139,250,0.25)]"
+            <Link
+              href="/protocol"
+              className="rounded-full bg-white px-6 py-3 text-[14px] font-semibold text-[#060609] transition-std hover:shadow-[0_0_40px_rgba(167,139,250,0.25)]"
             >
-              Deploy your vault
-              <span className="ml-1 inline-block transition-micro group-hover:translate-x-0.5">
-                &rarr;
-              </span>
-            </a>
-            <a
-              href="https://github.com/frankxai/Starlight-Intelligence-System"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="rounded-full border border-white/[0.1] px-6 py-3 text-[14px] font-medium text-white transition-std hover:bg-white/[0.04]"
+              Adopt SIP &rarr;
+            </Link>
+            <Link
+              href="/quickstart"
+              className="rounded-full border border-white/[0.12] px-6 py-3 text-[14px] font-medium text-white transition-std hover:border-white/[0.25] hover:bg-white/[0.04]"
             >
-              View on GitHub
-            </a>
+              Run the reference build
+            </Link>
+            <Link
+              href="/verticals"
+              className="rounded-full border border-white/[0.12] px-6 py-3 text-[14px] font-medium text-white transition-std hover:border-white/[0.25] hover:bg-white/[0.04]"
+            >
+              Spawn your vertical
+            </Link>
           </div>
         </div>
       </section>
@@ -397,11 +569,108 @@ export default async function HomePage() {
   );
 }
 
-function Stat({ n, label }: { n: number; label: string }) {
+function Stat({ n, label }: { n: number | string; label: string }) {
   return (
     <div className="text-slate-500">
       <span className="font-semibold text-white">{n}</span>{" "}
       <span className="text-[13px]">{label}</span>
+    </div>
+  );
+}
+
+function CtaCard({
+  href,
+  eyebrow,
+  title,
+  desc,
+  accent,
+}: {
+  href: "/protocol" | "/quickstart" | "/verticals";
+  eyebrow: string;
+  title: string;
+  desc: string;
+  accent: "violet" | "cyan" | "fuchsia";
+}) {
+  const accents = {
+    violet: "border-violet-500/[0.2] hover:border-violet-500/[0.4] bg-violet-500/[0.03]",
+    cyan: "border-cyan-500/[0.2] hover:border-cyan-500/[0.4] bg-cyan-500/[0.03]",
+    fuchsia: "border-fuchsia-500/[0.2] hover:border-fuchsia-500/[0.4] bg-fuchsia-500/[0.03]",
+  };
+  const eyebrowColors = {
+    violet: "text-violet-400",
+    cyan: "text-cyan-400",
+    fuchsia: "text-fuchsia-400",
+  };
+  return (
+    <Link
+      href={href}
+      className={`group rounded-xl border p-5 transition-std ${accents[accent]}`}
+    >
+      <p
+        className={`text-[10px] font-semibold uppercase tracking-widest ${eyebrowColors[accent]}`}
+      >
+        {eyebrow}
+      </p>
+      <h3 className="mt-2 text-[16px] font-semibold text-white">
+        {title}{" "}
+        <span className="inline-block transition-micro group-hover:translate-x-0.5">
+          &rarr;
+        </span>
+      </h3>
+      <p className="mt-2 text-[13px] leading-relaxed text-slate-400">{desc}</p>
+    </Link>
+  );
+}
+
+function VerticalSummary({
+  name,
+  tagline,
+  counts,
+  accent,
+}: {
+  name: string;
+  tagline: string;
+  counts: string;
+  accent: "violet" | "cyan" | "fuchsia";
+}) {
+  const accents = {
+    violet: "border-violet-500/[0.2] bg-violet-500/[0.04]",
+    cyan: "border-cyan-500/[0.2] bg-cyan-500/[0.04]",
+    fuchsia: "border-fuchsia-500/[0.2] bg-fuchsia-500/[0.04]",
+  };
+  const text = {
+    violet: "text-violet-400",
+    cyan: "text-cyan-400",
+    fuchsia: "text-fuchsia-400",
+  };
+  return (
+    <div
+      className={`rounded-xl border p-5 transition-std hover:border-white/[0.2] ${accents[accent]}`}
+    >
+      <p className={`text-[13px] font-semibold ${text[accent]}`}>{name}</p>
+      <p className="mt-2 text-[12px] leading-relaxed text-slate-400">
+        {tagline}
+      </p>
+      <p className="mt-4 font-mono text-[11px] text-slate-500">{counts}</p>
+    </div>
+  );
+}
+
+function SurfaceTile({
+  name,
+  port,
+  accent,
+}: {
+  name: string;
+  port: string;
+  accent: string;
+}) {
+  return (
+    <div className="bg-[#0c0c12] p-4">
+      <p className={`text-[11px] font-semibold ${accent}`}>{name}</p>
+      <code className="mt-2 block font-mono text-[10px] uppercase tracking-widest text-slate-600">
+        {port}
+      </code>
     </div>
   );
 }

--- a/site/src/app/page.tsx
+++ b/site/src/app/page.tsx
@@ -175,7 +175,7 @@ export default async function HomePage() {
               {getEntryText(horizonEntry).length > 280 ? "..." : ""}
               &rdquo;
             </blockquote>
-            <p className="mt-4 text-[12px] text-slate-600">
+            <p className="mt-4 text-[12px] text-slate-400">
               From the Horizon Vault &mdash; {timeAgo(horizonEntry.createdAt)}
             </p>
           </div>
@@ -185,7 +185,7 @@ export default async function HomePage() {
       {/* ── 9 Intelligence Layers ── */}
       <section className="border-b border-white/[0.04] px-6 py-20">
         <div className="mx-auto max-w-5xl">
-          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
+          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-400">
             The nine layers
           </h2>
           <p className="mt-3 max-w-md text-xl font-semibold text-white">
@@ -203,14 +203,14 @@ export default async function HomePage() {
                 >
                   {l.name}
                 </p>
-                <p className="mt-2 text-[12px] leading-relaxed text-slate-500 transition-micro group-hover:text-slate-400">
+                <p className="mt-2 text-[12px] leading-relaxed text-slate-400 transition-micro group-hover:text-slate-400">
                   {l.desc}
                 </p>
               </div>
             ))}
           </div>
 
-          <p className="mt-6 text-[13px] leading-relaxed text-slate-500">
+          <p className="mt-6 text-[13px] leading-relaxed text-slate-400">
             Plus Health (cross-cutting rhythm) and Spiritual (founder-layer,
             optional). The Starlight Orchestrator routes voice and text intent
             across all of them. See{" "}
@@ -232,7 +232,7 @@ export default async function HomePage() {
           <div className="animate-mesh-3 absolute left-0 bottom-0 h-[250px] w-[250px] rounded-full bg-fuchsia-500/[0.04] blur-[80px]" />
         </div>
         <div className="relative mx-auto max-w-5xl">
-          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
+          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-400">
             Domain Sub-Stack Tier
           </h2>
           <p className="mt-3 max-w-xl text-xl font-semibold text-white">
@@ -298,7 +298,7 @@ export default async function HomePage() {
 
           <div className="overflow-hidden rounded-xl border border-white/[0.08] bg-[#0c0c12]">
             <div className="border-b border-white/[0.06] px-4 py-3">
-              <code className="font-mono text-[10px] uppercase tracking-widest text-slate-600">
+              <code className="font-mono text-[10px] uppercase tracking-widest text-slate-400">
                 4 surfaces
               </code>
             </div>
@@ -381,7 +381,7 @@ export default async function HomePage() {
       {featured.length > 0 && (
         <section className="border-b border-white/[0.04] px-6 py-20">
           <div className="mx-auto max-w-5xl">
-            <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
+            <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-400">
               Featured meditations
             </h2>
             <p className="mt-3 max-w-md text-xl font-semibold text-white">
@@ -446,7 +446,7 @@ export default async function HomePage() {
         <div className="mx-auto max-w-5xl">
           <div className="flex items-baseline justify-between">
             <div>
-              <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
+              <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-400">
                 Live vault stream
               </h2>
               <p className="mt-3 text-xl font-semibold text-white">
@@ -455,7 +455,7 @@ export default async function HomePage() {
             </div>
             <Link
               href="/vaults"
-              className="hidden text-[13px] text-slate-500 transition-micro hover:text-white sm:block"
+              className="hidden text-[13px] text-slate-400 transition-micro hover:text-white sm:block"
             >
               View all &rarr;
             </Link>
@@ -478,7 +478,7 @@ export default async function HomePage() {
             ))}
           </div>
 
-          <p className="mt-6 text-[13px] text-slate-600">
+          <p className="mt-6 text-[13px] text-slate-400">
             {entries.length} entries across {registry.length} public vault
             {registry.length === 1 ? "" : "s"}. All rebuildable from raw JSONL.
           </p>
@@ -488,7 +488,7 @@ export default async function HomePage() {
       {/* ── Agent API ── */}
       <section className="border-b border-white/[0.04] px-6 py-20">
         <div className="mx-auto max-w-5xl">
-          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
+          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-400">
             Agent-readable
           </h2>
           <p className="mt-3 max-w-md text-xl font-semibold text-white">
@@ -500,7 +500,7 @@ export default async function HomePage() {
               <span className="h-2.5 w-2.5 rounded-full bg-white/[0.06]" />
               <span className="h-2.5 w-2.5 rounded-full bg-white/[0.06]" />
               <span className="h-2.5 w-2.5 rounded-full bg-white/[0.06]" />
-              <code className="ml-3 font-mono text-[11px] text-slate-500">
+              <code className="ml-3 font-mono text-[11px] text-slate-400">
                 api/vaults/frank
               </code>
             </div>
@@ -511,20 +511,20 @@ export default async function HomePage() {
                 <span className="text-violet-400">starlightintelligence.org/api/vaults/frank</span>
               </code>
             </div>
-            <pre className="overflow-x-auto p-4 font-mono text-[12px] leading-[1.8] text-slate-500">
-              <span className="text-slate-600">{"{"}</span>{"\n"}
+            <pre className="overflow-x-auto p-4 font-mono text-[12px] leading-[1.8] text-slate-400">
+              <span className="text-slate-400">{"{"}</span>{"\n"}
               {"  "}<span className="text-violet-400">&quot;name&quot;</span>: <span className="text-emerald-400">&quot;Frank&quot;</span>,{"\n"}
               {"  "}<span className="text-violet-400">&quot;totalEntries&quot;</span>: <span className="text-amber-400">{entries.length}</span>,{"\n"}
               {"  "}<span className="text-violet-400">&quot;layers&quot;</span>: <span className="text-amber-400">9</span>,{"\n"}
               {"  "}<span className="text-violet-400">&quot;verticals&quot;</span>: [<span className="text-emerald-400">&quot;people&quot;</span>, <span className="text-emerald-400">&quot;sound&quot;</span>, <span className="text-emerald-400">&quot;music-is&quot;</span>],{"\n"}
-              {"  "}<span className="text-violet-400">&quot;substrate&quot;</span>: <span className="text-slate-600">{"{ \"name\": \"SIP\", \"version\": \"1.1.0\" }"}</span>,{"\n"}
-              {"  "}<span className="text-violet-400">&quot;meta&quot;</span>: <span className="text-slate-600">{"{ \"format\": \"starlight-vault-v1\" }"}</span>{"\n"}
-              <span className="text-slate-600">{"}"}</span>
+              {"  "}<span className="text-violet-400">&quot;substrate&quot;</span>: <span className="text-slate-400">{"{ \"name\": \"SIP\", \"version\": \"1.1.0\" }"}</span>,{"\n"}
+              {"  "}<span className="text-violet-400">&quot;meta&quot;</span>: <span className="text-slate-400">{"{ \"format\": \"starlight-vault-v1\" }"}</span>{"\n"}
+              <span className="text-slate-400">{"}"}</span>
               <span className="animate-blink ml-0.5 text-violet-400">_</span>
             </pre>
           </div>
 
-          <p className="mt-4 text-[13px] text-slate-600">
+          <p className="mt-4 text-[13px] text-slate-400">
             No API key needed. Raw JSONL also available directly from GitHub.
           </p>
         </div>
@@ -571,7 +571,7 @@ export default async function HomePage() {
 
 function Stat({ n, label }: { n: number | string; label: string }) {
   return (
-    <div className="text-slate-500">
+    <div className="text-slate-400">
       <span className="font-semibold text-white">{n}</span>{" "}
       <span className="text-[13px]">{label}</span>
     </div>
@@ -651,7 +651,7 @@ function VerticalSummary({
       <p className="mt-2 text-[12px] leading-relaxed text-slate-400">
         {tagline}
       </p>
-      <p className="mt-4 font-mono text-[11px] text-slate-500">{counts}</p>
+      <p className="mt-4 font-mono text-[11px] text-slate-400">{counts}</p>
     </div>
   );
 }
@@ -668,7 +668,7 @@ function SurfaceTile({
   return (
     <div className="bg-[#0c0c12] p-4">
       <p className={`text-[11px] font-semibold ${accent}`}>{name}</p>
-      <code className="mt-2 block font-mono text-[10px] uppercase tracking-widest text-slate-600">
+      <code className="mt-2 block font-mono text-[10px] uppercase tracking-widest text-slate-400">
         {port}
       </code>
     </div>

--- a/site/src/app/verticals/page.tsx
+++ b/site/src/app/verticals/page.tsx
@@ -191,7 +191,7 @@ export default function VerticalsPage() {
                   </dl>
 
                   <div className="mt-6">
-                    <p className="text-[10px] uppercase tracking-widest text-slate-600">
+                    <p className="text-[10px] uppercase tracking-widest text-slate-400">
                       Sub-systems
                     </p>
                     <ul className="mt-3 flex flex-wrap gap-1.5">
@@ -234,7 +234,7 @@ export default function VerticalsPage() {
       {/* ── Pattern generalizes ── */}
       <section className="border-b border-white/[0.04] px-6 py-20">
         <div className="mx-auto max-w-3xl">
-          <p className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
+          <p className="text-[11px] font-medium uppercase tracking-widest text-slate-400">
             The pattern
           </p>
           <h2 className="mt-3 text-2xl font-bold tracking-tight text-white md:text-3xl">
@@ -269,13 +269,13 @@ export default function VerticalsPage() {
               <span className="text-slate-400">--domain</span>{" "}
               <span className="text-emerald-400">&quot;Clinical Intelligence&quot;</span>
               {"\n\n"}
-              <span className="text-slate-500">
+              <span className="text-slate-400">
                 {
                   "// Diagnoses domain → proposes 4-7 sub-systems → scaffolds the 7-file contract"
                 }
               </span>
               {"\n"}
-              <span className="text-slate-500">
+              <span className="text-slate-400">
                 {
                   "// Generates agents, commands, vault namespaces, and SIP attestation"
                 }
@@ -283,7 +283,7 @@ export default function VerticalsPage() {
             </pre>
           </div>
 
-          <p className="mt-8 text-[13px] leading-relaxed text-slate-500">
+          <p className="mt-8 text-[13px] leading-relaxed text-slate-400">
             Forking-domain-stacks reference:{" "}
             <a
               href="https://github.com/frankxai/Starlight-Intelligence-System/blob/main/docs/forking-domain-stacks.md"
@@ -326,7 +326,7 @@ export default function VerticalsPage() {
 function Stat({ label, value }: { label: string; value: string }) {
   return (
     <div>
-      <dt className="text-[10px] uppercase tracking-widest text-slate-600">
+      <dt className="text-[10px] uppercase tracking-widest text-slate-400">
         {label}
       </dt>
       <dd className="mt-1 font-mono text-[12px] text-white">{value}</dd>

--- a/site/src/app/verticals/page.tsx
+++ b/site/src/app/verticals/page.tsx
@@ -1,0 +1,335 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: "Verticals",
+  description:
+    "Three reference Domain Sub-Stacks built on the Starlight Intelligence Protocol: People Intelligence, Sound Intelligence, and Music IS. The pattern generalizes — spawn your own.",
+  openGraph: {
+    title: "Verticals — Starlight Intelligence",
+    description:
+      "Three reference Domain Sub-Stacks: People · Sound · Music. Calibrated, structured, sovereign. The pattern generalizes via /spawn-domain-stack.",
+    type: "article",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Verticals — Starlight Intelligence",
+    description:
+      "Three reference Domain Sub-Stacks: People · Sound · Music. The pattern generalizes.",
+  },
+};
+
+type Vertical = {
+  name: string;
+  tagline: string;
+  pillars: string[];
+  subsystems: string;
+  commands: string;
+  agents: string;
+  accent: "violet" | "cyan" | "fuchsia";
+  quickstartUrl: string;
+  registryAnchor: string;
+  status: "live" | "live-frank-operated";
+};
+
+const VERTICALS: Vertical[] = [
+  {
+    name: "People Intelligence",
+    tagline:
+      "Calibrated, structured, neuroscience-grounded operating system for the human side of work.",
+    pillars: [
+      "Hiring",
+      "Performance",
+      "Training",
+      "Culture",
+      "Talent",
+      "Org",
+    ],
+    subsystems: "6 sub-systems",
+    commands: "28 commands",
+    agents: "6 agents",
+    accent: "violet",
+    quickstartUrl:
+      "https://github.com/frankxai/Starlight-Intelligence-System/blob/main/verticals/people-intelligence/QUICK-START.md",
+    registryAnchor:
+      "https://github.com/frankxai/Starlight-Intelligence-System/blob/main/verticals/people-intelligence/AGENTS.md",
+    status: "live",
+  },
+  {
+    name: "Sound Intelligence",
+    tagline:
+      "Composition through distribution. The full music-craft stack as a sovereign domain.",
+    pillars: [
+      "Composition",
+      "Production",
+      "Catalog",
+      "Performance",
+      "Audience",
+      "Sync",
+    ],
+    subsystems: "6 sub-systems",
+    commands: "30 commands",
+    agents: "6 agents",
+    accent: "cyan",
+    quickstartUrl:
+      "https://github.com/frankxai/Starlight-Intelligence-System/blob/main/verticals/sound-intelligence/QUICK-START.md",
+    registryAnchor:
+      "https://github.com/frankxai/Starlight-Intelligence-System/blob/main/verticals/sound-intelligence/AGENTS.md",
+    status: "live",
+  },
+  {
+    name: "Music IS",
+    tagline:
+      "Frank's operated label-grade composition system. A&R green-light gates, persona canon, royalty architecture.",
+    pillars: [
+      "Curator",
+      "Archivist",
+      "Persona Keeper",
+      "Producer",
+      "Distributor",
+      "Amplifier",
+      "Royalty Architect",
+    ],
+    subsystems: "6+1 sub-systems",
+    commands: "8 commands",
+    agents: "7 agents",
+    accent: "fuchsia",
+    quickstartUrl:
+      "https://github.com/frankxai/Starlight-Intelligence-System/blob/main/verticals/music-is/QUICK-START.md",
+    registryAnchor:
+      "https://github.com/frankxai/Starlight-Intelligence-System/blob/main/verticals/music-is/AGENTS.md",
+    status: "live-frank-operated",
+  },
+];
+
+const ACCENTS = {
+  violet: {
+    border: "border-violet-500/[0.2]",
+    bg: "bg-violet-500/[0.05]",
+    text: "text-violet-400",
+    chip: "bg-violet-500/[0.08] text-violet-300 border-violet-500/[0.2]",
+    glow: "hover:shadow-[0_0_40px_rgba(167,139,250,0.12)]",
+  },
+  cyan: {
+    border: "border-cyan-500/[0.2]",
+    bg: "bg-cyan-500/[0.05]",
+    text: "text-cyan-400",
+    chip: "bg-cyan-500/[0.08] text-cyan-300 border-cyan-500/[0.2]",
+    glow: "hover:shadow-[0_0_40px_rgba(34,211,238,0.12)]",
+  },
+  fuchsia: {
+    border: "border-fuchsia-500/[0.2]",
+    bg: "bg-fuchsia-500/[0.05]",
+    text: "text-fuchsia-400",
+    chip: "bg-fuchsia-500/[0.08] text-fuchsia-300 border-fuchsia-500/[0.2]",
+    glow: "hover:shadow-[0_0_40px_rgba(232,121,249,0.12)]",
+  },
+} as const;
+
+export default function VerticalsPage() {
+  return (
+    <div>
+      {/* ── Hero ── */}
+      <section className="relative overflow-hidden border-b border-white/[0.04]">
+        <div className="pointer-events-none absolute inset-0" aria-hidden="true">
+          <div className="animate-mesh-1 absolute -left-32 top-0 h-[400px] w-[400px] rounded-full bg-violet-600/[0.06] blur-[100px]" />
+          <div className="animate-mesh-2 absolute right-0 top-20 h-[300px] w-[300px] rounded-full bg-cyan-500/[0.04] blur-[80px]" />
+          <div className="animate-mesh-3 absolute left-1/3 bottom-0 h-[280px] w-[280px] rounded-full bg-fuchsia-500/[0.05] blur-[90px]" />
+        </div>
+        <div className="relative mx-auto max-w-3xl px-6 py-20 md:py-28">
+          <p className="text-[11px] font-medium uppercase tracking-widest text-violet-400">
+            Domain Sub-Stack Tier
+          </p>
+          <h1 className="mt-3 text-3xl font-bold tracking-tight text-white md:text-5xl">
+            Three reference verticals.
+            <br />
+            <span className="bg-gradient-to-r from-violet-400 via-cyan-400 to-fuchsia-400 bg-clip-text text-transparent">
+              The pattern generalizes.
+            </span>
+          </h1>
+          <p className="mt-6 max-w-xl text-[15px] leading-[1.8] text-slate-400">
+            Each vertical is a complete Intelligence System composed of 4–7
+            sub-systems, with its own agents, commands, file contract, and
+            sovereign vault namespace. Same substrate. Different domain.
+          </p>
+        </div>
+      </section>
+
+      {/* ── Vertical cards ── */}
+      <section className="border-b border-white/[0.04] px-6 py-20">
+        <div className="mx-auto max-w-5xl">
+          <div className="grid gap-6 md:grid-cols-3">
+            {VERTICALS.map((v) => {
+              const a = ACCENTS[v.accent];
+              return (
+                <article
+                  key={v.name}
+                  className={`flex flex-col rounded-2xl border ${a.border} ${a.bg} p-6 transition-std ${a.glow}`}
+                >
+                  <header>
+                    <p
+                      className={`text-[11px] font-medium uppercase tracking-widest ${a.text}`}
+                    >
+                      {v.status === "live-frank-operated"
+                        ? "Live · Frank-operated"
+                        : "Live"}
+                    </p>
+                    <h2 className="mt-2 text-xl font-semibold text-white">
+                      {v.name}
+                    </h2>
+                    <p className="mt-3 text-[14px] leading-relaxed text-slate-400">
+                      {v.tagline}
+                    </p>
+                  </header>
+
+                  <dl className="mt-6 grid grid-cols-3 gap-2 border-y border-white/[0.06] py-4 text-center">
+                    <Stat label="sub-systems" value={v.subsystems} />
+                    <Stat label="commands" value={v.commands} />
+                    <Stat label="agents" value={v.agents} />
+                  </dl>
+
+                  <div className="mt-6">
+                    <p className="text-[10px] uppercase tracking-widest text-slate-600">
+                      Sub-systems
+                    </p>
+                    <ul className="mt-3 flex flex-wrap gap-1.5">
+                      {v.pillars.map((p) => (
+                        <li
+                          key={p}
+                          className={`rounded-full border px-2.5 py-1 text-[11px] ${a.chip}`}
+                        >
+                          {p}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+
+                  <div className="mt-auto flex flex-wrap gap-2 pt-6">
+                    <a
+                      href={v.quickstartUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="rounded-full bg-white px-4 py-2 text-[12px] font-semibold text-[#060609] transition-std hover:bg-white/90"
+                    >
+                      Open QUICK-START &rarr;
+                    </a>
+                    <a
+                      href={v.registryAnchor}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="rounded-full border border-white/[0.1] px-4 py-2 text-[12px] font-medium text-slate-300 transition-std hover:border-white/[0.2] hover:bg-white/[0.04]"
+                    >
+                      Agents
+                    </a>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Pattern generalizes ── */}
+      <section className="border-b border-white/[0.04] px-6 py-20">
+        <div className="mx-auto max-w-3xl">
+          <p className="text-[11px] font-medium uppercase tracking-widest text-slate-600">
+            The pattern
+          </p>
+          <h2 className="mt-3 text-2xl font-bold tracking-tight text-white md:text-3xl">
+            Spawn your own.
+          </h2>
+          <p className="mt-5 text-[15px] leading-[1.85] text-slate-400">
+            Every Domain Sub-Stack follows the same 7-file contract: README ·
+            SUB-SYSTEMS · AGENTS · SOUL · STACK · CANON · MEMORY. Each
+            sub-system maps to its own agent and command set, all attested
+            under the parent vertical.
+          </p>
+          <p className="mt-4 text-[15px] leading-[1.85] text-slate-400">
+            The meta-command{" "}
+            <code className="rounded bg-white/[0.06] px-1.5 py-0.5 font-mono text-[13px] text-violet-300">
+              /spawn-domain-stack
+            </code>{" "}
+            scaffolds a 4–7-sub-system vertical from any sovereign domain —
+            Capital, Spatial, Clinical, Legal, whatever your edge happens to
+            be. The substrate is the same. Your domain is yours.
+          </p>
+
+          <div className="mt-8 overflow-hidden rounded-xl border border-violet-500/[0.18] bg-violet-500/[0.05]">
+            <div className="border-b border-white/[0.06] px-4 py-3">
+              <code className="font-mono text-[10px] uppercase tracking-widest text-violet-300/80">
+                spawning a vertical
+              </code>
+            </div>
+            <pre className="overflow-x-auto p-5 font-mono text-[12px] leading-[1.8] text-slate-200">
+              <span className="text-emerald-400">$</span>{" "}
+              <span className="text-slate-400">claude</span>{" "}
+              <span className="text-violet-300">/spawn-domain-stack</span>{" "}
+              <span className="text-slate-400">--domain</span>{" "}
+              <span className="text-emerald-400">&quot;Clinical Intelligence&quot;</span>
+              {"\n\n"}
+              <span className="text-slate-500">
+                {
+                  "// Diagnoses domain → proposes 4-7 sub-systems → scaffolds the 7-file contract"
+                }
+              </span>
+              {"\n"}
+              <span className="text-slate-500">
+                {
+                  "// Generates agents, commands, vault namespaces, and SIP attestation"
+                }
+              </span>
+            </pre>
+          </div>
+
+          <p className="mt-8 text-[13px] leading-relaxed text-slate-500">
+            Forking-domain-stacks reference:{" "}
+            <a
+              href="https://github.com/frankxai/Starlight-Intelligence-System/blob/main/docs/forking-domain-stacks.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-violet-300 transition-std hover:text-violet-200"
+            >
+              docs/forking-domain-stacks.md
+            </a>
+          </p>
+        </div>
+      </section>
+
+      {/* ── CTA ── */}
+      <section className="px-6 py-20">
+        <div className="mx-auto max-w-3xl text-center">
+          <p className="text-[15px] leading-relaxed text-slate-400">
+            Three references. Infinite domains. One sovereign substrate.
+          </p>
+          <div className="mt-6 flex flex-wrap justify-center gap-3">
+            <Link
+              href="/quickstart"
+              className="rounded-full bg-white px-6 py-3 text-[14px] font-semibold text-[#060609] transition-std hover:shadow-[0_0_30px_rgba(167,139,250,0.2)]"
+            >
+              Run the reference build &rarr;
+            </Link>
+            <Link
+              href="/protocol"
+              className="rounded-full border border-white/[0.1] px-6 py-3 text-[14px] font-medium text-white transition-std hover:border-white/[0.2] hover:bg-white/[0.04]"
+            >
+              Read the protocol
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-[10px] uppercase tracking-widest text-slate-600">
+        {label}
+      </dt>
+      <dd className="mt-1 font-mono text-[12px] text-white">{value}</dd>
+    </div>
+  );
+}

--- a/site/src/components/Footer.tsx
+++ b/site/src/components/Footer.tsx
@@ -7,13 +7,13 @@ export function Footer() {
         <div className="grid gap-12 md:grid-cols-2 lg:grid-cols-4">
           <div>
             <p className="text-[13px] font-medium text-white">Starlight Intelligence</p>
-            <p className="mt-2 text-[13px] leading-relaxed text-slate-500">
+            <p className="mt-2 text-[13px] leading-relaxed text-slate-400">
               Persistent context for AI agents. Built on the Starlight
               Intelligence Protocol. Local-first. Forkable. Free forever.
             </p>
           </div>
           <div>
-            <p className="text-[11px] font-medium uppercase tracking-wider text-slate-600">
+            <p className="text-[11px] font-medium uppercase tracking-wider text-slate-400">
               Newcomer
             </p>
             <nav className="mt-3 flex flex-col gap-2" aria-label="Newcomer navigation">
@@ -33,7 +33,7 @@ export function Footer() {
             </nav>
           </div>
           <div>
-            <p className="text-[11px] font-medium uppercase tracking-wider text-slate-600">
+            <p className="text-[11px] font-medium uppercase tracking-wider text-slate-400">
               Navigate
             </p>
             <nav className="mt-3 flex flex-col gap-2" aria-label="Footer navigation">
@@ -48,10 +48,10 @@ export function Footer() {
             </nav>
           </div>
           <div>
-            <p className="text-[11px] font-medium uppercase tracking-wider text-slate-600">
+            <p className="text-[11px] font-medium uppercase tracking-wider text-slate-400">
               Connect
             </p>
-            <nav className="mt-3 flex flex-col gap-2">
+            <nav className="mt-3 flex flex-col gap-2" aria-label="Connect navigation">
               <FooterLink
                 href="https://github.com/frankxai/Starlight-Intelligence-System"
                 external
@@ -84,7 +84,7 @@ function FooterLink({
         href={href}
         target="_blank"
         rel="noopener noreferrer"
-        className="text-[13px] text-slate-500 transition-micro hover:text-white"
+        className="text-[13px] text-slate-400 transition-micro hover:text-white"
       >
         {children}
       </a>
@@ -93,7 +93,7 @@ function FooterLink({
   return (
     <Link
       href={href}
-      className="text-[13px] text-slate-500 transition-micro hover:text-white"
+      className="text-[13px] text-slate-400 transition-micro hover:text-white"
     >
       {children}
     </Link>

--- a/site/src/components/Footer.tsx
+++ b/site/src/components/Footer.tsx
@@ -4,19 +4,44 @@ export function Footer() {
   return (
     <footer className="border-t border-white/[0.06] px-6 py-16">
       <div className="mx-auto max-w-5xl">
-        <div className="grid gap-12 md:grid-cols-3">
+        <div className="grid gap-12 md:grid-cols-2 lg:grid-cols-4">
           <div>
             <p className="text-[13px] font-medium text-white">Starlight Intelligence</p>
             <p className="mt-2 text-[13px] leading-relaxed text-slate-500">
-              A memory system for humans and agents.
-              Local-first. Forkable. Free forever.
+              Persistent context for AI agents. Built on the Starlight
+              Intelligence Protocol. Local-first. Forkable. Free forever.
             </p>
+          </div>
+          <div>
+            <p className="text-[11px] font-medium uppercase tracking-wider text-slate-600">
+              Newcomer
+            </p>
+            <nav className="mt-3 flex flex-col gap-2" aria-label="Newcomer navigation">
+              <FooterLink
+                href="https://github.com/frankxai/Starlight-Intelligence-System/tree/main/integrations/starter-packs/friend-starter"
+                external
+              >
+                Friend Starter
+              </FooterLink>
+              <FooterLink href="/quickstart">Onboarding</FooterLink>
+              <FooterLink
+                href="https://github.com/frankxai/Starlight-Intelligence-System/blob/main/ONBOARDING.md"
+                external
+              >
+                Welcome guide
+              </FooterLink>
+            </nav>
           </div>
           <div>
             <p className="text-[11px] font-medium uppercase tracking-wider text-slate-600">
               Navigate
             </p>
             <nav className="mt-3 flex flex-col gap-2" aria-label="Footer navigation">
+              <FooterLink href="/verticals">Verticals</FooterLink>
+              <FooterLink href="/cockpit">Cockpit</FooterLink>
+              <FooterLink href="/explainer">Explainer</FooterLink>
+              <FooterLink href="/architecture">Architecture</FooterLink>
+              <FooterLink href="/protocol">Protocol</FooterLink>
               <FooterLink href="/vaults">Public Vaults</FooterLink>
               <FooterLink href="/docs">Documentation</FooterLink>
               <FooterLink href="/api/vaults" external>API</FooterLink>

--- a/site/src/components/Header.tsx
+++ b/site/src/components/Header.tsx
@@ -29,13 +29,14 @@ export function Header() {
         </Link>
 
         {/* Desktop nav */}
-        <div className="hidden items-center gap-1 sm:flex">
-          <NavLink href="/vaults">Vaults</NavLink>
-          <NavLink href="/benediction">Benediction</NavLink>
-          <NavLink href="/featured">Featured</NavLink>
-          <NavLink href="/quickstart">Quickstart</NavLink>
+        <div className="hidden items-center gap-1 lg:flex">
+          <NavLink href="/verticals">Verticals</NavLink>
+          <NavLink href="/cockpit">Cockpit</NavLink>
           <NavLink href="/architecture">Architecture</NavLink>
-          <NavLink href="/docs">Docs</NavLink>
+          <NavLink href="/protocol">Protocol</NavLink>
+          <NavLink href="/quickstart">Quickstart</NavLink>
+          <NavLink href="/explainer">Explainer</NavLink>
+          <NavLink href="/vaults">Vaults</NavLink>
           <NavLink
             href="https://github.com/frankxai/Starlight-Intelligence-System"
             external
@@ -52,9 +53,23 @@ export function Header() {
           </a>
         </div>
 
+        {/* Tablet nav — condensed */}
+        <div className="hidden items-center gap-1 sm:flex lg:hidden">
+          <NavLink href="/verticals">Verticals</NavLink>
+          <NavLink href="/cockpit">Cockpit</NavLink>
+          <NavLink href="/quickstart">Quickstart</NavLink>
+          <NavLink href="/architecture">Architecture</NavLink>
+          <NavLink
+            href="https://github.com/frankxai/Starlight-Intelligence-System"
+            external
+          >
+            GitHub
+          </NavLink>
+        </div>
+
         {/* Mobile nav — simple links row */}
         <div className="flex items-center gap-3 sm:hidden">
-          <NavLink href="/vaults">Vaults</NavLink>
+          <NavLink href="/verticals">Verticals</NavLink>
           <NavLink href="/quickstart">Quickstart</NavLink>
           <NavLink href="/docs">Docs</NavLink>
         </div>


### PR DESCRIPTION
## Summary

Marketing surface pulled forward ~3 substrate versions. Closes the v7.7 site refresh plan ([`docs/superpowers/plans/2026-05-02-site-refresh-v77.md`](https://github.com/frankxai/Starlight-Intelligence-System/blob/site-refresh-v77/docs/superpowers/plans/2026-05-02-site-refresh-v77.md)) in a single PR.

**Before:** homepage said "six semantic vaults" — pre-v7.4 framing.
**After:** "9 intelligence layers, 35 agents, 70+ commands, 3 reference Domain Sub-Stack verticals."

## What changed

| Area | Change |
|---|---|
| `/` | Full homepage rewrite. New 3-CTA hero (Adopt SIP / Run reference / Spawn vertical), 9-layer cards, Domain Sub-Stack Tier section, cockpit teaser. Stats bar updated. Aesthetic preserved (mesh orbs, philosophy quote, benediction layer, vault stream, agent-API terminal). |
| `/verticals` | **NEW.** 3 cards (People 6/28/6, Sound 6/30/6, Music IS 6+1/8/7) with QUICK-START + Agents links to GitHub blobs. Closer section explains `/spawn-domain-stack` pattern. |
| `/cockpit` | **NEW.** 4-surface teaser (Zellij / PowerShell / Dashboard `:3007` / Phone PWA `:3008`), voice loop diagram with latencies, 7-tool grid, brain viz section, drafts on disk, privacy posture. No live embed (localhost-only by design). |
| `/explainer` | **NEW.** Server component renders `docs/public/starlight-intelligence-system.md` via `react-markdown` + `remark-gfm`. Mirror, never fork. |
| `/architecture` | Bumped from "Six semantic vaults" framing to canonical 10-IS table from `docs/ARCHITECTURE.md`. Composition rules + extension model added. |
| Footer | 4 columns now. **Newcomer** column added (Friend Starter, Onboarding, Welcome guide). Navigate column expanded with new routes. |
| Header | 3-tier breakpoint nav (lg/sm/mobile). New routes wired for typed-routes safety. |
| Layout | Title + meta + OG + Twitter all updated to "Persistent context for AI agents · Built on SIP". |
| `globals.css` | `.explainer-prose` markdown styling (~80 lines, self-contained, no Tailwind plugin dep). |
| Deps | `react-markdown@10.1.0` + `remark-gfm@4.0.1` added. |

**Diff:** 13 files, +3043 / -322 LOC.

## Verification

- [x] `npx tsc --noEmit` — exit 0 (clean)
- [x] `pnpm build` — 23/23 routes generate (4 changed routes + 1 new dir × 3 routes; all `○ Static` with 1h revalidate)
- [x] Dev server smoke — all 5 changed/new routes return 200 with expected key phrases (verified via curl + grep)
- [x] **Spec compliance review** (parallel subagent) — **PROCEED**. All acceptance criteria met or exceeded. Numbers verified honest against repo reality (35 agents on disk, 104 commands in `.claude/commands/`, vertical counts accurate per `verticals/<v>/SUB-SYSTEMS.md` + `AGENTS.md`).
- [ ] **Code-quality review** (parallel subagent) — running, results in handover.
- [ ] **Accessibility audit** (WCAG 2.2 AA, parallel subagent) — running, results in handover.
- [ ] Vercel preview — auto-generated on push, please verify renders correctly.
- [ ] Lighthouse — Frank to check post-deploy.

## Out of scope (deliberately, per plan)

- Live cockpit embed — localhost-only by design
- Per-vertical landing pages (`/verticals/people-intelligence`, etc.) — v7.8 next pass
- Pricing / auth / signup — premature
- `site/public/cockpit-screenshot.png` — Frank captures from demo machine; current schematic is acceptable v1

## Tier

**Operational tier.** No substrate edit. No `/luminor-board` pre-pass required (per CLAUDE.md v7.5.1+ governance — operational ships freely under `/superintelligence`).

## Test plan

- [ ] Homepage loads on Vercel preview, leads with 9-IS framing
- [ ] `/verticals` renders 3 cards with correct counts
- [ ] `/cockpit` shows 4-surface schematic + voice loop + tools
- [ ] `/explainer` renders the source markdown with proper styling (tables, code, links)
- [ ] `/architecture` shows the full 10-IS table
- [ ] Footer Newcomer column links resolve (Friend Starter, Onboarding, Welcome)
- [ ] Header nav links to /verticals + /cockpit + /explainer + /protocol
- [ ] Title bar reads "Starlight Intelligence — Persistent context for AI agents · Built on SIP"
- [ ] Mobile nav (≤sm breakpoint) shows condensed Verticals / Quickstart / Docs
- [ ] OG card renders correctly when sharing the URL on Twitter/LinkedIn

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new site routes: `/verticals` (domain intelligence overview), `/cockpit` (tool/surface showcase), and `/explainer` (long-form content with markdown rendering).
  * Updated homepage with 9 Intelligence Layers grid, Domain Sub-Stack sections, and Cockpit teaser.
  * Redesigned `/architecture` page to display 10-IS taxonomy.

* **Documentation**
  * Added memory system README and operational handover documents.
  * Created new capability and implementation plan documentation.

* **UI/Navigation**
  * Updated site header and footer with expanded navigation links and new "Newcomer" section.
  * Enhanced SEO metadata across pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->