### PR TITLE
feat(site): v7.8 per-vertical landing pages + ACCENTS extraction + a11y polish

### DIFF
--- a/site/src/app/cockpit/page.tsx
+++ b/site/src/app/cockpit/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { ACCENT_TEXT, ACCENT_BORDER } from "@/lib/accents";
 
 export const revalidate = 3600;
 
@@ -337,19 +338,13 @@ export default function CockpitPage() {
   );
 }
 
-const ACCENTS = {
-  violet: { text: "text-violet-400", border: "border-violet-500/[0.2]" },
-  cyan: { text: "text-cyan-400", border: "border-cyan-500/[0.2]" },
-  fuchsia: { text: "text-fuchsia-400", border: "border-fuchsia-500/[0.2]" },
-  emerald: { text: "text-emerald-400", border: "border-emerald-500/[0.2]" },
-} as const;
-
 function SurfaceCell({ surface }: { surface: Surface }) {
-  const a = ACCENTS[surface.accent];
   return (
     <div className="bg-[#0c0c12] p-5">
       <div className="flex items-center justify-between">
-        <p className={`text-[12px] font-semibold ${a.text}`}>{surface.name}</p>
+        <p className={`text-[12px] font-semibold ${ACCENT_TEXT[surface.accent]}`}>
+          {surface.name}
+        </p>
         <code className="font-mono text-[10px] uppercase tracking-widest text-slate-400">
           {surface.port}
         </code>
@@ -372,12 +367,13 @@ function Stage({
   detail: string;
   accent: "violet" | "cyan" | "fuchsia";
 }) {
-  const a = ACCENTS[accent];
   return (
     <div
-      className={`flex-1 rounded-xl border ${a.border} bg-white/[0.02] p-5 text-center`}
+      className={`flex-1 rounded-xl border ${ACCENT_BORDER[accent]} bg-white/[0.02] p-5 text-center`}
     >
-      <p className={`font-mono text-[10px] uppercase tracking-widest ${a.text}`}>
+      <p
+        className={`font-mono text-[10px] uppercase tracking-widest ${ACCENT_TEXT[accent]}`}
+      >
         {n} · {label}
       </p>
       <p className="mt-2 text-[12px] leading-relaxed text-slate-400">{detail}</p>

--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -53,8 +53,16 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${inter.variable} ${jbMono.variable}`}>
       <body className="flex min-h-dvh flex-col bg-[#060609] font-sans text-slate-200 antialiased">
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[100] focus:rounded-md focus:bg-white focus:px-4 focus:py-2 focus:text-[13px] focus:font-semibold focus:text-[#060609]"
+        >
+          Skip to content
+        </a>
         <Header />
-        <main className="flex-1">{children}</main>
+        <main id="main-content" className="flex-1">
+          {children}
+        </main>
         <Footer />
       </body>
     </html>

--- a/site/src/app/page.tsx
+++ b/site/src/app/page.tsx
@@ -8,6 +8,11 @@ import {
   timeAgo,
 } from "@/lib/vault";
 import { EntryCard } from "@/components/EntryCard";
+import {
+  ACCENT_TEXT,
+  ACCENT_BORDER,
+  ACCENT_BG_SOFT,
+} from "@/lib/accents";
 
 export const revalidate = 3600;
 
@@ -65,23 +70,7 @@ const LAYERS: LayerCard[] = [
   },
 ];
 
-const ACCENT_BG: Record<LayerCard["accent"], string> = {
-  violet: "border-violet-500/[0.18] bg-violet-500/[0.04]",
-  cyan: "border-cyan-500/[0.18] bg-cyan-500/[0.04]",
-  fuchsia: "border-fuchsia-500/[0.18] bg-fuchsia-500/[0.04]",
-  emerald: "border-emerald-500/[0.18] bg-emerald-500/[0.04]",
-  amber: "border-amber-500/[0.18] bg-amber-500/[0.04]",
-  rose: "border-rose-500/[0.18] bg-rose-500/[0.04]",
-};
-
-const ACCENT_TEXT: Record<LayerCard["accent"], string> = {
-  violet: "text-violet-400",
-  cyan: "text-cyan-400",
-  fuchsia: "text-fuchsia-400",
-  emerald: "text-emerald-400",
-  amber: "text-amber-400",
-  rose: "text-rose-400",
-};
+// Accents come from @/lib/accents — see ACCENT_TEXT, ACCENT_BORDER, ACCENT_BG_SOFT.
 
 export default async function HomePage() {
   const [entries, registry, featured, benedictions] = await Promise.all([
@@ -196,7 +185,7 @@ export default async function HomePage() {
             {LAYERS.map((l) => (
               <div
                 key={l.name}
-                className={`group rounded-xl border p-5 transition-std hover:border-white/[0.2] ${ACCENT_BG[l.accent]}`}
+                className={`group rounded-xl border p-5 transition-std hover:border-white/[0.2] ${ACCENT_BORDER[l.accent]} ${ACCENT_BG_SOFT[l.accent]}`}
               >
                 <p
                   className={`text-[13px] font-semibold ${ACCENT_TEXT[l.accent]}`}
@@ -633,21 +622,11 @@ function VerticalSummary({
   counts: string;
   accent: "violet" | "cyan" | "fuchsia";
 }) {
-  const accents = {
-    violet: "border-violet-500/[0.2] bg-violet-500/[0.04]",
-    cyan: "border-cyan-500/[0.2] bg-cyan-500/[0.04]",
-    fuchsia: "border-fuchsia-500/[0.2] bg-fuchsia-500/[0.04]",
-  };
-  const text = {
-    violet: "text-violet-400",
-    cyan: "text-cyan-400",
-    fuchsia: "text-fuchsia-400",
-  };
   return (
     <div
-      className={`rounded-xl border p-5 transition-std hover:border-white/[0.2] ${accents[accent]}`}
+      className={`rounded-xl border p-5 transition-std hover:border-white/[0.2] ${ACCENT_BORDER[accent]} ${ACCENT_BG_SOFT[accent]}`}
     >
-      <p className={`text-[13px] font-semibold ${text[accent]}`}>{name}</p>
+      <p className={`text-[13px] font-semibold ${ACCENT_TEXT[accent]}`}>{name}</p>
       <p className="mt-2 text-[12px] leading-relaxed text-slate-400">
         {tagline}
       </p>

--- a/site/src/app/verticals/[slug]/page.tsx
+++ b/site/src/app/verticals/[slug]/page.tsx
@@ -1,0 +1,315 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import {
+  VERTICAL_BY_SLUG,
+  VERTICAL_SLUGS,
+  type Vertical,
+  type VerticalSlug,
+} from "@/lib/verticals";
+import {
+  ACCENT_TEXT,
+  ACCENT_TEXT_LIGHT,
+  ACCENT_BORDER,
+  ACCENT_BG,
+  ACCENT_BG_SOFT,
+  ACCENT_CHIP,
+  ACCENT_GLOW,
+} from "@/lib/accents";
+
+export const revalidate = 3600;
+
+export function generateStaticParams() {
+  return VERTICAL_SLUGS.map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const v = VERTICAL_BY_SLUG[slug as VerticalSlug];
+  if (!v) {
+    return { title: "Vertical not found" };
+  }
+  const title = v.name;
+  const description = v.taglineShort;
+  return {
+    title,
+    description,
+    openGraph: {
+      title: `${title} — Starlight Intelligence`,
+      description,
+      type: "article",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: `${title} — Starlight Intelligence`,
+      description,
+    },
+  };
+}
+
+export default async function VerticalPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const v = VERTICAL_BY_SLUG[slug as VerticalSlug];
+  if (!v) notFound();
+
+  const a = {
+    text: ACCENT_TEXT[v.accent],
+    textLight: ACCENT_TEXT_LIGHT[v.accent],
+    border: ACCENT_BORDER[v.accent],
+    bg: ACCENT_BG[v.accent],
+    bgSoft: ACCENT_BG_SOFT[v.accent],
+    chip: ACCENT_CHIP[v.accent],
+    glow: ACCENT_GLOW[v.accent],
+  };
+
+  return (
+    <div>
+      {/* ── Hero ── */}
+      <section className="relative overflow-hidden border-b border-white/[0.04]">
+        <div className="pointer-events-none absolute inset-0" aria-hidden="true">
+          <div className="animate-mesh-1 absolute -left-32 top-0 h-[400px] w-[400px] rounded-full bg-violet-600/[0.06] blur-[100px]" />
+          <div className="animate-mesh-2 absolute right-0 top-20 h-[300px] w-[300px] rounded-full bg-cyan-500/[0.04] blur-[80px]" />
+          <div className="animate-mesh-3 absolute left-1/3 bottom-0 h-[280px] w-[280px] rounded-full bg-fuchsia-500/[0.05] blur-[90px]" />
+        </div>
+        <div className="relative mx-auto max-w-3xl px-6 py-20 md:py-28">
+          <Link
+            href="/verticals"
+            className="text-[12px] text-slate-400 transition-micro hover:text-white"
+          >
+            <span aria-hidden="true">&larr;</span> All verticals
+          </Link>
+          <div className="mt-4 flex flex-wrap items-center gap-2 text-[11px]">
+            <span
+              className={`rounded-full border px-2.5 py-1 uppercase tracking-widest ${a.chip}`}
+            >
+              {v.status === "live-frank-operated"
+                ? "Live · Frank-operated"
+                : "Live · Reference"}
+            </span>
+            <span className="font-mono text-slate-400">
+              Domain Sub-Stack
+            </span>
+          </div>
+          <h1 className="mt-5 text-3xl font-bold tracking-tight text-white md:text-5xl">
+            {v.name}
+          </h1>
+          <p className="mt-5 max-w-xl text-[15px] leading-[1.85] text-slate-400">
+            {v.taglineShort}
+          </p>
+
+          <blockquote
+            className={`mt-8 rounded-xl border ${a.border} ${a.bg} p-5`}
+          >
+            <p className="text-[16px] italic leading-[1.7] text-slate-200">
+              &ldquo;{v.heroQuote}&rdquo;
+            </p>
+            <footer
+              className={`mt-3 text-[10px] uppercase tracking-widest ${a.text}`}
+            >
+              {v.name} · SOUL.md
+            </footer>
+          </blockquote>
+
+          <dl className="mt-8 grid grid-cols-3 gap-2 border-t border-white/[0.04] pt-6 text-center">
+            <Stat label="sub-systems" value={v.counts.subSystems} />
+            <Stat label="commands" value={v.counts.commands} />
+            <Stat label="agents" value={v.counts.agents} />
+          </dl>
+        </div>
+      </section>
+
+      {/* ── Sub-systems ── */}
+      <section className="border-b border-white/[0.04] px-6 py-20">
+        <div className="mx-auto max-w-5xl">
+          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-400">
+            Sub-systems
+          </h2>
+          <p className="mt-3 max-w-md text-xl font-semibold text-white">
+            {v.subSystems.length} pillars. Each a focused practice with its own
+            command surface.
+          </p>
+
+          <div className="mt-10 grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {v.subSystems.map((s) => (
+              <article
+                key={s.name}
+                className={`rounded-xl border p-5 transition-std hover:border-white/[0.2] ${a.border} ${a.bgSoft}`}
+              >
+                <div className="flex items-baseline justify-between gap-2">
+                  <h3 className={`text-[14px] font-semibold ${a.text}`}>
+                    {s.name}
+                  </h3>
+                  <code className="font-mono text-[11px] text-slate-400">
+                    {s.primaryCommand}
+                  </code>
+                </div>
+                <p className="mt-3 text-[13px] leading-relaxed text-slate-400">
+                  {s.purpose}
+                </p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Agents ── */}
+      <section className="border-b border-white/[0.04] px-6 py-20">
+        <div className="mx-auto max-w-5xl">
+          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-400">
+            Agents
+          </h2>
+          <p className="mt-3 max-w-md text-xl font-semibold text-white">
+            {v.agents.length} named agents. One identity per pillar.
+          </p>
+
+          <div className="mt-10 grid gap-3 md:grid-cols-2">
+            {v.agents.map((agent) => (
+              <article
+                key={agent.name}
+                className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-5 transition-std hover:border-white/[0.12] hover:bg-white/[0.04]"
+              >
+                <code className={`font-mono text-[12px] ${a.textLight}`}>
+                  {agent.name}
+                </code>
+                <p className="mt-2 text-[13px] leading-relaxed text-slate-400">
+                  {agent.role}
+                </p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Quick start ── */}
+      <section className="border-b border-white/[0.04] px-6 py-20">
+        <div className="mx-auto max-w-3xl">
+          <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-400">
+            Quickstart
+          </h2>
+          <p className="mt-3 text-xl font-semibold text-white">
+            Five steps to feel the composition.
+          </p>
+          <ol className="mt-8 space-y-4">
+            {v.quickStartSteps.map((step, i) => (
+              <li
+                key={step}
+                className="flex gap-4 rounded-xl border border-white/[0.06] bg-white/[0.02] p-5"
+              >
+                <span
+                  className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full border font-mono text-[12px] ${a.chip}`}
+                >
+                  {String(i + 1).padStart(2, "0")}
+                </span>
+                <p className="text-[14px] leading-[1.7] text-slate-300">
+                  {step}
+                </p>
+              </li>
+            ))}
+          </ol>
+
+          <div className="mt-8 flex flex-wrap gap-3">
+            <a
+              href={`${v.githubBlobBase}/QUICK-START.md`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-full bg-white px-5 py-2.5 text-[14px] font-semibold text-[#060609] transition-std hover:shadow-[0_0_30px_rgba(167,139,250,0.2)]"
+            >
+              Full QUICK-START on GitHub &rarr;
+            </a>
+            <a
+              href={`${v.githubBlobBase}/AGENTS.md`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-full border border-white/[0.12] px-5 py-2.5 text-[14px] font-medium text-white transition-std hover:border-white/[0.25] hover:bg-white/[0.04]"
+            >
+              AGENTS.md
+            </a>
+            <a
+              href={`${v.githubBlobBase}/SUB-SYSTEMS.md`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-full border border-white/[0.12] px-5 py-2.5 text-[14px] font-medium text-white transition-std hover:border-white/[0.25] hover:bg-white/[0.04]"
+            >
+              SUB-SYSTEMS.md
+            </a>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Refusals ── */}
+      {v.refusals.length > 0 && (
+        <section className="border-b border-white/[0.04] px-6 py-20">
+          <div className="mx-auto max-w-3xl">
+            <h2 className="text-[11px] font-medium uppercase tracking-widest text-rose-400">
+              Refusals
+            </h2>
+            <p className="mt-3 text-xl font-semibold text-white">
+              Patterns this vertical refuses to ship.
+            </p>
+            <p className="mt-3 max-w-xl text-[14px] leading-[1.85] text-slate-400">
+              Sovereignty includes the right to say no. Each vertical names what
+              it will not produce — making the refusal explicit prevents drift
+              into theater.
+            </p>
+            <ul className="mt-8 grid gap-2 sm:grid-cols-2">
+              {v.refusals.map((r) => (
+                <li
+                  key={r}
+                  className="flex items-start gap-3 rounded-lg border border-rose-500/[0.18] bg-rose-500/[0.04] p-3"
+                >
+                  <span
+                    aria-hidden="true"
+                    className="mt-0.5 inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-rose-400/80"
+                  />
+                  <span className="text-[13px] text-slate-300">{r}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+      )}
+
+      {/* ── Closer ── */}
+      <section className="px-6 py-20">
+        <div className="mx-auto max-w-3xl text-center">
+          <p className="text-[15px] leading-relaxed text-slate-400">
+            The pattern generalizes. <code className="rounded bg-white/[0.06] px-1.5 py-0.5 font-mono text-[13px] text-violet-300">/spawn-domain-stack</code> scaffolds a 4–7 sub-system vertical from any sovereign domain.
+          </p>
+          <div className="mt-6 flex flex-wrap justify-center gap-3">
+            <Link
+              href="/verticals"
+              className="rounded-full border border-white/[0.12] px-5 py-2.5 text-[14px] font-medium text-white transition-std hover:border-white/[0.25] hover:bg-white/[0.04]"
+            >
+              All verticals &rarr;
+            </Link>
+            <Link
+              href="/protocol"
+              className="rounded-full border border-white/[0.12] px-5 py-2.5 text-[14px] font-medium text-white transition-std hover:border-white/[0.25] hover:bg-white/[0.04]"
+            >
+              Read the protocol
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-[10px] uppercase tracking-widest text-slate-400">
+        {label}
+      </dt>
+      <dd className="mt-1 font-mono text-[12px] text-white">{value}</dd>
+    </div>
+  );
+}

--- a/site/src/app/verticals/page.tsx
+++ b/site/src/app/verticals/page.tsx
@@ -1,5 +1,13 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { VERTICALS } from "@/lib/verticals";
+import {
+  ACCENT_TEXT,
+  ACCENT_BORDER,
+  ACCENT_BG,
+  ACCENT_CHIP,
+  ACCENT_GLOW,
+} from "@/lib/accents";
 
 export const revalidate = 3600;
 
@@ -20,113 +28,6 @@ export const metadata: Metadata = {
       "Three reference Domain Sub-Stacks: People · Sound · Music. The pattern generalizes.",
   },
 };
-
-type Vertical = {
-  name: string;
-  tagline: string;
-  pillars: string[];
-  subsystems: string;
-  commands: string;
-  agents: string;
-  accent: "violet" | "cyan" | "fuchsia";
-  quickstartUrl: string;
-  registryAnchor: string;
-  status: "live" | "live-frank-operated";
-};
-
-const VERTICALS: Vertical[] = [
-  {
-    name: "People Intelligence",
-    tagline:
-      "Calibrated, structured, neuroscience-grounded operating system for the human side of work.",
-    pillars: [
-      "Hiring",
-      "Performance",
-      "Training",
-      "Culture",
-      "Talent",
-      "Org",
-    ],
-    subsystems: "6 sub-systems",
-    commands: "28 commands",
-    agents: "6 agents",
-    accent: "violet",
-    quickstartUrl:
-      "https://github.com/frankxai/Starlight-Intelligence-System/blob/main/verticals/people-intelligence/QUICK-START.md",
-    registryAnchor:
-      "https://github.com/frankxai/Starlight-Intelligence-System/blob/main/verticals/people-intelligence/AGENTS.md",
-    status: "live",
-  },
-  {
-    name: "Sound Intelligence",
-    tagline:
-      "Composition through distribution. The full music-craft stack as a sovereign domain.",
-    pillars: [
-      "Composition",
-      "Production",
-      "Catalog",
-      "Performance",
-      "Audience",
-      "Sync",
-    ],
-    subsystems: "6 sub-systems",
-    commands: "30 commands",
-    agents: "6 agents",
-    accent: "cyan",
-    quickstartUrl:
-      "https://github.com/frankxai/Starlight-Intelligence-System/blob/main/verticals/sound-intelligence/QUICK-START.md",
-    registryAnchor:
-      "https://github.com/frankxai/Starlight-Intelligence-System/blob/main/verticals/sound-intelligence/AGENTS.md",
-    status: "live",
-  },
-  {
-    name: "Music IS",
-    tagline:
-      "Frank's operated label-grade composition system. A&R green-light gates, persona canon, royalty architecture.",
-    pillars: [
-      "Curator",
-      "Archivist",
-      "Persona Keeper",
-      "Producer",
-      "Distributor",
-      "Amplifier",
-      "Royalty Architect",
-    ],
-    subsystems: "6+1 sub-systems",
-    commands: "8 commands",
-    agents: "7 agents",
-    accent: "fuchsia",
-    quickstartUrl:
-      "https://github.com/frankxai/Starlight-Intelligence-System/blob/main/verticals/music-is/QUICK-START.md",
-    registryAnchor:
-      "https://github.com/frankxai/Starlight-Intelligence-System/blob/main/verticals/music-is/AGENTS.md",
-    status: "live-frank-operated",
-  },
-];
-
-const ACCENTS = {
-  violet: {
-    border: "border-violet-500/[0.2]",
-    bg: "bg-violet-500/[0.05]",
-    text: "text-violet-400",
-    chip: "bg-violet-500/[0.08] text-violet-300 border-violet-500/[0.2]",
-    glow: "hover:shadow-[0_0_40px_rgba(167,139,250,0.12)]",
-  },
-  cyan: {
-    border: "border-cyan-500/[0.2]",
-    bg: "bg-cyan-500/[0.05]",
-    text: "text-cyan-400",
-    chip: "bg-cyan-500/[0.08] text-cyan-300 border-cyan-500/[0.2]",
-    glow: "hover:shadow-[0_0_40px_rgba(34,211,238,0.12)]",
-  },
-  fuchsia: {
-    border: "border-fuchsia-500/[0.2]",
-    bg: "bg-fuchsia-500/[0.05]",
-    text: "text-fuchsia-400",
-    chip: "bg-fuchsia-500/[0.08] text-fuchsia-300 border-fuchsia-500/[0.2]",
-    glow: "hover:shadow-[0_0_40px_rgba(232,121,249,0.12)]",
-  },
-} as const;
 
 export default function VerticalsPage() {
   return (
@@ -161,72 +62,69 @@ export default function VerticalsPage() {
       <section className="border-b border-white/[0.04] px-6 py-20">
         <div className="mx-auto max-w-5xl">
           <div className="grid gap-6 md:grid-cols-3">
-            {VERTICALS.map((v) => {
-              const a = ACCENTS[v.accent];
-              return (
-                <article
-                  key={v.name}
-                  className={`flex flex-col rounded-2xl border ${a.border} ${a.bg} p-6 transition-std ${a.glow}`}
-                >
-                  <header>
-                    <p
-                      className={`text-[11px] font-medium uppercase tracking-widest ${a.text}`}
-                    >
-                      {v.status === "live-frank-operated"
-                        ? "Live · Frank-operated"
-                        : "Live"}
-                    </p>
-                    <h2 className="mt-2 text-xl font-semibold text-white">
-                      {v.name}
-                    </h2>
-                    <p className="mt-3 text-[14px] leading-relaxed text-slate-400">
-                      {v.tagline}
-                    </p>
-                  </header>
+            {VERTICALS.map((v) => (
+              <article
+                key={v.slug}
+                className={`flex flex-col rounded-2xl border ${ACCENT_BORDER[v.accent]} ${ACCENT_BG[v.accent]} p-6 transition-std ${ACCENT_GLOW[v.accent]}`}
+              >
+                <header>
+                  <p
+                    className={`text-[11px] font-medium uppercase tracking-widest ${ACCENT_TEXT[v.accent]}`}
+                  >
+                    {v.status === "live-frank-operated"
+                      ? "Live · Frank-operated"
+                      : "Live"}
+                  </p>
+                  <h2 className="mt-2 text-xl font-semibold text-white">
+                    {v.name}
+                  </h2>
+                  <p className="mt-3 text-[14px] leading-relaxed text-slate-400">
+                    {v.taglineShort}
+                  </p>
+                </header>
 
-                  <dl className="mt-6 grid grid-cols-3 gap-2 border-y border-white/[0.06] py-4 text-center">
-                    <Stat label="sub-systems" value={v.subsystems} />
-                    <Stat label="commands" value={v.commands} />
-                    <Stat label="agents" value={v.agents} />
-                  </dl>
+                <dl className="mt-6 grid grid-cols-3 gap-2 border-y border-white/[0.06] py-4 text-center">
+                  <Stat label="sub-systems" value={v.counts.subSystems} />
+                  <Stat label="commands" value={v.counts.commands} />
+                  <Stat label="agents" value={v.counts.agents} />
+                </dl>
 
-                  <div className="mt-6">
-                    <p className="text-[10px] uppercase tracking-widest text-slate-400">
-                      Sub-systems
-                    </p>
-                    <ul className="mt-3 flex flex-wrap gap-1.5">
-                      {v.pillars.map((p) => (
-                        <li
-                          key={p}
-                          className={`rounded-full border px-2.5 py-1 text-[11px] ${a.chip}`}
-                        >
-                          {p}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
+                <div className="mt-6">
+                  <p className="text-[10px] uppercase tracking-widest text-slate-400">
+                    Sub-systems
+                  </p>
+                  <ul className="mt-3 flex flex-wrap gap-1.5">
+                    {v.pillars.map((p) => (
+                      <li
+                        key={p}
+                        className={`rounded-full border px-2.5 py-1 text-[11px] ${ACCENT_CHIP[v.accent]}`}
+                      >
+                        {p}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
 
-                  <div className="mt-auto flex flex-wrap gap-2 pt-6">
-                    <a
-                      href={v.quickstartUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="rounded-full bg-white px-4 py-2 text-[12px] font-semibold text-[#060609] transition-std hover:bg-white/90"
-                    >
-                      Open QUICK-START &rarr;
-                    </a>
-                    <a
-                      href={v.registryAnchor}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="rounded-full border border-white/[0.1] px-4 py-2 text-[12px] font-medium text-slate-300 transition-std hover:border-white/[0.2] hover:bg-white/[0.04]"
-                    >
-                      Agents
-                    </a>
-                  </div>
-                </article>
-              );
-            })}
+                <div className="mt-auto flex flex-wrap gap-2 pt-6">
+                  <Link
+                    href={`/verticals/${v.slug}`}
+                    aria-label={`Explore ${v.name}`}
+                    className="rounded-full bg-white px-4 py-2 text-[12px] font-semibold text-[#060609] transition-std hover:bg-white/90"
+                  >
+                    Explore <span aria-hidden="true">&rarr;</span>
+                  </Link>
+                  <a
+                    href={`${v.githubBlobBase}/QUICK-START.md`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label={`${v.name} QUICK-START on GitHub`}
+                    className="rounded-full border border-white/[0.1] px-4 py-2 text-[12px] font-medium text-slate-300 transition-std hover:border-white/[0.2] hover:bg-white/[0.04]"
+                  >
+                    QUICK-START
+                  </a>
+                </div>
+              </article>
+            ))}
           </div>
         </div>
       </section>

--- a/site/src/lib/accents.ts
+++ b/site/src/lib/accents.ts
@@ -1,0 +1,85 @@
+// Shared accent token system. Used by /verticals, /verticals/[slug], /cockpit,
+// /architecture and the homepage so all surfaces speak the same color language.
+// Tailwind 4 utility class composition; tree-shakeable.
+
+export type Accent =
+  | "violet"
+  | "cyan"
+  | "fuchsia"
+  | "emerald"
+  | "amber"
+  | "rose";
+
+export const ACCENT_TEXT: Record<Accent, string> = {
+  violet: "text-violet-400",
+  cyan: "text-cyan-400",
+  fuchsia: "text-fuchsia-400",
+  emerald: "text-emerald-400",
+  amber: "text-amber-400",
+  rose: "text-rose-400",
+};
+
+// One shade lighter for code/labels that should accent without competing
+// with primary headings.
+export const ACCENT_TEXT_LIGHT: Record<Accent, string> = {
+  violet: "text-violet-300",
+  cyan: "text-cyan-300",
+  fuchsia: "text-fuchsia-300",
+  emerald: "text-emerald-300",
+  amber: "text-amber-300",
+  rose: "text-rose-300",
+};
+
+export const ACCENT_BORDER: Record<Accent, string> = {
+  violet: "border-violet-500/[0.2]",
+  cyan: "border-cyan-500/[0.2]",
+  fuchsia: "border-fuchsia-500/[0.2]",
+  emerald: "border-emerald-500/[0.2]",
+  amber: "border-amber-500/[0.2]",
+  rose: "border-rose-500/[0.2]",
+};
+
+export const ACCENT_BG: Record<Accent, string> = {
+  violet: "bg-violet-500/[0.05]",
+  cyan: "bg-cyan-500/[0.05]",
+  fuchsia: "bg-fuchsia-500/[0.05]",
+  emerald: "bg-emerald-500/[0.05]",
+  amber: "bg-amber-500/[0.05]",
+  rose: "bg-rose-500/[0.05]",
+};
+
+export const ACCENT_BG_SOFT: Record<Accent, string> = {
+  violet: "bg-violet-500/[0.04]",
+  cyan: "bg-cyan-500/[0.04]",
+  fuchsia: "bg-fuchsia-500/[0.04]",
+  emerald: "bg-emerald-500/[0.04]",
+  amber: "bg-amber-500/[0.04]",
+  rose: "bg-rose-500/[0.04]",
+};
+
+export const ACCENT_CHIP: Record<Accent, string> = {
+  violet: "bg-violet-500/[0.08] text-violet-300 border-violet-500/[0.2]",
+  cyan: "bg-cyan-500/[0.08] text-cyan-300 border-cyan-500/[0.2]",
+  fuchsia: "bg-fuchsia-500/[0.08] text-fuchsia-300 border-fuchsia-500/[0.2]",
+  emerald: "bg-emerald-500/[0.08] text-emerald-300 border-emerald-500/[0.2]",
+  amber: "bg-amber-500/[0.08] text-amber-300 border-amber-500/[0.2]",
+  rose: "bg-rose-500/[0.08] text-rose-300 border-rose-500/[0.2]",
+};
+
+export const ACCENT_GLOW: Record<Accent, string> = {
+  violet: "hover:shadow-[0_0_40px_rgba(167,139,250,0.12)]",
+  cyan: "hover:shadow-[0_0_40px_rgba(34,211,238,0.12)]",
+  fuchsia: "hover:shadow-[0_0_40px_rgba(232,121,249,0.12)]",
+  emerald: "hover:shadow-[0_0_40px_rgba(52,211,153,0.12)]",
+  amber: "hover:shadow-[0_0_40px_rgba(251,191,36,0.12)]",
+  rose: "hover:shadow-[0_0_40px_rgba(251,113,133,0.12)]",
+};
+
+export const ACCENT_GRADIENT_FROM: Record<Accent, string> = {
+  violet: "from-violet-400",
+  cyan: "from-cyan-400",
+  fuchsia: "from-fuchsia-400",
+  emerald: "from-emerald-400",
+  amber: "from-amber-400",
+  rose: "from-rose-400",
+};

--- a/site/src/lib/verticals.ts
+++ b/site/src/lib/verticals.ts
@@ -1,0 +1,371 @@
+// Built on SIP — structured data for the 3 reference Domain Sub-Stack verticals.
+// Source-of-truth for vertical metadata. Read by /verticals (index) and
+// /verticals/[slug] (detail). Updates here ripple to both surfaces.
+
+export type VerticalSlug =
+  | "people-intelligence"
+  | "sound-intelligence"
+  | "music-is";
+
+export type Accent = "violet" | "cyan" | "fuchsia";
+
+export type SubSystem = {
+  name: string;
+  purpose: string;
+  primaryCommand: string;
+};
+
+export type VerticalAgent = {
+  name: string;
+  role: string;
+};
+
+export type Vertical = {
+  slug: VerticalSlug;
+  name: string;
+  status: "live" | "live-frank-operated";
+  accent: Accent;
+  taglineShort: string;
+  heroQuote: string;
+  pillars: string[];
+  counts: {
+    subSystems: string;
+    commands: string;
+    agents: string;
+  };
+  subSystems: SubSystem[];
+  agents: VerticalAgent[];
+  quickStartSteps: string[];
+  refusals: string[];
+  githubBlobBase: string;
+};
+
+const VERTICAL_LIST: Vertical[] = [
+  {
+    slug: "people-intelligence",
+    name: "People Intelligence",
+    status: "live",
+    accent: "violet",
+    taglineShort:
+      "Psychologist · neuroscientist · MBA synthesis. Refuses HR theater. Every framework grounded in research.",
+    heroQuote:
+      "People-flourishing practiced as a science — every framework grounded in psychology and neuroscience, every system designed for sustainable excellence, every conversation honoring both the business and the person.",
+    pillars: [
+      "Hiring",
+      "Performance",
+      "Training",
+      "Culture",
+      "Talent",
+      "Org",
+    ],
+    counts: {
+      subSystems: "6 sub-systems",
+      commands: "28 commands",
+      agents: "6 agents",
+    },
+    subSystems: [
+      {
+        name: "Hiring",
+        purpose:
+          "Structured interview, calibration, culture-add assessment, 90-day onboarding — decision-making under uncertainty about future performance.",
+        primaryCommand: "/hire-icp",
+      },
+      {
+        name: "Performance",
+        purpose:
+          "Feedback rehearsal, review redesign, difficult conversations, coaching — behavior-change conversations grounded in SBI and solution-focus.",
+        primaryCommand: "/perf-feedback-rehearsal",
+      },
+      {
+        name: "Training",
+        purpose:
+          "Outcome-back curriculum, program design, train-the-trainer, transfer measurement — L3/L4 behavior and results as success metrics.",
+        primaryCommand: "/training-curriculum",
+      },
+      {
+        name: "Culture",
+        purpose:
+          "Values-ops matrix operationalizing declared culture into hire/promote/fire/reward decisions — Schein's three levels as audit engine.",
+        primaryCommand: "/culture-values-ops",
+      },
+      {
+        name: "Talent",
+        purpose:
+          "Burnout detection (Maslach), psychological safety (Edmondson), motivation mapping, retention architecture — team dynamics diagnostics.",
+        primaryCommand: "/talent-burnout-detect",
+      },
+      {
+        name: "Org",
+        purpose:
+          "Role design with decision rights, span-of-control audit, reorg trauma sequencing, succession readiness — structure as load-bearing.",
+        primaryCommand: "/org-role-design",
+      },
+    ],
+    agents: [
+      {
+        name: "starlight-hiring",
+        role: "Structured-interview architect; calibration rigor; refusal of vibe-check and personality-assessment theater.",
+      },
+      {
+        name: "starlight-performance",
+        role: "Feedback craft and conversation voice; difficult-conversation protocol; review system redesign.",
+      },
+      {
+        name: "starlight-training",
+        role: "Outcome-back curriculum design; transfer measurement; behavior-change architecture.",
+      },
+      {
+        name: "starlight-culture",
+        role: "Systems design over slogans; values-ops as operational constraint across all five sub-systems.",
+      },
+      {
+        name: "starlight-talent",
+        role: "Clinical-depth team diagnostics; Maslach/Edmondson grounding; stay-interview cadence.",
+      },
+      {
+        name: "starlight-org",
+        role: "Structure design and reorg trauma awareness; 70%+ reorg-failure honesty in sequencing.",
+      },
+    ],
+    quickStartSteps: [
+      "Pick entry sub-system based on immediate pain (hiring new role, broken reviews, culture undefined, team strain, reorg pending).",
+      "Run the daily-5 in sequence (hire-icp → perf-feedback → talent-burnout → culture-values-ops → org-role-design) to feel composition.",
+      "Run one full sub-system flow end-to-end (e.g., hire-icp → hire-design → hire-calibrate → hire-debrief).",
+      "Validate composition rule: culture-design + values-ops before hire-assess-fit; org-role-design before hire-icp.",
+      "Log first attested artifact in MEMORY.md naming one refusal pattern the system refused to ship.",
+    ],
+    refusals: [
+      "PIP-as-firing-cover",
+      "Stack-rank performance",
+      "Values-posters without ops",
+      "Engagement survey as the only signal",
+    ],
+    githubBlobBase:
+      "https://github.com/frankxai/Starlight-Intelligence-System/blob/main/verticals/people-intelligence",
+  },
+  {
+    slug: "sound-intelligence",
+    name: "Sound Intelligence",
+    status: "live",
+    accent: "cyan",
+    taglineShort:
+      "Architecture of sustained listening. Composition theory, mix physics, catalog discipline, fanbase sovereignty.",
+    heroQuote:
+      "Sound practiced as the architecture of sustained listening — every composition decision grounded in music theory and cognitive science, every production decision honoring the listener's nervous system, every release built so the catalog compounds rather than scatters.",
+    pillars: [
+      "Composition",
+      "Production",
+      "Catalog",
+      "Performance",
+      "Audience",
+      "Sync",
+    ],
+    counts: {
+      subSystems: "6 sub-systems",
+      commands: "30 commands",
+      agents: "6 agents",
+    },
+    subSystems: [
+      {
+        name: "Composition",
+        purpose:
+          "Songwriting with tension-and-release (Huron ITPRA), arrangement as architecture, lyric prosody, transition design.",
+        primaryCommand: "/sound-composition-arrange",
+      },
+      {
+        name: "Production",
+        purpose:
+          "Mix planning (frequency budget, gain-stage), mastering with dynamic-range preservation, vocal chain — refuses loudness war.",
+        primaryCommand: "/sound-production-mix-plan",
+      },
+      {
+        name: "Catalog",
+        purpose:
+          "ISRC/ISWC minting, metadata as load-bearing, version mapping, deplatform recovery — catalog as asset, not orphan singles.",
+        primaryCommand: "/sound-catalog-metadata-pack",
+      },
+      {
+        name: "Performance",
+        purpose:
+          "Set design (tension-and-release across 75 min), audience contract, live mix architecture, residency, broadcast prep.",
+        primaryCommand: "/sound-performance-set-design",
+      },
+      {
+        name: "Audience",
+        purpose:
+          "Cohort mapping (entry-point, depth, channel), list architecture, ritual design, fan stay-interviews, sovereign publishing.",
+        primaryCommand: "/sound-audience-list-architecture",
+      },
+      {
+        name: "Sync & Licensing",
+        purpose:
+          "Brief-fit gate (vision boundaries enforced), placement thesis, license economics, rights pack, stay-interview cadence.",
+        primaryCommand: "/sound-sync-brief-fit",
+      },
+    ],
+    agents: [
+      {
+        name: "starlight-sound-composition",
+        role: "Composition architecture grounded in music theory and cognitive science; transitions as structure, not fade-outs.",
+      },
+      {
+        name: "starlight-sound-production",
+        role: "Mix and master as system design; loudness-war refusal; dynamic-range and transient preservation.",
+      },
+      {
+        name: "starlight-sound-catalog",
+        role: "Metadata discipline as sovereign infrastructure; ISRC architecture; version-map topology.",
+      },
+      {
+        name: "starlight-sound-performance",
+        role: "Set design as architecture; audience contract framing; broadcast-prep state management.",
+      },
+      {
+        name: "starlight-sound-audience",
+        role: "Fan relationships over algorithmic follower metrics; list architecture in practitioner voice.",
+      },
+      {
+        name: "starlight-sound-sync",
+        role: "Vision-boundary enforcement at brief-fit; rights-pack completeness; sync economics audit.",
+      },
+    ],
+    quickStartSteps: [
+      "Pick entry sub-system based on current work (writing song, mixing session, releasing track, touring, growing fanbase, pitching sync).",
+      "Run the daily-5 in sequence (composition-arrange → production-mix-plan → catalog-metadata → audience-list-architecture → sync-brief-fit).",
+      "Run one complete flow end-to-end (composition-score → arrange → demo for a new song; or catalog-release-plan → isrc-mint → metadata-pack for a release).",
+      "Validate composition rule: arrangement before mix-plan; sample-clearance + AI-vocal-license before production-master.",
+      "Log first artifact in MEMORY.md naming one refusal pattern (loudness-war, AI-impersonation, uncleared sample, sync-against-vision).",
+    ],
+    refusals: [
+      "Loudness-war mastering",
+      "AI-vocal impersonation without consent",
+      "Uncleared samples shipped to release",
+      "Sync placements that breach the artist's vision",
+    ],
+    githubBlobBase:
+      "https://github.com/frankxai/Starlight-Intelligence-System/blob/main/verticals/sound-intelligence",
+  },
+  {
+    slug: "music-is",
+    name: "Music IS",
+    status: "live-frank-operated",
+    accent: "fuchsia",
+    taglineShort:
+      "Frank's operated Arcanea Records — four labels under one canon. Persona-gated green-light, royalty-cascade-at-spawn.",
+    heroQuote:
+      "Four labels under one canon — every release traceable to a persona, every persona traceable to a sovereign brand-graph, every green-light gated through A&R taste that refuses volume-without-canon.",
+    pillars: [
+      "Catalog",
+      "Persona",
+      "Asset",
+      "Distribution",
+      "Amplification",
+      "Royalty",
+      "A&R",
+    ],
+    counts: {
+      subSystems: "6+1 sub-systems",
+      commands: "8 commands",
+      agents: "7 agents",
+    },
+    subSystems: [
+      {
+        name: "Catalog",
+        purpose:
+          "CSV master as source-of-truth; per-state folders (draft/released/archived); ISRC indexing; royalty-graph reference.",
+        primaryCommand: "/music-song",
+      },
+      {
+        name: "Persona",
+        purpose:
+          "Spawn persona with sound DNA + visual DNA + voice DNA + audience + monetization stack; canon defense; retirement.",
+        primaryCommand: "/music-persona",
+      },
+      {
+        name: "Asset",
+        purpose:
+          "Cover (Nano Banana), motion video (Seedance), cinematic (Higgsfield), Spotify Canvas (Remotion) — full bundle per release.",
+        primaryCommand: "/music-canvas",
+      },
+      {
+        name: "Distribution",
+        purpose:
+          "DistroKid (streaming), Bandcamp (direct), frankx.ai/music, Spotify Canvas, sync-library pitching per label routing.",
+        primaryCommand: "/music-release",
+      },
+      {
+        name: "Amplification",
+        purpose:
+          "OpenClaws agents (5 per persona: X, IG, TikTok, YT, Spotify) orchestrated via Blotato + n8n; voice-locked, frequency-capped.",
+        primaryCommand: "/music-amplify",
+      },
+      {
+        name: "Royalty Graph",
+        purpose:
+          "Attribution-cascade design at spawn, not retrofit; streaming, sync, NFT, fan-tier, direct revenue tracked per rail.",
+        primaryCommand: "/music-release",
+      },
+      {
+        name: "A&R Gate",
+        purpose:
+          "Non-waivable green-light authority. Canon-anchoring + asset-completeness check before any release ships.",
+        primaryCommand: "/music-release",
+      },
+    ],
+    agents: [
+      {
+        name: "music-curator",
+        role: "A&R green-light gate (Opus); non-waivable over all releases; canon-anchoring and asset-completeness enforcer.",
+      },
+      {
+        name: "music-archivist",
+        role: "Catalog CRUD and hygiene (Haiku); source-of-truth maintenance; metadata tagging.",
+      },
+      {
+        name: "persona-keeper",
+        role: "One per persona (Opus); canon defense; voice-lock checks; spawn/retire discipline.",
+      },
+      {
+        name: "music-producer",
+        role: "Asset pipeline orchestration (Sonnet); cover + motion + Canvas rendering per persona/label DNA.",
+      },
+      {
+        name: "music-distributor",
+        role: "DistroKid + Bandcamp + frankx.ai/music sync (Sonnet); metadata lock; ISRC pull; sync-pitch generation.",
+      },
+      {
+        name: "music-amplifier",
+        role: "OpenClaws orchestration (Sonnet); per-platform voice-locked copy generation; frequency-cap enforcement.",
+      },
+      {
+        name: "royalty-architect",
+        role: "Royalty-cascade graph design at spawn (Sonnet); monetization-rail design; sync-deal economics.",
+      },
+    ],
+    quickStartSteps: [
+      "Lock Frank's Vibes persona name (Lumen / Aether / Dawn) and verify Spotify/Apple/YouTube availability.",
+      "Begin catalog migration: run /music-song for the 46 pre-cataloged tracks from the FrankX archive.",
+      "Queue first Frank Riemer release: Suno URL → catalog draft → asset bundle → /music-release gate.",
+      "Draft first Alera release plan per label/persona CANON.md; plan 6 releases through gate by end of Phase 1.",
+      "Run first weekly hygiene ritual (12-check Monday checklist); confirm Notion mirror setup complete.",
+    ],
+    refusals: [
+      "Volume releases without canon anchoring",
+      "Persona spawn without royalty-cascade design",
+      "Voice drift from sound/visual/voice DNA",
+      "Amplification posts that bypass voice-lock",
+    ],
+    githubBlobBase:
+      "https://github.com/frankxai/Starlight-Intelligence-System/blob/main/verticals/music-is",
+  },
+];
+
+export const VERTICALS = VERTICAL_LIST;
+
+export const VERTICAL_BY_SLUG: Record<VerticalSlug, Vertical> =
+  Object.fromEntries(VERTICAL_LIST.map((v) => [v.slug, v])) as Record<
+    VerticalSlug,
+    Vertical
+  >;
+
+export const VERTICAL_SLUGS: VerticalSlug[] = VERTICAL_LIST.map((v) => v.slug);


### PR DESCRIPTION
## Summary

3 new SSG routes — `/verticals/people-intelligence`, `/verticals/sound-intelligence`, `/verticals/music-is` — each rendering Hero · Sub-systems · Agents · Quickstart · Refusals · Closer. Generated via dynamic `[slug]` route + `generateStaticParams`.

Plus the v7.7 code-review carry-forward: ACCENTS map extraction across 4 files (`page.tsx`, `cockpit/page.tsx`, `verticals/page.tsx`, `[slug]/page.tsx` all consume `@/lib/accents` instead of inline objects).

Closes the v7.7 plan's "Future" carry-forward: *"Per-vertical landing pages (`/verticals/people-intelligence`, etc.)"* — partially. Currently uses paraphrased quickstart steps; full QUICK-START.md rendering deferred to v7.9.

## Files

- `site/src/lib/verticals.ts` — NEW · typed source-of-truth (taglines, hero quotes, sub-systems, agents, steps, refusals)
- `site/src/lib/accents.ts` — NEW · shared accent tokens (text/border/bg/bgSoft/chip/glow/textLight)
- `site/src/app/verticals/[slug]/page.tsx` — NEW · dynamic route, 3 SSG slugs
- `site/src/app/verticals/page.tsx` · UPDATED — Links to `/verticals/<slug>` instead of GitHub blobs as primary CTA
- `site/src/app/page.tsx` · UPDATED — homepage uses `lib/accents`
- `site/src/app/cockpit/page.tsx` · UPDATED — Stage + SurfaceCell helpers use `lib/accents`
- `site/src/app/layout.tsx` · UPDATED — skip link (SC 2.4.1) + `id="main-content"` on `<main>`

**Diff: 7 files, +865 / -213 LOC.**

## Reviewers (parallel subagents)

- **Spec compliance: PROCEED.** Numbers verified honest against repo: 28 People + 30 Sound + 8 Music commands counted exactly; 6/6/7 agents match `AGENTS.md`. Hero quotes faithful trims of SOUL.md. Refusals extracted from named drift rules.
- **Accessibility (WCAG 2.2 AA): PASS-WITH-NITS** → 4 fixes applied in same PR:
  - Skip link added (SC 2.4.1)
  - `aria-label` differentiation on `/verticals` card CTAs (SC 2.4.6) — "Explore People Intelligence" not just "Explore"
  - `aria-hidden` on decorative arrows + rose dot
  - Plus polish: `ACCENT_TEXT_LIGHT` token threading so agent-name `<code>` picks up vertical accent (cyan for sound, fuchsia for music) instead of hardcoded violet

## Verification

- [x] `npx tsc --noEmit` exit 0
- [x] `pnpm build` exit 0; 3 new SSG routes generated
- [x] Local dev smoke: all 6 routes 200; index Links to sub-pages; aria-labels in source
- [ ] Vercel preview/production
- [ ] Per-route smoke after deploy

## Test plan

- [ ] `/verticals/people-intelligence` shows Hiring/Performance/Training/Culture/Talent/Org sub-systems + 6 agents + refusals
- [ ] `/verticals/sound-intelligence` shows Composition/Production/Catalog/Performance/Audience/Sync + agents in cyan
- [ ] `/verticals/music-is` shows Frank-operated chip + 7 agents + refusals
- [ ] `/verticals` index cards link to sub-pages (not GitHub blobs)
- [ ] Skip link visible on Tab focus from any page
- [ ] No regression on `/`, `/cockpit`, `/architecture`, `/explainer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Created individual pages for each vertical (People Intelligence, Sound Intelligence, Music Is) with dedicated sections covering overview, sub-systems, agents, and quick-start guides
  * Added skip-to-content accessibility link for improved keyboard navigation

* **Refactor & Style**
  * Established shared accent color system across the site for consistent styling
  * Unified vertical metadata management with improved data organization
  * Updated vertical cards with enhanced information display including counts and quick links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->