### PR TITLE
ci(site): bump Vercel CLI pin + add explainer drift-check workflow

### DIFF
--- a/.github/workflows/content-drift-check.yml
+++ b/.github/workflows/content-drift-check.yml
@@ -1,0 +1,62 @@
+# Built on SIP — Starlight Intelligence Protocol v1.1.0
+# Substrate: starlightintelligence.org/protocol
+# Layers used: [file-contract, attestation, sovereignty]
+#
+# Catches drift between docs/public/starlight-intelligence-system.md (the source-
+# of-truth) and site/content/explainer.md (the committed copy that Vercel reads
+# at runtime — see PR #7 v7.7.2). The site/scripts/sync-explainer.mjs script
+# normally runs as a predev/prebuild step, but if a contributor edits the source
+# without running build, the committed copy goes stale silently.
+#
+# This workflow runs the sync and fails if it produces a diff. The fix is to
+# either run `pnpm build` locally before pushing, or run `node site/scripts/
+# sync-explainer.mjs` directly.
+
+name: Content drift check
+
+on:
+  pull_request:
+    paths:
+      - "docs/public/starlight-intelligence-system.md"
+      - "site/content/explainer.md"
+      - "site/scripts/sync-explainer.mjs"
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/public/starlight-intelligence-system.md"
+      - "site/content/explainer.md"
+      - "site/scripts/sync-explainer.mjs"
+
+permissions:
+  contents: read
+
+jobs:
+  drift-check:
+    runs-on: ubuntu-latest
+    name: Verify site/content/explainer.md matches source
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
+        with:
+          node-version: "20"
+
+      - name: Run sync-explainer
+        working-directory: site
+        run: node scripts/sync-explainer.mjs
+
+      - name: Verify no drift
+        run: |
+          if git diff --exit-code site/content/explainer.md; then
+            echo "site/content/explainer.md is in sync with docs/public/starlight-intelligence-system.md"
+          else
+            echo ""
+            echo "::error::Drift detected. site/content/explainer.md does not match docs/public/starlight-intelligence-system.md."
+            echo "::error::To fix: run 'node site/scripts/sync-explainer.mjs' locally and commit the result, or run 'pnpm build' from site/."
+            exit 1
+          fi

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -42,7 +42,7 @@ jobs:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      VERCEL_CLI_VERSION: "39.4.0"
+      VERCEL_CLI_VERSION: "42.2.0"
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7


### PR DESCRIPTION
## Summary

Two operational-infra carry-forwards from v7.7–v7.8.

**1. `vercel-deploy.yml` pin bump 39.4.0 → 42.2.0** — The pinned CLI version doesn't exist on npm (latest is 53.x), causing every recent run to fail at the "Install Vercel CLI" step. 42.2.0 matches the version Frank uses locally for manual `vercel --prod` ships.

⚠️ **Production deploys still require `VERCEL_TOKEN` / `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID` secrets** to be set in repo settings. Those are Frank's call. After this PR merges, the workflow will install the CLI successfully but fail at `vercel pull` until secrets land.

**2. `content-drift-check.yml` (new)** — runs `sync-explainer.mjs` on PR + push touching `docs/public/starlight-intelligence-system.md` or `site/content/explainer.md` or the sync script. Verifies `git diff --exit-code site/content/explainer.md` produces no diff. Catches the silent-drift failure where a contributor edits the source without running `pnpm build`.

## Verified locally

- yaml syntax valid (`yaml.safe_load` both workflows)
- `node site/scripts/sync-explainer.mjs` runs idempotently
- `git diff --exit-code site/content/explainer.md` returns exit 0 when in sync
- Cannot end-to-end test the deploy workflow without secrets — that gate stays with Frank

## Tier

Operational. No substrate edit.