### PR TITLE
fix(site): /explainer markdown actually renders on Vercel (prebuild sync)

### DIFF
--- a/site/.gitignore
+++ b/site/.gitignore
@@ -36,6 +36,9 @@ yarn-error.log*
 # vercel
 .vercel
 
+# auto-synced from docs/public/ at build time via scripts/sync-explainer.mjs
+content/explainer.md
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts

--- a/site/package.json
+++ b/site/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "sync-explainer": "node scripts/sync-explainer.mjs",
+    "predev": "node scripts/sync-explainer.mjs",
+    "prebuild": "node scripts/sync-explainer.mjs",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",

--- a/site/scripts/sync-explainer.mjs
+++ b/site/scripts/sync-explainer.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+// Built on SIP — copies docs/public/starlight-intelligence-system.md into
+// site/content/explainer.md at build time so the /explainer route can read
+// from a path that exists in the Vercel serverless function root
+// (process.cwd() resolves to site/, repo-relative paths don't survive).
+
+import { copyFileSync, existsSync, mkdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const siteRoot = resolve(here, "..");
+const repoRoot = resolve(siteRoot, "..");
+
+const src = join(repoRoot, "docs", "public", "starlight-intelligence-system.md");
+const dstDir = join(siteRoot, "content");
+const dst = join(dstDir, "explainer.md");
+
+if (!existsSync(src)) {
+  console.error(`[sync-explainer] source missing: ${src}`);
+  process.exit(1);
+}
+
+if (!existsSync(dstDir)) {
+  mkdirSync(dstDir, { recursive: true });
+}
+
+copyFileSync(src, dst);
+console.log(`[sync-explainer] copied ${src} -> ${dst}`);

--- a/site/src/app/explainer/page.tsx
+++ b/site/src/app/explainer/page.tsx
@@ -30,15 +30,11 @@ const EXPLAINER_FALLBACK = `Explainer source temporarily unavailable.
 Read it on GitHub instead: [docs/public/starlight-intelligence-system.md](https://github.com/frankxai/Starlight-Intelligence-System/blob/main/docs/public/starlight-intelligence-system.md).`;
 
 function loadExplainerSource(): string {
-  // process.cwd() resolves to site/ on Vercel and locally; ../docs/public is repo-relative.
-  // If the source is ever moved or the build invoked from a different cwd, fall back gracefully.
-  const path = join(
-    process.cwd(),
-    "..",
-    "docs",
-    "public",
-    "starlight-intelligence-system.md"
-  );
+  // The prebuild script (scripts/sync-explainer.mjs) copies the source markdown
+  // from docs/public/ into site/content/explainer.md so the file lives inside
+  // the Next.js function root and survives Vercel's serverless packaging.
+  // process.cwd() resolves to site/ on both Vercel and local builds.
+  const path = join(process.cwd(), "content", "explainer.md");
   let raw: string;
   try {
     raw = readFileSync(path, "utf-8");


### PR DESCRIPTION
## Summary

v7.7 fast-follow. Production `/explainer` was hitting the try/catch fallback ("Explainer source temporarily unavailable") because `process.cwd()` at request time on Vercel resolves to the function root, not the repo root — so `../docs/public/starlight-intelligence-system.md` never existed at runtime.

This was the exact failure mode the code-quality reviewer flagged in PR #5 (Important #1). Fixing it before users see the degraded page.

## Fix

Prebuild script copies the source markdown from `docs/public/` into `site/content/` at build time. The file lives inside the Next.js function root and survives Vercel's serverless packaging. Single source of truth remains `docs/public/`.

## Changes

- `site/scripts/sync-explainer.mjs` — Node copy script (29 LOC, no deps)
- `site/package.json` — `predev` + `prebuild` scripts wire the sync into `pnpm dev` / `pnpm build`
- `site/src/app/explainer/page.tsx` — reads from `process.cwd()/content/explainer.md` instead of repo-relative
- `site/content/.gitkeep` — directory placeholder
- `site/.gitignore` — exclude auto-synced `content/explainer.md` (prebuild always refreshes; never commit a potentially stale copy)

## Verification

- `pnpm build` clean
- Static-rendered HTML at `.next/server/app/explainer.html` contains "Phase 1 — Welcome" and "Phase 5 — Compound" — full markdown body present
- No "temporarily unavailable" fallback text in the build output

## Test plan

- [ ] Vercel preview / production renders `/explainer` with full long-form (5 phases, 9-layer vision, How to start, etc.)
- [ ] No "Explainer source temporarily unavailable" text on the rendered page
- [ ] `pnpm dev` locally also resolves correctly (predev script runs the sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)