### PR TITLE
fix(site): commit content/explainer.md so Vercel can read it (v7.7.2)

### DIFF
--- a/site/.gitignore
+++ b/site/.gitignore
@@ -36,9 +36,6 @@ yarn-error.log*
 # vercel
 .vercel
 
-# auto-synced from docs/public/ at build time via scripts/sync-explainer.mjs
-content/explainer.md
-
 # typescript
 *.tsbuildinfo
 next-env.d.ts

--- a/site/content/explainer.md
+++ b/site/content/explainer.md
@@ -1,0 +1,175 @@
+# Starlight Intelligence System
+
+> **You already have the genius. It's just scattered across ten files you never opened together.**
+
+This is for people who've spent fifteen years building expertise across multiple companies, frameworks, decks, Canva exports, Drive folders, half-finished Notion projects, and screenshots they swear they'll organize "next weekend." You're not missing intelligence. You're missing architecture.
+
+Starlight Intelligence System (SIS) finds your genius inside the mess you already have, sorts every activity in your work into four buckets (keep, delegate, automate, kill), helps you organize the mess into a second brain you actually own, and then lets you compound — a trained executor, a content pipeline, a business layer — one layer at a time. You keep everything. You can leave anytime. The only thing we ask back is attribution.
+
+Freedom through architecture, not grind.
+
+---
+
+## Who this is for
+
+**The indispensable professional.** Fifteen years of expertise across multiple companies. Psychologist turned leadership consultant. Ex-HR turned solopreneur. Designer turned strategist. You've built the same coaching framework four times — once for each client engagement, each time from scratch, because you can never find last year's version. Your material lives in three hundred Canva templates, four Google Drive accounts (personal, two old companies, the consulting one), a Notion you started in 2022 and abandoned in 2023, and screenshots on your phone. You're good at what you do. You're also the only one who can do anything. You want to hand off the operational work, reclaim your own frameworks, and build something that's actually yours — instead of waking up at 6am to deliver another workshop you've already delivered twelve times.
+
+**The creator with a body of work.** You have an audience. You have output. What you don't have is a system. Every piece of content starts from a blank page even though you've written something structurally similar forty times before. You love the work and you're burning out on it at the same time. You don't want someone to ghostwrite over your voice — you want something that preserves it, learns it, and gives you leverage without flattening you into a content machine.
+
+If either vignette lands, read on. SIS was designed with people like you in the room.
+
+---
+
+## How it works — the journey
+
+Five phases. You don't have to commit to all of them. You just have to start.
+
+### Phase 1 — Welcome + Intake (10 minutes)
+
+No form. No quiz. You open a conversation with Starlight and tell it, in one paragraph, what's going on: what you do, what's scattered, what you want to build. The intake routes you to one of four paths — stamped artifact, vertical spawn, alliance forge, or sovereign spawn — and explains which one fits before you commit to it. Most first-time adopters land on vertical spawn or stamped artifact. That's fine. The point of intake is to prevent you from building the wrong thing.
+
+### Phase 2 — Genius Discovery (1-2 sessions, ~90 minutes total)
+
+This is the one that surprises people.
+
+You drag in three to five sources of your scattered material. A Canva export folder. A Google Drive subtree. A local directory. A Notion page export. Twenty screenshots. Whatever you have. SIS's Genius agent reads across all of it and produces two documents:
+
+**Your Genius Profile.** The frameworks you keep rebuilding without realizing it. Your distinctive vocabulary — the words you use that nobody else in your field uses quite that way. Your cross-domain synthesis edge — where your psychology background meets your ops instinct meets your aesthetic taste. Voice samples. The shape of your actual thinking, extracted from your own work.
+
+**Your Freedom Path.** Every recurring activity in your work, sorted into four buckets: **KEEP** (only you can do this), **DELEGATE** (anyone trained properly can do this), **AUTOMATE** (a workflow or an AI can do this), **KILL** (stop doing this; it was never worth the time).
+
+The frame matters here: this is empirical, not oracular. SIS doesn't tell you what your genius is. It shows you what has been there all along, scattered across your corpus, and lets you recognize it. The documents are yours the moment they exist. You can edit them, fork them, feed them back in. They're markdown files on your machine — not an insight sitting in someone else's database.
+
+### Phase 3 — Knowledge Reclamation (3-hour session)
+
+Once the Genius Profile exists, you run `/reclaim-knowledge` against the same sources. SIS produces a Reclamation Map — a folder tree organized by **function** (frameworks, client deliverables, thinking-in-progress, voice samples, reference material, etc.), not by where the file happens to live today.
+
+The map includes explicit drag-and-drop instructions. "Move `Canva > Coaching Frameworks > 2023 Client Intake` to `~/genius/frameworks/intake-structures/v1-2023-client.canva`." You execute. In one focused session, years of material move into a coherent architecture. The thinking is already done; your job is to drag.
+
+At the end of the session, you have a second brain. Yours. Structured by how you actually work, not by which tool you happened to use in which year.
+
+### Phase 4 — Choose your next layer
+
+With Genius Profile + Freedom Path + reclaimed second brain in hand, one of the next layers becomes the highest-leverage move. You don't have to guess — the Freedom Path makes it obvious.
+
+- **Train an executor.** If your DELEGATE bucket is full of work you've been avoiding hiring for because "it would take longer to explain than to do it," `/train-executor` generates a full handover playbook. SOPs in your voice. A training curriculum (Observe → Shadow → Autonomous). Automated flagging of outdated material as the executor learns the current version.
+- **Build a creator pipeline.** If you want to build a content business aligned with your actual expertise, `/creator-pipeline` turns your frameworks into a twelve-week content calendar across text, audio, image, video, and podcast. Every piece in your voice. Every piece attestation-stamped. Every piece compounds the body of work.
+- **Architect your business layer.** Accounting, taxes, legal entity, revenue modeling. (Business IS ships month 2.)
+- **Define vision + brand.** If the genius is clear but the public face isn't yet — positioning, narrative architecture, visual identity. (Vision / Brand IS ships month 2.)
+
+Each layer is an **Intelligence System** — your own. You own it. You take it anywhere. No platform lock-in, ever.
+
+### Phase 5 — Compound
+
+Every artifact you ship carries a "Built on SIP" attestation. This is not a badge you earn. It's an ambient mark the system writes for you automatically when a real composition happens. A blog post, a deck, a track, a product brief, a book chapter — the attestation rides along, pins which substrate version you used, names which canon you composed with, and logs the ship.
+
+As your ledger grows, your work compounds into a visible body of sovereign practice. Not a subscription. Not a vendor lock-in. A public trail of real compositions under your own name.
+
+---
+
+## What's different from "just using ChatGPT"
+
+Four differences. Specific, not rhetorical.
+
+- **Memory that's yours, not a chat log.** Your Genius Profile, your frameworks, your voice samples live in structured markdown files on your filesystem. You can take them anywhere — Cursor, ChatGPT Projects, Gemini Gems, a new tool that doesn't exist yet. No vendor owns your second brain. You do.
+- **Architecture, not chat.** SIS isn't a chatbot with a clever system prompt. It's a nine-layer operating system for your intellectual life: Genius → Second Brain → Vision / Brand → Business → Creator → Wealth → Health → Relational → Spiritual. Each layer is its own Intelligence System. You pick which ones you need. You compose them in the order that serves you.
+- **Sovereignty as a feature.** Your work is your work. No platform tax, no ownership claim, no data lock-in. Attribution via "Built on SIP" is the only compounding mechanism — and you can leave any time. Exit is always available. Attribution history stays immutable because attestation is how the substrate compounds, not how it traps you.
+- **Voice preservation.** Every output is in your voice, not generic AI voice. The system fingerprints how you uniquely say things — your cadence, your vocabulary, the structural moves you make — and refuses to ghostwrite over it. The Genius Profile is the anchor. If a draft drifts away from your voice, the system flags it before you ship.
+
+---
+
+## How to start
+
+Three paths. Pick the one that matches how you work.
+
+### Path 1 — Claude Desktop + Cowork (non-technical, recommended for first-timers)
+
+1. Install Claude Desktop.
+2. Create a new Claude Project.
+3. Download the SIS starter pack (hosted as a .zip — link from the site tab).
+4. Import into your Project — four clicks: New Project → Knowledge → Upload → Done.
+5. Start chatting. Say "/welcome" or just describe what's scattered. Starlight takes it from there.
+
+**Time:** 15 minutes to set up. 90 minutes for your first Genius Profile.
+
+### Path 2 — Claude Code, Cursor, or Gemini CLI (builder path)
+
+Fork the main repo. Drop in the platform adapter (`.claude/`, `.cursorrules`, or `GEMINI.md` — all shipped). Run the commands directly. Full substrate access, full MCP server, 10 vault tools, every slash command including the ones not yet exported to workspace tools.
+
+This is for builders who want their own instance of the reference implementation. Clone, wire, go. Frank runs the same thing daily.
+
+### Path 3 — Let Frank run your first session
+
+Book a pilot session. Frank runs `/intake` + `/discover-genius` with you live, walks you through the reclamation, produces the Profile + Freedom Path artifacts, and hands them over. You leave the session owning your own intelligence system foundation. No ongoing engagement required — you take what you've built and keep going on your own.
+
+Limited availability. Application-based. Link from the site tab.
+
+---
+
+## The nine-layer vision
+
+You don't need all nine to start. You need one — Genius — working. The rest compounds when the time is right.
+
+| Layer | Purpose | Status |
+|---|---|---|
+| 1. Genius IS | What only you uniquely see | Alpha (v7.4 shipping) |
+| 2. Second Brain IS | Knowledge architecture | Alpha |
+| 3. Vision / Brand IS | Why + how + design | Month 2 |
+| 4. Business IS | Accounting, taxes, entity, revenue | Month 2-3 |
+| 5. Creator IS | Content pipeline, multi-modal | Alpha |
+| 6. Wealth / Freedom IS | Compounding capital + time | Month 3 |
+| 7. Health IS | Body is the substrate | Month 2 |
+| 8. Relational IS | Network + alliance architecture | Month 3 |
+| 9. Spiritual IS *(optional)* | Meaning layer | Always optional |
+
+Spiritual IS is explicitly optional and never imposed. Founder-layer practice stays at the founder layer. Your substrate, your practices.
+
+---
+
+## What it costs — what we ask
+
+SIS is not a product with a price sheet. The substrate is free. What we ask in return is reciprocity, not payment.
+
+- **Attribution.** Cross-party artifacts carry "Built on SIP." Silent composition — using SIP elements without the block — is a breach of trust, not a legal issue, and we treat it accordingly.
+- **Sovereignty clause.** Your work is yours. You can leave anytime. Your vaults stay on your machine. Attribution history remains immutable because it's how the whole protocol compounds.
+- **Optional: feed learnings back.** If SIS helps you, help the protocol evolve. Pressure-test it via Luminor Board sessions. Submit substrate contributions. Or just write about what worked. Abundance attracts abundance; transactional filters itself out.
+
+**Paid tier (limited):** Frank runs pilot sessions and custom advisory. No pricing list — terms are artifact-shaped (named deliverables by named dates), not hour-shaped. Frank's time is the bottleneck, not substrate capacity. Contact via the site tab if you want to explore.
+
+---
+
+## For builders
+
+If you're technical and want the architecture view:
+
+- **Protocol:** SIP v1.1.0 — six layers: file contract (SKILL.md, AGENTS.md, MEMORY.md, CANON.md, SOUL.md, STACK.md, `.claude/commands/`), attestation protocol, MCP registry standard, command taxonomy, sovereignty clause, optional archetype extension.
+- **Stack:** Markdown + JSONL vaults + TypeScript MCP server (`@arcanea/starlight-intelligence-system`) + Claude Code commands as reference implementation. Zero runtime deps outside `better-sqlite3`.
+- **Runtime coverage:** Claude Code (first-class), Cursor, Codex, Gemini CLI, Cline, Antigravity, OpenCode. Workspace exports (v7.4) for Claude Projects, ChatGPT Projects, Gemini Gems, Cowork. Modality attestation (v7.5) for Suno, Udio, Imagen, Midjourney, ElevenLabs.
+- **Test harness:** 35 substrate conformance assertions + 19 v7.3 newcomer-surface assertions. Reference build runs clean.
+- **License:** MIT for substrate spec + reference commands + operational layer. CC-BY-NC for Arcanea canon if you compose with it.
+- **Repo:** [`github.com/frankxai/Starlight-Intelligence-System`](https://github.com/frankxai/Starlight-Intelligence-System). Protocol spec: [`starlightintelligence.org/protocol`](https://starlightintelligence.org/protocol).
+
+Full integration map: see `docs/ecosystem-integration.md` in the repo. Full newcomer surface: `ONBOARDING.md` + `DELIVERY.md`.
+
+---
+
+## Close
+
+Sovereignty isn't a brand. It's an architecture. Nine layers, yours, compounding. Start with one: your genius.
+
+You already have it. Let's organize it.
+
+**Start with Path 1 (Claude Desktop + the starter pack). 15 minutes to set up. 90 minutes to your first Genius Profile. You keep everything.**
+
+---
+
+**Built on SIP** — Starlight Intelligence Protocol
+
+Substrate: starlightintelligence.org/protocol v1.1.0
+Layers used: [file-contract, attestation, commands, sovereignty]
+
+Verticals:
+- starlight-intelligence-system@v7.3 · public explainer surface
+
+Generated: 2026-04-24
+Attestation is compounding, not credit transfer: every composition strengthens every node.

--- a/site/scripts/sync-explainer.mjs
+++ b/site/scripts/sync-explainer.mjs
@@ -16,13 +16,24 @@ const src = join(repoRoot, "docs", "public", "starlight-intelligence-system.md")
 const dstDir = join(siteRoot, "content");
 const dst = join(dstDir, "explainer.md");
 
-if (!existsSync(src)) {
-  console.error(`[sync-explainer] source missing: ${src}`);
-  process.exit(1);
-}
-
 if (!existsSync(dstDir)) {
   mkdirSync(dstDir, { recursive: true });
+}
+
+if (!existsSync(src)) {
+  // Vercel only mounts site/ as project root — the docs/ source isn't reachable
+  // there. The committed site/content/explainer.md is used as-is. Locally the
+  // sync runs and refreshes the copy. Both paths produce a renderable file.
+  if (existsSync(dst)) {
+    console.log(
+      `[sync-explainer] source not reachable at ${src} — using committed copy at ${dst}`
+    );
+    process.exit(0);
+  }
+  console.error(
+    `[sync-explainer] source missing at ${src} AND no committed copy at ${dst}`
+  );
+  process.exit(1);
 }
 
 copyFileSync(src, dst);


### PR DESCRIPTION
Fast-follow on PR #6. Vercel only mounts site/ as the project root, so the prebuild script's repo-relative copy of docs/public/...md fails. Solution: commit site/content/explainer.md as the source-of-truth for Vercel; sync script becomes fail-soft and refreshes the copy locally. Trade-off filed as v7.8 follow-up.