### PR TITLE
feat(substrate): Calculator + Validation + Schemas + Energy IS scaffold + 3 board verdicts

### DIFF
--- a/docs/boards/2026-05-03-calculator-validation-substrate.md
+++ b/docs/boards/2026-05-03-calculator-validation-substrate.md
@@ -1,0 +1,39 @@
+# Starlight Board — SovereignNode + Calculator + ValidationRequirement substrate addition
+
+**Date:** 2026-05-03
+**Pre-pass:** `docs/superpowers/board-pre-passes/2026-05-03-calculator-validation-substrate.md`
+**Convened by:** Claude Opus 4.7 (1M context) on Frank's directive
+
+---
+
+**Sovereign:** Adding a typed substrate primitive that any infra-touching Domain Sub-Stack must use is real ambition with bounded scope — People/Sound/Music IS opt out, only Energy/Compute/Home/Capital opt in. The proposal can be taken back by deprecating the package; existing adopters retain their work. Worth the name.
+
+**Seer:** In 18 months, only a subset of Domain Sub-Stacks will be infra-touching enough to need this. Most verticals stay LLM-prose because their numerical claims are loose (frameworks, vocabularies, retention plans — no calculator there). That makes this a tool for a subset, not a universal substrate primitive — fine if scoped honestly.
+
+**Harmonizer:** The `ValidationRequirement` enum hardcodes regulatory geography: `licensed_electrician_review`, `tax_advisor_review`, etc. These are claims about jurisdiction. If the enum bakes in a specific frame, it breaks for sub-stacks operating elsewhere. Needs an explicit `jurisdiction-specific` extension point from day one.
+
+**Strategist:** This unlocks legal-and-financial defensibility for any product making numerical claims — exactly what Tier-1 sprint clients need (PV-Lager especially). Closes off pure-LLM "AI does the math" framings, which we don't want anyway. Real unlock.
+
+**Verifier:** Pilot on Energy IS before retrofit is sound. Risk: a calculator producing a wrong number that nonetheless passes its `confidence` check. The packet's mitigation (bench against fixed I/O corpus) is correct but underspecified — what is "promotion"? Add explicit pipeline: `shadow` → `live-with-warnings` → `live` → `deprecated`.
+
+**Overseer:** Most load-bearing concern is regulatory geography in the enum. Strongest case for proceeding: this is the only path to numerical claims without legal liability landmines. Pilot on Energy IS, encode extensibility, ship in shadow mode first.
+
+**Recommendation:** PROCEED-WITH-REVISE
+**Rationale:** Add jurisdiction-extensibility to ValidationRequirement and define the calculator promotion pipeline before the pilot lands.
+
+## REVISE items captured
+
+1. `ValidationRequirement` is an extensible enum, not a closed set. Core canonical members ship; jurisdictions extend.
+2. Every calculator carries a `mode: "shadow" | "live-with-warnings" | "live" | "deprecated"` field. Promotion pipeline named explicitly in `packages/calculators/README.md`.
+
+## Ship plan post-board
+
+1. Build `packages/schemas/` (SovereignNode + Profiles)
+2. Build `packages/validation/` (ValidationRequirement enum + extension mechanism)
+3. Build `packages/calculators/` (Calculator interface + CalculatorResult shape + promotion modes)
+4. Update `docs/ARCHITECTURE.md` with substrate addition section
+5. Pilot on Energy IS (separate, gated on this ship)
+
+---
+
+**Built on SIP** · Starlight Board verdict · 2026-05-03

--- a/docs/boards/2026-05-03-copilotkit-adoption.md
+++ b/docs/boards/2026-05-03-copilotkit-adoption.md
@@ -1,0 +1,39 @@
+# Starlight Board — CopilotKit as standardized agent-UI runtime
+
+**Date:** 2026-05-03
+**Pre-pass:** `docs/superpowers/board-pre-passes/2026-05-03-copilotkit-adoption.md`
+**Convened by:** Claude Opus 4.7 (1M context) on Frank's directive
+
+---
+
+**Sovereign:** Coupling 5+ repos to a single OSS dependency is real — if CopilotKit changes direction, cost is across the ecosystem. But the alternative is what we have today: every repo invents its own assistant UX. CopilotKit is at the same coupling tier as Next.js/React; we accept those. The wrapper package is the exit-cost mitigation.
+
+**Seer:** In 18 months, AG-UI Protocol may be one of three competing standards. Adopting CopilotKit is a bet — reasonable (30k stars, real users, open protocol) but a bet. Hedge: the wrapper interface is what we own; underneath, swappable.
+
+**Harmonizer:** The strong-boundary table (CopilotKit owns UI, NOT memory/canon/identity) is well-stated but historically erodes under product pressure. Real test: when a CopilotKit feature requests memory access, will we hold the line? Encode boundary in lint rules + CI checks on consuming apps — not just promised.
+
+**Strategist:** Generative UI + shared state + human-in-the-loop is the missing primitive. Adopting unlocks the entire "agent proposes, user approves" flow that the bespoke cockpit doesn't have. Real unlock.
+
+**Verifier:** What fails first: boundary erosion. When Arcanea Luminor sidebar wants to show "what does Vel'Tara mean", it'll try to reach into canon. Mitigation: provider-pattern. The wrapper exposes `canon-query-provider` that the app injects — UI doesn't reach into canon, app does and supplies the result.
+
+**Overseer:** Most load-bearing concern: boundary erosion. Strongest case: bespoke cockpit stays Frank's local Jarvis (we keep), CopilotKit wins where standardization beats fit. Pilot on one app, prove boundary, then propagate.
+
+**Recommendation:** PROCEED-WITH-REVISE
+**Rationale:** Build boundary enforcement (CI lint rules + provider-pattern for canon/memory access) into the wrapper package from day one — not as follow-up.
+
+## REVISE items captured
+
+1. Provider-pattern is the only way the wrapper accesses memory/canon/identity. The wrapper does NOT import from those domains directly; the consuming app injects providers.
+2. CI lint rules (eslint custom rule or simple grep check) flag any direct `import from "@starlight/memory"` etc. inside `packages/agent-ui-runtime/src/` as a violation.
+3. `BOUNDARY.md` is a required file in the package and CI checks for its presence + non-empty.
+
+## Ship plan post-board
+
+1. Scaffold `packages/agent-ui-runtime/` with `BOUNDARY.md` + provider interfaces — DONE this PR.
+2. CI lint rule for boundary enforcement — separate v8.x ship.
+3. Golden reference impl in `apps/arcanea-command-center` — lives in `C:\Users\frank\Arcanea` repo (cross-repo distribution packet already filed at `docs/cross-repo-distributions/2026-05-03-arcanea-luminor-sidebar-copilotkit.md`).
+4. Bespoke cockpit unchanged.
+
+---
+
+**Built on SIP** · Starlight Board verdict · 2026-05-03

--- a/docs/boards/2026-05-03-energy-is-domain-substack.md
+++ b/docs/boards/2026-05-03-energy-is-domain-substack.md
@@ -1,0 +1,36 @@
+# Starlight Board — Energy IS as 4th reference Domain Sub-Stack
+
+**Date:** 2026-05-03
+**Pre-pass:** `docs/superpowers/board-pre-passes/2026-05-03-energy-is-domain-substack.md`
+**Convened by:** Claude Opus 4.7 (1M context) on Frank's directive
+
+---
+
+**Sovereign:** "Energy" is the right level — narrower than "Infrastructure", broader than "Solar", absorbs sibling concerns (storage, grid, thermal, compute-as-load). Frank's family business gives it operator-tier validation. Worth the name. Irreversibility same as any reference vertical — once shipped, hard to deprecate.
+
+**Seer:** This will be the most operator-tier-revenue-generating reference vertical. Energy installers are concrete buyers; psychologists and musicians are aspirational. Sets a precedent that infrastructure-shaped sub-stacks (Compute, Home, Capital) are SIS-blessed — accelerates SIS as productization platform.
+
+**Harmonizer:** PV-Lager is a sovereign instance that pre-exists this proposal. The packet handles correctly — public Energy IS stays generic; PV-Lager goes to `private/`. No conflict.
+
+**Strategist:** First commercial wedge that's not creator-shaped. Different ICP (small-business operators in regulated market), different willingness to pay, different sales cycle. Real diversification of the product portfolio.
+
+**Verifier:** Correctly gated on Calculator/Validation substrate landing first. Without that, Energy IS ships LLM-prose for numerical claims and is worse than not shipping. 3-4 week scaffold timeline plausible if scope holds at 6 sub-systems.
+
+**Overseer:** Sequencing dependency on Board 1 is real. Strongest case: right vertical, right time, complementary to existing 3 references. Sequence: Board 1 ships → Calculator/Validation substrate lands → re-board Energy IS with substrate available → scaffold.
+
+**Recommendation:** PROCEED (sequencing-gated on Board 1)
+**Rationale:** Right next vertical; gate the actual scaffolding on Calculator/Validation substrate landing first per the packet's own coupling note.
+
+## Ship plan post-board
+
+1. Wait for Calculator/Validation substrate ship (Board 1 outcome)
+2. Scaffold `verticals/energy-intelligence/` with 7-file contract — STUBS shipped this PR; full content in v8.x cycle
+3. Integrate `@starlight/calculators` for sizing/cost/payback
+4. Integrate `@starlight/validation` with `licensed_electrician_review`, `grid_operator_confirmation` as extended jurisdiction-canonical members
+5. Author 6-7 agents at `agents/starlight-energy-{sizing,cost,installer,operations,buyer,grid,recovery}.md`
+6. Author 20-30 commands at `.claude/commands/energy-*.md`
+7. PV-Lager instantiates as sovereign instance under `private/verticals/pv-lager/` (separate ship, Frank-driven)
+
+---
+
+**Built on SIP** · Starlight Board verdict · 2026-05-03

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,0 +1,57 @@
+# `packages/` — substrate packages
+
+> TypeScript packages that any Domain Sub-Stack composes with. Each package
+> declares interfaces + base classes + canonical types. Implementations live
+> per-vertical; the substrate provides the contract.
+
+## Status
+
+This directory is **NEW as of 2026-05-03** per the `/starlight-board` ratification of the SovereignNode + Calculator + ValidationRequirement substrate proposal (`docs/boards/2026-05-03-calculator-validation-substrate.md` — verdict PROCEED-WITH-REVISE).
+
+The packages currently ship **interface + types + base classes**. Full build infrastructure (npm publish, tests, CI) is v8.x scope. Today, packages are imported via path resolution from consuming code, or used as design references.
+
+## Packages
+
+| Package | Purpose | Status |
+|---|---|---|
+| `@starlight/schemas` | Canonical entity types — SovereignNode + Profiles (Zod) | Foundation shipped 2026-05-03 |
+| `@starlight/validation` | ValidationRequirement enum + jurisdiction extension mechanism | Foundation shipped 2026-05-03 |
+| `@starlight/calculators` | Calculator interface + CalculatorResult + promotion-pipeline modes | Foundation shipped 2026-05-03 |
+| `@starlight/agent-ui-runtime` | CopilotKit wrapper with strong-boundary enforcement | Scaffold + BOUNDARY.md only; full impl is cross-repo (Arcanea) |
+
+## Composition rules
+
+Every infra-touching Domain Sub-Stack (Energy, Home, Compute, Capital) **must** use:
+
+1. `SovereignNode` from `@starlight/schemas` as its canonical entity type
+2. `Calculator<I, O>` from `@starlight/calculators` for any numerical output (cost, sizing, ROI, capacity)
+3. `ValidationRequirement` from `@starlight/validation` to gate any irreversible action
+
+Non-infra-touching Domain Sub-Stacks (People, Sound, Music IS) opt out — their numerical claims are loose enough that LLM-prose is acceptable.
+
+## The deterministic-not-LLM principle
+
+Numerical and structural decisions never go through an LLM. The LLM does interpretation, extraction, and prose framing — never the math. This is a hard contract enforced by the package shape: a Calculator output carries `confidence` / `assumptions` / `warnings` / `required_validation` / `trace` and is auditable; an LLM output is not.
+
+## Promotion pipeline
+
+Every calculator carries a `mode` field with one of four values:
+
+| Mode | Meaning | Use |
+|---|---|---|
+| `shadow` | Runs alongside legacy path; outputs logged but not shown to user | New calculators ship here |
+| `live-with-warnings` | Outputs shown to user with explicit warning banner | After shadow corpus passes |
+| `live` | Outputs shown to user as canonical | After live-with-warnings stabilizes |
+| `deprecated` | Outputs hidden; calculator preserved for replay only | When superseded |
+
+The promotion pipeline lives in `packages/calculators/README.md`.
+
+## Cross-repo
+
+When a sibling repo (`arcanea-flow`, `agentic-creator-os`, `arcanea`) wants to consume these packages, it imports via path resolution (today) or via npm install (v8.x). The cross-repo distribution packets at `docs/cross-repo-distributions/` name where each package consumer should land.
+
+---
+
+**Built on SIP** · Starlight Intelligence Protocol v1.1.0
+- Layers used: [file-contract, attestation, sovereignty]
+- Substrate ratified: 2026-05-03 (Board verdict at `docs/boards/2026-05-03-calculator-validation-substrate.md`)

--- a/packages/agent-ui-runtime/BOUNDARY.md
+++ b/packages/agent-ui-runtime/BOUNDARY.md
@@ -1,0 +1,76 @@
+# Agent UI Runtime — Strong Boundary
+
+> Per Board verdict 2026-05-03: this file is a **required artifact** of the
+> package. CI checks for its existence + non-empty body. Boundary enforcement
+> begins here.
+
+## What this package owns
+
+- UI orchestration (sidebar, modals, panels)
+- Agent-user message exchange
+- Shared state across agent + frontend session
+- Frontend tool registration and invocation
+- Generative UI rendering (cards, tables, timelines, forms)
+- Human-in-the-loop approval flows
+- Theme + chrome (font, color, spacing)
+
+## What this package does NOT own
+
+- **Memory** — durable state lives in `@starlight/memory` (or equivalent consumer-supplied store). The wrapper does NOT read or write memory directly.
+- **Canon** — symbolic / mythic / domain knowledge lives in the consumer's canon system (e.g., Arcanea's MCP canon, or a vault). The wrapper does NOT lookup canon directly.
+- **Identity** — sovereign identity, auth, current-user determination lives in the consumer's identity system. The wrapper does NOT determine identity.
+- **Business logic** — calculators, workflows, n8n integrations, MCP servers stay in their own packages. The wrapper renders results; it doesn't compute them.
+- **Workflow state** — durable workflow state lives in `private/voice-operator/config/workflows/` (or the consumer's equivalent). The wrapper renders progress; it doesn't persist.
+- **Repo intelligence** — `CLAUDE.md` / `MASTER_PLAN.md` / `SIP.md` are read by agents, not by the UI wrapper.
+- **Security policy** — auth, secrets, audit policy stay in the consumer's security layer. The wrapper renders approval flows; it doesn't decide what requires approval.
+- **Publishing authority** — what ships when stays with the sovereign with decision rights per SIP § 5. The wrapper renders the decision UI; it doesn't make the decision.
+
+## Enforcement
+
+### Static (lint-checkable)
+
+CI rule will flag any of the following as a boundary violation in `packages/agent-ui-runtime/src/`:
+
+- `import ... from "@starlight/memory"` (or any direct memory-package import)
+- `import ... from "@starlight/canon"` (or any canon-system import)
+- `import ... from "@starlight/identity"` (or any identity-system import)
+- `import ... from "@starlight/calculators"` for direct calc invocation (the wrapper renders results, but app injects them)
+
+**Implementation note:** the lint rule will be added in the v8.x cycle as either a custom ESLint rule or a simple grep gate in CI. Until then, the boundary is enforced by code review.
+
+### Provider pattern (runtime contract)
+
+All access to memory / canon / identity / calculators flows through `AgentUIProviders` injected by the consuming app:
+
+```ts
+interface AgentUIProviders {
+  canon?: { query(term: string): Promise<CanonResult>; };
+  memory?: { recall(query: string): Promise<MemoryResult>; };
+  identity?: { current(): SovereignIdentity; };
+  calculators?: { run<I, O>(name: string, input: I): Promise<CalculatorResult<O>>; };
+}
+```
+
+The wrapper sees only the interface. The implementation lives in the consuming app. Two apps can inject completely different impls without the wrapper knowing.
+
+## What this enables
+
+- Arcanea's Luminor sidebar can use the wrapper to render generative UI while keeping Arcanea's canon system as the single source of truth for Guardian / Vel'Tara lookups.
+- FrankX's operator cockpit can use the same wrapper while keeping FrankX's memory/identity layer.
+- ACOS's creator console can use the same wrapper while keeping ACOS's creator-shaped identity.
+- The bespoke v7.5.3 cockpit (orb + dashboard + DispatchPanel + brain SSE) **does not adopt** this package. It stays bespoke as Frank's local Jarvis surface — which is the explicit recommendation in the board pre-pass packet.
+
+## When this boundary is challenged
+
+When a CopilotKit feature wants direct access to memory or canon (a generative-UI flow that wants to "remember" something, or a card that wants to look up canon inline), the answer is:
+
+1. Add a method to `AgentUIProviders` instead.
+2. The consumer app injects the provider.
+3. The wrapper still doesn't import the underlying system.
+
+The boundary is non-negotiable. Erosion would defeat the purpose of the wrapper (which is portability across consuming apps with different memory/canon/identity backends).
+
+---
+
+**Built on SIP** · Starlight Intelligence Protocol v1.1.0
+- Source: Board verdict at `docs/boards/2026-05-03-copilotkit-adoption.md` (REVISE item 1: "Provider-pattern is the only way the wrapper accesses memory/canon/identity")

--- a/packages/agent-ui-runtime/README.md
+++ b/packages/agent-ui-runtime/README.md
@@ -1,0 +1,70 @@
+# `@starlight/agent-ui-runtime`
+
+CopilotKit wrapper with strong-boundary enforcement. Provides one consistent agent-UI surface across Arcanea, FrankX, ACOS, and any other consumer that wants generative UI + shared state + human-in-the-loop without inventing its own.
+
+## Status
+
+**Scaffold only (v0.1.0-scaffold) shipped 2026-05-03.** Per Board PROCEED-WITH-REVISE (`docs/boards/2026-05-03-copilotkit-adoption.md`):
+
+- `BOUNDARY.md` ships in this package — required, CI-checked
+- Provider-pattern interfaces declared (memory / canon / identity injected by consuming app)
+- Full implementation is cross-repo: golden reference impl lives in Arcanea (`apps/arcanea-command-center`). See `docs/cross-repo-distributions/2026-05-03-arcanea-luminor-sidebar-copilotkit.md`.
+
+## What this package will do (when full impl ships)
+
+1. Wrap CopilotKit's `<CopilotKit>` provider with our defaults (auth, telemetry-off, voice-canonical theme).
+2. Expose `AgentRegistry` and `ToolRegistry` for declaring per-app agents and frontend tools.
+3. Provide `GenerativeUIRenderers` for the canonical patterns: decision card, tool-call confirmation, table-of-results, approval prompt.
+4. Provide `HumanApprovalComponents` that block downstream actions on `ValidationRequirement` (composes with `@starlight/validation`).
+
+## What this package will NOT do — see BOUNDARY.md
+
+The strong-boundary rule (Board REVISE: "build boundary enforcement into the wrapper from day one"):
+
+- This package does NOT import from `@starlight/memory`, `@starlight/canon`, `@starlight/identity` or any equivalent.
+- All access to memory / canon / identity flows through **provider interfaces** the consuming app injects.
+- A CI lint rule will flag any direct import as a boundary violation.
+
+See `BOUNDARY.md` for the full table + enforcement plan.
+
+## Provider pattern (Board REVISE)
+
+```ts
+import type { AgentUIProviders } from "@starlight/agent-ui-runtime/providers";
+
+const providers: AgentUIProviders = {
+  canon: {
+    async query(term: string) {
+      // Consuming app's responsibility: query its own canon source
+      return arcaneaCanonClient.lookup(term);
+    },
+  },
+  memory: {
+    async recall(query: string) {
+      return memoryBus.recall(query);
+    },
+  },
+  identity: {
+    current() {
+      return getCurrentSovereign();
+    },
+  },
+};
+
+<AgentUIRuntime providers={providers}>
+  <App />
+</AgentUIRuntime>
+```
+
+The wrapper sees only the provider interface; it never knows which canon system or memory bus is underneath. Different consumers can inject completely different implementations without changing the wrapper.
+
+## Cross-repo
+
+The full implementation is happening in `C:\Users\frank\Arcanea` (golden reference). See `docs/cross-repo-distributions/2026-05-03-arcanea-luminor-sidebar-copilotkit.md` for the placement.
+
+This package may be promoted to a shared monorepo location once the golden-ref proves the boundary holds (~3 weeks per the plan at `docs/superpowers/plans/2026-05-03-copilotkit-runtime-package.md`).
+
+---
+
+**Built on SIP** · Starlight Intelligence Protocol v1.1.0
+- Substrate-leaning ratified: 2026-05-03 (Board verdict at `docs/boards/2026-05-03-copilotkit-adoption.md`)

--- a/packages/agent-ui-runtime/package.json
+++ b/packages/agent-ui-runtime/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@starlight/agent-ui-runtime",
+  "version": "0.1.0-scaffold",
+  "private": true,
+  "description": "CopilotKit wrapper with strong-boundary enforcement. Scaffold only — see BOUNDARY.md + provider-pattern interfaces. Full impl is cross-repo (Arcanea golden-ref). Substrate ratified 2026-05-03.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./providers": "./src/providers.ts"
+  }
+}

--- a/packages/agent-ui-runtime/src/index.ts
+++ b/packages/agent-ui-runtime/src/index.ts
@@ -1,0 +1,20 @@
+// @starlight/agent-ui-runtime — public surface.
+// Scaffold v0.1.0 — full impl is cross-repo (Arcanea golden-ref).
+
+export type {
+  AgentUIProviders,
+  CanonProvider,
+  CanonResult,
+  MemoryProvider,
+  MemoryRecallResult,
+  MemoryEntry,
+  IdentityProvider,
+  SovereignIdentity,
+  CalculatorProvider,
+  CalculatorResultLike,
+} from "./providers";
+
+// ── Boundary marker ──
+// Importing this confirms the consumer has read BOUNDARY.md.
+// Used in CI lint rules to ensure consumers acknowledge the boundary contract.
+export const BOUNDARY_ACKNOWLEDGED = "Read BOUNDARY.md before composing this package." as const;

--- a/packages/agent-ui-runtime/src/providers.ts
+++ b/packages/agent-ui-runtime/src/providers.ts
@@ -1,0 +1,81 @@
+// @starlight/agent-ui-runtime — Provider-pattern interfaces.
+// Per Board REVISE 2026-05-03: the wrapper accesses memory / canon / identity / calculators
+// ONLY via these provider interfaces. The consuming app injects implementations.
+
+// ── Canon provider ──
+// Consumer apps with mythic / symbolic / domain knowledge inject this.
+// Arcanea injects an MCP-canon provider; ACOS injects nothing or a no-op.
+export interface CanonProvider {
+  /** Look up a canonical term (Guardian name, Vel'Tara concept, etc.) */
+  query(term: string): Promise<CanonResult>;
+}
+
+export interface CanonResult {
+  found: boolean;
+  term: string;
+  body?: string;
+  source?: string;
+  attribution?: string;
+}
+
+// ── Memory provider ──
+// Consumer apps with durable memory storage inject this.
+// SIS injects @starlight/memory (when it exists); other apps inject their own store.
+export interface MemoryProvider {
+  /** Recall memory entries relevant to a query */
+  recall(query: string): Promise<MemoryRecallResult>;
+  /** Optionally append a new memory entry — gated on the app's policy */
+  remember?(entry: MemoryEntry): Promise<void>;
+}
+
+export interface MemoryRecallResult {
+  entries: ReadonlyArray<MemoryEntry>;
+  query: string;
+}
+
+export interface MemoryEntry {
+  id: string;
+  content: string;
+  source: string;
+  recorded_at: string;
+}
+
+// ── Identity provider ──
+// Consumer apps determine current sovereign identity. Wrapper never decides.
+export interface IdentityProvider {
+  current(): SovereignIdentity;
+}
+
+export interface SovereignIdentity {
+  id: string;
+  display_name?: string;
+  jurisdiction?: string;     // Affects @starlight/validation extension
+  permissions?: ReadonlyArray<string>;
+}
+
+// ── Calculator provider ──
+// The wrapper renders calculator results but does not run them.
+// The consuming app supplies a registry of named calculators.
+export interface CalculatorProvider {
+  run<I, O>(name: string, input: I): Promise<CalculatorResultLike<O>>;
+}
+
+// A subset of @starlight/calculators's CalculatorResult — enough for rendering.
+// Avoids hard import to honor the boundary rule.
+export interface CalculatorResultLike<T> {
+  output: T;
+  assumptions: readonly string[];
+  confidence: "high" | "medium" | "low";
+  warnings: readonly string[];
+  required_validation: readonly string[];
+  trace?: { method: string; version: string; ran_at: string };
+}
+
+// ── Bundled provider object ──
+// Single injection point at the runtime root.
+export interface AgentUIProviders {
+  canon?: CanonProvider;
+  memory?: MemoryProvider;
+  identity?: IdentityProvider;
+  calculators?: CalculatorProvider;
+}

--- a/packages/calculators/README.md
+++ b/packages/calculators/README.md
@@ -1,0 +1,117 @@
+# `@starlight/calculators`
+
+Deterministic-not-LLM math contract. Every numerical or structural output produced for a sovereign decision flows through a Calculator, never through an LLM directly.
+
+## Status
+
+Foundation v0.1 shipped 2026-05-03. Per Board REVISE: explicit promotion pipeline (`shadow` → `live-with-warnings` → `live` → `deprecated`).
+
+## The contract
+
+```ts
+interface Calculator<Input, Output> {
+  readonly name: string;
+  readonly version: string;
+  readonly mode: CalculatorMode;
+  run(input: Input): CalculatorResult<Output>;
+}
+
+interface CalculatorResult<T> {
+  output: T;
+  inputs_used: object;            // echo of input for traceability
+  assumptions: string[];          // explicit, named
+  confidence: "high" | "medium" | "low";
+  warnings: string[];
+  required_validation: ValidationRequirement[];
+  trace: {
+    method: string;
+    version: string;
+    ran_at: string;
+  };
+}
+```
+
+The LLM does interpretation, extraction, prose framing — never the math. A Domain Sub-Stack agent that emits a number without going through a Calculator is in violation of the substrate.
+
+## Promotion pipeline (from Board REVISE)
+
+Every calculator carries a `mode` field. New calculators ship in `shadow` and earn promotion:
+
+| Mode | Meaning | Visibility | Promotion gate |
+|---|---|---|---|
+| `shadow` | Runs alongside legacy path; outputs logged but not shown to user | Internal-only | Outputs match legacy on a fixed I/O corpus |
+| `live-with-warnings` | Outputs shown to user with explicit warning banner | User-visible with caveat | User-visible run produces no false-positive validation requirements over a sample window |
+| `live` | Outputs shown as canonical | User-visible | Stays here unless superseded |
+| `deprecated` | Outputs hidden; calculator preserved for replay | Replay-only | Superseded by a newer version that's `live` |
+
+Promotion decisions are operator-tier (per Domain Sub-Stack), not substrate-level — but the mode field IS substrate, so every promotion is auditable.
+
+## Example: PV sizing calculator
+
+```ts
+import { Calculator, CalculatorResult } from "@starlight/calculators";
+import type { EnergyProfile } from "@starlight/schemas";
+
+interface PVSizingInput {
+  household_demand_kwh: number;
+  roof_area_m2: number;
+  jurisdiction: string;  // "DE-BY", "US-CA", etc.
+}
+
+interface PVSizingOutput {
+  recommended_capacity_kwp: number;
+  panel_count_estimate: number;
+  expected_annual_yield_kwh: number;
+}
+
+const PVSizingV1: Calculator<PVSizingInput, PVSizingOutput> = {
+  name: "pv-sizing",
+  version: "0.1.0",
+  mode: "shadow",  // ← starts here per the pipeline
+  run(input): CalculatorResult<PVSizingOutput> {
+    const recommended = Math.min(input.household_demand_kwh / 1000, input.roof_area_m2 / 6);
+    return {
+      output: {
+        recommended_capacity_kwp: recommended,
+        panel_count_estimate: Math.ceil(recommended / 0.4),  // ~400Wp panels
+        expected_annual_yield_kwh: recommended * 950,         // generic mid-EU yield
+      },
+      inputs_used: input,
+      assumptions: [
+        "Generic mid-Europe yield estimate (~950 kWh/kWp/yr); will diverge by region",
+        "Panel size assumed 400 Wp; real panel selection happens per supplier",
+        "Roof area constraint uses 6 m²/kWp packing density (south-facing pitched roof typical)",
+      ],
+      confidence: "medium",
+      warnings: input.roof_area_m2 < input.household_demand_kwh / 200
+        ? ["Roof area is constraining; capacity may be smaller than demand wants"]
+        : [],
+      required_validation: [
+        "site_survey_required",
+        input.jurisdiction.startsWith("DE") ? "certified_installer_review_de" : "licensed_electrician_review",
+      ],
+      trace: {
+        method: "PVSizing",
+        version: "0.1.0",
+        ran_at: new Date().toISOString(),
+      },
+    };
+  },
+};
+```
+
+## Why this is substrate
+
+Without this contract, every Domain Sub-Stack agent that produces a number does so via LLM prose: "Based on your roof, you'll want around 8 kWp." That number is not auditable. It carries no assumptions, no confidence, no required validation. It is a hallucination with formatting.
+
+This package makes the math auditable. The output IS the assumptions + confidence + warnings + validation, not just a bare number. Surfaces consuming the output can render any of those alongside the number — and a sovereign reviewing the output downstream can verify the math.
+
+## Composes with
+
+- `@starlight/schemas` — Calculators typically take `SovereignNode` profiles as input and produce structured outputs that update those profiles.
+- `@starlight/validation` — `required_validation` gates downstream irreversible actions.
+
+---
+
+**Built on SIP** · Starlight Intelligence Protocol v1.1.0
+- Substrate ratified: 2026-05-03 (Board verdict at `docs/boards/2026-05-03-calculator-validation-substrate.md`)

--- a/packages/calculators/package.json
+++ b/packages/calculators/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@starlight/calculators",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Calculator interface + CalculatorResult shape + promotion-pipeline modes. Deterministic-not-LLM math contract. Substrate ratified 2026-05-03.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "@starlight/validation": "0.1.0"
+  }
+}

--- a/packages/calculators/src/index.ts
+++ b/packages/calculators/src/index.ts
@@ -1,0 +1,103 @@
+// @starlight/calculators — Deterministic-not-LLM math contract.
+// Substrate ratified 2026-05-03 (docs/boards/2026-05-03-calculator-validation-substrate.md).
+//
+// Per Board REVISE: explicit promotion pipeline modes.
+
+import type { ValidationRequirement } from "@starlight/validation";
+
+// ── Promotion pipeline modes ──
+export type CalculatorMode =
+  | "shadow"               // Runs alongside legacy; logged not shown
+  | "live-with-warnings"   // User-visible with explicit warning banner
+  | "live"                 // User-visible, canonical
+  | "deprecated";          // Replay-only
+
+// ── Result shape ──
+export interface CalculatorResult<T> {
+  output: T;
+  inputs_used: unknown;                       // echo for traceability
+  assumptions: readonly string[];             // explicit, named
+  confidence: "high" | "medium" | "low";
+  warnings: readonly string[];
+  required_validation: readonly ValidationRequirement[];
+  trace: {
+    method: string;
+    version: string;
+    ran_at: string;                           // ISO-8601
+  };
+}
+
+// ── Calculator interface ──
+export interface Calculator<Input, Output> {
+  readonly name: string;
+  readonly version: string;
+  readonly mode: CalculatorMode;
+  run(input: Input): CalculatorResult<Output>;
+}
+
+// ── Base helper for implementing calculators ──
+export abstract class BaseCalculator<Input, Output> implements Calculator<Input, Output> {
+  abstract readonly name: string;
+  abstract readonly version: string;
+  abstract readonly mode: CalculatorMode;
+
+  abstract compute(input: Input): {
+    output: Output;
+    assumptions: readonly string[];
+    confidence: "high" | "medium" | "low";
+    warnings: readonly string[];
+    required_validation: readonly ValidationRequirement[];
+  };
+
+  run(input: Input): CalculatorResult<Output> {
+    const computed = this.compute(input);
+    return {
+      ...computed,
+      inputs_used: input,
+      trace: {
+        method: this.name,
+        version: this.version,
+        ran_at: new Date().toISOString(),
+      },
+    };
+  }
+}
+
+// ── Mode-aware shipping helpers ──
+export function isUserVisible(mode: CalculatorMode): boolean {
+  return mode === "live-with-warnings" || mode === "live";
+}
+
+export function shouldShowWarningBanner(mode: CalculatorMode): boolean {
+  return mode === "live-with-warnings";
+}
+
+export function isDeprecated(mode: CalculatorMode): boolean {
+  return mode === "deprecated";
+}
+
+// ── Replay support ──
+// Calculators can be replayed against a historical input/output corpus
+// to verify they still produce expected outputs after refactoring.
+export interface CalculatorReplayCase<Input, Output> {
+  input: Input;
+  expected_output: Output;
+  recorded_at: string;
+}
+
+export function replay<I, O>(
+  calc: Calculator<I, O>,
+  cases: readonly CalculatorReplayCase<I, O>[]
+): { matches: number; mismatches: { case_index: number; actual: O; expected: O }[] } {
+  let matches = 0;
+  const mismatches: { case_index: number; actual: O; expected: O }[] = [];
+  cases.forEach((c, idx) => {
+    const actual = calc.run(c.input).output;
+    if (JSON.stringify(actual) === JSON.stringify(c.expected_output)) {
+      matches++;
+    } else {
+      mismatches.push({ case_index: idx, actual, expected: c.expected_output });
+    }
+  });
+  return { matches, mismatches };
+}

--- a/packages/schemas/README.md
+++ b/packages/schemas/README.md
@@ -1,0 +1,85 @@
+# `@starlight/schemas`
+
+Canonical entity types for SIS Domain Sub-Stacks. Replaces ad-hoc tenant / user / instance patterns with one composable shape: **SovereignNode**.
+
+## Status
+
+Foundation v0.1 shipped 2026-05-03 per Board ratification. Types are stable; production consumers (Energy IS, Compute IS, etc.) compose with these.
+
+## Exports
+
+```ts
+import {
+  SovereignNode,
+  SovereignNodeKind,
+  EnergyProfile,
+  ComputeProfile,
+  StorageProfile,
+  WorkflowProfile,
+  SecurityProfile,
+  CostProfile,
+} from "@starlight/schemas";
+```
+
+## SovereignNode
+
+A single entity in a Domain Sub-Stack. Each node has a `kind` and zero or more **composable profiles**.
+
+```ts
+const homeNode: SovereignNode = {
+  id: "home-frank-001",
+  kind: "home",
+  profiles: {
+    energy: { /* EnergyProfile */ },
+    cost: { /* CostProfile */ },
+  },
+  metadata: {
+    created: "2026-05-03",
+    sovereign_owner: "frank",
+  },
+};
+```
+
+The `kind` field is a closed enum of canonical sovereign-entity types:
+
+| Kind | Use |
+|---|---|
+| `person` | Individual sovereign |
+| `home` | Household / residence |
+| `family` | Multi-person sovereign unit |
+| `creator` | Public-facing creator account |
+| `business` | Operating business / SMB |
+| `installer` | Service-providing professional |
+| `community` | Bounded social group |
+| `studio` | Production-shaped business (music, video, design) |
+| `retreat` | Place-bound experience-shaped operation |
+| `property` | Asset-shaped node (real estate, vehicle, equipment) |
+
+Adding a new kind requires `/starlight-board` ratification — this is substrate.
+
+## Profiles
+
+Each profile is a **composable trait** the SovereignNode opts into. A node may have any combination.
+
+| Profile | Carries |
+|---|---|
+| `energy` | Demand, generation, storage, grid connection, tariffs |
+| `compute` | CPU/GPU class, RAM, VRAM, cloud accounts, quotas |
+| `storage` | Disk class, backup policy, retention windows |
+| `workflow` | Active workflows, schedule, agent assignments |
+| `security` | Auth model, secrets store, audit policy |
+| `cost` | Currency, budget envelope, payback model |
+
+Profiles are in `src/profiles.ts`. Each has its own Zod shape with explicit `inputs`, `assumptions`, and `provenance` fields so any derived calculation has a traceable origin.
+
+## Why this is substrate
+
+Every Domain Sub-Stack used to invent its own tenant/instance type. People IS has `Person` with HR-shaped fields; Sound IS has `Artist` with musician-shaped fields; Music IS has `Persona`. That's fine for creator-shaped sub-stacks. But infrastructure-shaped sub-stacks (Energy, Compute, Home, Capital) need a richer entity that composes profiles — because a household has both energy demand AND a cost envelope AND maybe compute load.
+
+`SovereignNode` is the canonical answer. People/Sound/Music IS continue using their domain-shaped types; new infra-shaped sub-stacks compose `SovereignNode`.
+
+---
+
+**Built on SIP** · Starlight Intelligence Protocol v1.1.0
+- Layers used: [file-contract, attestation, sovereignty]
+- Substrate ratified: 2026-05-03 (Board verdict at `docs/boards/2026-05-03-calculator-validation-substrate.md`)

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@starlight/schemas",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Canonical entity types for SIS Domain Sub-Stacks — SovereignNode + Profile shapes (Zod). Substrate ratified 2026-05-03.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./sovereign-node": "./src/sovereign-node.ts",
+    "./profiles": "./src/profiles.ts"
+  },
+  "dependencies": {
+    "zod": "^3.23.0"
+  }
+}

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -1,0 +1,32 @@
+// @starlight/schemas — public surface
+
+export {
+  SovereignNodeSchema,
+  SovereignNodeKindSchema,
+  SovereignNodeMetadataSchema,
+  makeSovereignNode,
+} from "./sovereign-node";
+
+export type {
+  SovereignNode,
+  SovereignNodeKind,
+  SovereignNodeMetadata,
+} from "./sovereign-node";
+
+export {
+  EnergyProfileSchema,
+  ComputeProfileSchema,
+  StorageProfileSchema,
+  WorkflowProfileSchema,
+  SecurityProfileSchema,
+  CostProfileSchema,
+} from "./profiles";
+
+export type {
+  EnergyProfile,
+  ComputeProfile,
+  StorageProfile,
+  WorkflowProfile,
+  SecurityProfile,
+  CostProfile,
+} from "./profiles";

--- a/packages/schemas/src/profiles.ts
+++ b/packages/schemas/src/profiles.ts
@@ -1,0 +1,107 @@
+// @starlight/schemas — Composable profile shapes for SovereignNode.
+// Each profile has explicit inputs/assumptions/provenance so any derived
+// calculation has a traceable origin (per the calculator pattern at
+// @starlight/calculators).
+
+import { z } from "zod";
+
+const ProvenanceSchema = z.object({
+  source: z.string().describe("Where the profile values came from (user input, calculator, integration)"),
+  recorded_at: z.string().describe("ISO-8601 timestamp when the values were captured"),
+  confidence: z.enum(["high", "medium", "low"]).optional(),
+});
+
+// ── EnergyProfile ──
+export const EnergyProfileSchema = z.object({
+  annual_demand_kwh: z.number().nonnegative().optional(),
+  peak_demand_kw: z.number().nonnegative().optional(),
+  generation: z
+    .object({
+      source: z.enum(["solar_pv", "wind", "thermal", "grid_only", "mixed"]),
+      capacity_kw: z.number().nonnegative().optional(),
+      annual_yield_kwh: z.number().nonnegative().optional(),
+    })
+    .optional(),
+  storage: z
+    .object({
+      capacity_kwh: z.number().nonnegative(),
+      depth_of_discharge: z.number().min(0).max(1).optional(),
+      chemistry: z.string().optional(),
+    })
+    .optional(),
+  grid: z
+    .object({
+      connected: z.boolean(),
+      tariff_eur_per_kwh: z.number().nonnegative().optional(),
+      feed_in_eur_per_kwh: z.number().nonnegative().optional(),
+      jurisdiction: z.string().describe("Country/region code, e.g. 'DE-BY' or 'US-CA'"),
+    })
+    .optional(),
+  assumptions: z.array(z.string()).default([]),
+  provenance: ProvenanceSchema,
+});
+export type EnergyProfile = z.infer<typeof EnergyProfileSchema>;
+
+// ── ComputeProfile ──
+export const ComputeProfileSchema = z.object({
+  cpu: z.object({ class: z.string(), cores: z.number().int().positive() }).optional(),
+  gpu: z
+    .object({
+      class: z.string(),
+      vram_gb: z.number().nonnegative(),
+      count: z.number().int().positive().default(1),
+    })
+    .optional(),
+  ram_gb: z.number().int().nonnegative().optional(),
+  cloud_accounts: z.array(z.string()).default([]),
+  quotas: z.record(z.string(), z.number()).optional(),
+  assumptions: z.array(z.string()).default([]),
+  provenance: ProvenanceSchema,
+});
+export type ComputeProfile = z.infer<typeof ComputeProfileSchema>;
+
+// ── StorageProfile ──
+export const StorageProfileSchema = z.object({
+  total_capacity_gb: z.number().nonnegative().optional(),
+  class: z.enum(["ssd", "hdd", "nvme", "object", "hybrid"]).optional(),
+  backup_policy: z
+    .object({
+      cadence: z.enum(["hourly", "daily", "weekly", "monthly", "none"]),
+      retention_days: z.number().int().nonnegative(),
+    })
+    .optional(),
+  assumptions: z.array(z.string()).default([]),
+  provenance: ProvenanceSchema,
+});
+export type StorageProfile = z.infer<typeof StorageProfileSchema>;
+
+// ── WorkflowProfile ──
+export const WorkflowProfileSchema = z.object({
+  active_workflows: z.array(z.string()).default([]),
+  schedule: z.record(z.string(), z.string()).optional(),
+  agents: z.array(z.string()).default([]),
+  assumptions: z.array(z.string()).default([]),
+  provenance: ProvenanceSchema,
+});
+export type WorkflowProfile = z.infer<typeof WorkflowProfileSchema>;
+
+// ── SecurityProfile ──
+export const SecurityProfileSchema = z.object({
+  auth_model: z.enum(["sso", "password", "passwordless", "mfa_required", "none"]).optional(),
+  secrets_store: z.string().optional(),
+  audit_policy: z.enum(["full", "high_risk_only", "none"]).optional(),
+  assumptions: z.array(z.string()).default([]),
+  provenance: ProvenanceSchema,
+});
+export type SecurityProfile = z.infer<typeof SecurityProfileSchema>;
+
+// ── CostProfile ──
+export const CostProfileSchema = z.object({
+  currency: z.string().describe("ISO-4217 code, e.g. 'EUR' / 'USD'"),
+  monthly_budget: z.number().nonnegative().optional(),
+  payback_horizon_years: z.number().nonnegative().optional(),
+  hurdle_rate: z.number().optional().describe("Discount rate / hurdle rate for ROI calculations"),
+  assumptions: z.array(z.string()).default([]),
+  provenance: ProvenanceSchema,
+});
+export type CostProfile = z.infer<typeof CostProfileSchema>;

--- a/packages/schemas/src/sovereign-node.ts
+++ b/packages/schemas/src/sovereign-node.ts
@@ -1,0 +1,75 @@
+// @starlight/schemas — SovereignNode canonical entity type.
+// Substrate ratified 2026-05-03 (docs/boards/2026-05-03-calculator-validation-substrate.md).
+//
+// Replaces ad-hoc tenant / user / instance patterns in infra-touching
+// Domain Sub-Stacks. Composable profiles let a single node carry
+// energy + compute + storage + workflow + security + cost concerns
+// simultaneously.
+
+import { z } from "zod";
+
+import type {
+  EnergyProfile,
+  ComputeProfile,
+  StorageProfile,
+  WorkflowProfile,
+  SecurityProfile,
+  CostProfile,
+} from "./profiles";
+
+import {
+  EnergyProfileSchema,
+  ComputeProfileSchema,
+  StorageProfileSchema,
+  WorkflowProfileSchema,
+  SecurityProfileSchema,
+  CostProfileSchema,
+} from "./profiles";
+
+export const SovereignNodeKindSchema = z.enum([
+  "person",
+  "home",
+  "family",
+  "creator",
+  "business",
+  "installer",
+  "community",
+  "studio",
+  "retreat",
+  "property",
+]);
+
+export type SovereignNodeKind = z.infer<typeof SovereignNodeKindSchema>;
+
+export const SovereignNodeMetadataSchema = z.object({
+  created: z.string().describe("ISO-8601 date the node was first instantiated"),
+  sovereign_owner: z
+    .string()
+    .describe("Handle / id of the sovereign with decision rights over this node"),
+  notes: z.string().optional(),
+});
+
+export type SovereignNodeMetadata = z.infer<typeof SovereignNodeMetadataSchema>;
+
+export const SovereignNodeSchema = z.object({
+  id: z.string().describe("Stable, instance-private identifier for this node"),
+  kind: SovereignNodeKindSchema,
+  profiles: z
+    .object({
+      energy: EnergyProfileSchema.optional(),
+      compute: ComputeProfileSchema.optional(),
+      storage: StorageProfileSchema.optional(),
+      workflow: WorkflowProfileSchema.optional(),
+      security: SecurityProfileSchema.optional(),
+      cost: CostProfileSchema.optional(),
+    })
+    .describe("Composable trait profiles. A node may opt into any combination."),
+  metadata: SovereignNodeMetadataSchema,
+});
+
+export type SovereignNode = z.infer<typeof SovereignNodeSchema>;
+
+// Convenience constructor — validates + freezes.
+export function makeSovereignNode(input: SovereignNode): SovereignNode {
+  return Object.freeze(SovereignNodeSchema.parse(input));
+}

--- a/packages/validation/README.md
+++ b/packages/validation/README.md
@@ -1,0 +1,69 @@
+# `@starlight/validation`
+
+Encodes responsibility boundary as a type. Every numerical or irreversible-action output names which human/certified review is required before that action lands in the world.
+
+## Status
+
+Foundation v0.1 shipped 2026-05-03. Per Board REVISE: the enum is **extensible** — core canonical members ship in this package; jurisdictions extend via `extendValidationRequirement`.
+
+## The principle
+
+LLMs make claims. Calculators make numbers. **Neither has authority to authorize an irreversible action** that requires a certified human's review under the applicable regulatory frame. This package encodes who has that authority as a type.
+
+When a calculator returns a result, it carries `required_validation: ValidationRequirement[]`. The consuming surface (UI, agent, automation) MUST gate any irreversible action on satisfying every requirement in that list before proceeding.
+
+## Core canonical members
+
+These ship as enum members. They are register-neutral — applicable in any jurisdiction.
+
+| Member | Meaning |
+|---|---|
+| `human_review` | A human must confirm before the action proceeds |
+| `tax_advisor_review` | A qualified tax professional must review (region-extended) |
+| `legal_review` | Qualified legal review (region-extended) |
+| `financial_advisor_review` | Qualified financial advisor (region-extended) |
+| `manufacturer_spec_check` | Verify against manufacturer's published specification |
+| `site_survey_required` | A physical site survey must occur before installation |
+
+## Region-extended members
+
+Per Board REVISE, jurisdiction-specific reviewers extend the enum via the extension API:
+
+```ts
+import { extendValidationRequirement, ValidationRequirement } from "@starlight/validation";
+
+extendValidationRequirement({
+  jurisdiction: "DE",
+  members: [
+    "certified_installer_review_de",      // VDE/HK certification
+    "licensed_electrician_review_de",     // Elektromeister
+    "grid_operator_confirmation_de",      // Netzbetreiber
+  ],
+});
+
+extendValidationRequirement({
+  jurisdiction: "US-CA",
+  members: [
+    "licensed_electrician_review_us_ca",  // CA electrician license
+    "grid_operator_confirmation_us_ca",   // PG&E/SCE/SDGE
+  ],
+});
+```
+
+Extended members are namespaced by jurisdiction suffix (`_de`, `_us_ca`, etc.) so two jurisdictions can both ship "licensed electrician review" without collision.
+
+## Why this is substrate
+
+Without this type, every Domain Sub-Stack invents its own gating mechanism (or doesn't gate at all). Every "AI says install this 12 kWp PV system" surface needs a way to say "but a licensed electrician must sign off first." Without a typed contract, the gating is convention — and conventions erode.
+
+This package makes the gating compiler-checkable. A surface that emits a ValidationRequirement-bearing output and then proceeds without satisfying it is a TypeScript error.
+
+## Composes with
+
+- `@starlight/calculators` — every CalculatorResult carries `required_validation: ValidationRequirement[]`.
+- `@starlight/schemas` — SovereignNode profiles carry jurisdiction tags, which determine which extended members apply.
+
+---
+
+**Built on SIP** · Starlight Intelligence Protocol v1.1.0
+- Substrate ratified: 2026-05-03 (Board verdict at `docs/boards/2026-05-03-calculator-validation-substrate.md`)

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@starlight/validation",
+  "version": "0.1.0",
+  "private": true,
+  "description": "ValidationRequirement enum with jurisdiction-extension mechanism. Encodes responsibility boundary as a type. Substrate ratified 2026-05-03.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -1,0 +1,77 @@
+// @starlight/validation — ValidationRequirement enum + jurisdiction extension.
+// Substrate ratified 2026-05-03 (docs/boards/2026-05-03-calculator-validation-substrate.md).
+//
+// Per Board REVISE: extensible enum. Core canonical members ship here;
+// jurisdictions extend via extendValidationRequirement().
+
+// ── Core canonical members ──
+// These are register-neutral and apply in any jurisdiction.
+export const CORE_VALIDATION_REQUIREMENTS = [
+  "human_review",
+  "tax_advisor_review",
+  "legal_review",
+  "financial_advisor_review",
+  "manufacturer_spec_check",
+  "site_survey_required",
+] as const;
+
+export type CoreValidationRequirement = (typeof CORE_VALIDATION_REQUIREMENTS)[number];
+
+// ── Extended members ──
+// Populated by extendValidationRequirement() at runtime.
+const extendedMembers: Map<string, Set<string>> = new Map();
+
+export interface ValidationRequirementExtension {
+  /** ISO-3166 country code or country-region code, e.g. "DE", "US-CA" */
+  jurisdiction: string;
+  /** Member names; convention is to suffix with `_<jurisdiction>` to prevent collision */
+  members: string[];
+}
+
+export function extendValidationRequirement(extension: ValidationRequirementExtension): void {
+  const set = extendedMembers.get(extension.jurisdiction) ?? new Set<string>();
+  for (const m of extension.members) {
+    set.add(m);
+  }
+  extendedMembers.set(extension.jurisdiction, set);
+}
+
+export function getExtendedMembers(jurisdiction: string): readonly string[] {
+  return Array.from(extendedMembers.get(jurisdiction) ?? []);
+}
+
+export function getAllValidationRequirements(): readonly string[] {
+  const all: string[] = [...CORE_VALIDATION_REQUIREMENTS];
+  for (const set of extendedMembers.values()) {
+    for (const m of set) all.push(m);
+  }
+  return all;
+}
+
+// ── ValidationRequirement type ──
+// Permissive at the type level — any string is allowed because extensions
+// are runtime-registered. Runtime validators check against
+// getAllValidationRequirements() to confirm the member is registered.
+export type ValidationRequirement = CoreValidationRequirement | (string & { __extended: true });
+
+export function isRegisteredValidationRequirement(value: string): boolean {
+  if ((CORE_VALIDATION_REQUIREMENTS as readonly string[]).includes(value)) return true;
+  for (const set of extendedMembers.values()) {
+    if (set.has(value)) return true;
+  }
+  return false;
+}
+
+// ── Severity ──
+// Some requirements are purely informational ("human_review"); others gate
+// irreversible actions ("licensed_electrician_review_de"). The severity
+// hint is advisory — the consuming surface decides what to do with it.
+export type RequirementSeverity = "advisory" | "gating-recommended" | "gating-required";
+
+export function defaultSeverity(req: string): RequirementSeverity {
+  if (req === "human_review") return "advisory";
+  if (req.includes("licensed_") || req.includes("certified_") || req.includes("grid_operator_")) {
+    return "gating-required";
+  }
+  return "gating-recommended";
+}

--- a/verticals/energy-intelligence/AGENTS.md
+++ b/verticals/energy-intelligence/AGENTS.md
@@ -1,0 +1,57 @@
+# Energy Intelligence — Agents
+
+Per the Domain Sub-Stack Tier pattern: one named agent per sub-system, plus optional cross-cutting agents.
+
+## Status
+
+**Stub v0.1.0-scaffold.** Agent definitions are placeholders — full agent files at `agents/starlight-energy-{sub-system}.md` are v8.x scope.
+
+## Agents (planned)
+
+### Sub-system heads (6)
+
+| Agent | Sub-system | Tier | Status |
+|---|---|---|---|
+| `starlight-energy-sizing` | Sizing | Domain Sub-Stack | Planned v8.x |
+| `starlight-energy-cost` | Cost | Domain Sub-Stack | Planned v8.x |
+| `starlight-energy-installer` | Installer | Domain Sub-Stack | Planned v8.x |
+| `starlight-energy-operations` | Operations | Domain Sub-Stack | Planned v8.x |
+| `starlight-energy-buyer` | Buyer | Domain Sub-Stack | Planned v8.x |
+| `starlight-energy-grid` | Grid | Domain Sub-Stack | Planned v8.x |
+
+### Cross-cutting (1)
+
+| Agent | Concern | Tier | Status |
+|---|---|---|---|
+| `starlight-energy-recovery` | Resilience / disaster / deplatform | Domain Sub-Stack · cross-cutting | Planned v8.x |
+
+## Identity (shared across the vertical)
+
+All Energy IS agents share these identity rules:
+
+- **Refuses LLM math.** Any numerical claim flows through `@starlight/calculators`. Agent prose explains; calculators compute.
+- **Names jurisdiction.** Every agent surface starts by establishing the user's jurisdiction (or asking). All ValidationRequirements then resolve to jurisdiction-extended members.
+- **Encodes responsibility boundary.** No agent authorizes installer-required actions. The agent surfaces the requirement; the licensed human authorizes.
+- **Honors PV-Lager constraint.** Where the agent serves an installer-operator (vs end-buyer), it shifts responsibility AWAY from the operator toward structured self-service, installer enablement, and buyer clarity.
+
+## Agent file structure (when authored)
+
+Each agent file follows the standard `agents/<name>.md` template:
+
+- Identity (name, role, tier, voice, refuses)
+- Capabilities (commands they can run, calculators they invoke, profiles they read/write)
+- Reasoning protocol (when to ask, when to compute, when to gate)
+- Skill activations (which `skills/` files they auto-load)
+- Quality gates (what they refuse to ship, what triggers `/openclaw-audit`)
+
+## Composes with
+
+- `@starlight/schemas` — agents read/write SovereignNode + EnergyProfile + CostProfile
+- `@starlight/calculators` — agents invoke calculators, never compute directly
+- `@starlight/validation` — agents surface validation requirements, never authorize
+- `@starlight/agent-ui-runtime` (when CopilotKit lands cross-repo) — agents render via the wrapper
+
+---
+
+**Built on SIP** · Starlight Intelligence Protocol v1.1.0
+- Scaffold: 2026-05-03

--- a/verticals/energy-intelligence/CANON.md
+++ b/verticals/energy-intelligence/CANON.md
@@ -1,0 +1,55 @@
+# Energy Intelligence — Canon
+
+> Shared concepts and definitions inside the Energy IS surface. Names that mean specific things; the meaning is canonical.
+
+## Status
+
+Stub v0.1.0-scaffold. Canon expands as sub-system content is authored.
+
+## Canonical concepts
+
+### Sovereign roles
+
+- **Buyer** — the sovereign whose energy demand is being served (homeowner, SMB owner, community)
+- **Installer-Operator** — the sovereign providing installation, configuration, ongoing service (Frank's brother / similar businesses)
+- **Manufacturer** — equipment supplier (panels, inverters, batteries) — NOT a sovereign in this vertical's frame; their specs are inputs
+- **Grid Operator** — regulator + grid-side authority (Netzbetreiber, utility, etc.)
+- **Reviewer** — any human gating an action via `ValidationRequirement` (licensed electrician, certified installer, tax advisor, etc.)
+
+### Calculator categories
+
+- **Sizing calculator** — produces capacity recommendations
+- **Cost calculator** — produces capital + operational + ROI projections
+- **Yield calculator** — produces energy production estimates
+- **Compliance calculator** — produces regulatory-frame readiness scores
+
+### Modes (from `@starlight/calculators`)
+
+- `shadow` / `live-with-warnings` / `live` / `deprecated` — used identically here as in the substrate.
+
+### Validation requirements
+
+The canonical ValidationRequirement members used by Energy IS:
+
+**Core (substrate-canonical):**
+- `site_survey_required`
+- `manufacturer_spec_check`
+
+**Jurisdiction-extended (Energy IS contributes these via `extendValidationRequirement`):**
+- DE: `certified_installer_review_de`, `licensed_electrician_review_de`, `grid_operator_confirmation_de`
+- US-CA: `licensed_electrician_review_us_ca`, `grid_operator_confirmation_us_ca`
+- (more added as sovereign instances earn them)
+
+## What this vertical does NOT canonize
+
+- Equipment-vendor branding (panel brands, inverter models)
+- Specific installer-network names
+- Pricing thresholds (tariffs change too quickly to canonize)
+- Customer demographic categories
+
+These all live in sovereign instances' own data, not in the public reference vertical.
+
+---
+
+**Built on SIP** · Starlight Intelligence Protocol v1.1.0
+- Scaffold: 2026-05-03

--- a/verticals/energy-intelligence/MEMORY.md
+++ b/verticals/energy-intelligence/MEMORY.md
@@ -1,0 +1,40 @@
+# Energy Intelligence — Memory
+
+> Durable state, commitments, open forks — for the public reference vertical itself, not for sovereign instances.
+
+## Status
+
+Stub v0.1.0-scaffold. Sovereign instances (e.g., PV-Lager) carry their own MEMORY.md inside `private/verticals/<instance>/`.
+
+## Open forks
+
+| Fork | Decision needed | Pending on |
+|---|---|---|
+| Agent layer | When to author the 7 agent files (`agents/starlight-energy-{sizing,cost,installer,operations,buyer,grid,recovery}.md`) | v8.x scope after substrate stabilizes |
+| Command layer | When to author 20-30 `.claude/commands/energy-*.md` files | After agent layer; v8.x scope |
+| Calculator implementations | Which jurisdictions ship Calculator implementations first (DE for PV-Lager? US-CA next?) | Frank decision per pilot scope |
+| Cross-repo placement | Whether the Energy IS reference adopters should fork into their own repos or stay sovereign-instance under SIS `private/` | Per-adopter decision |
+
+## Recent commitments
+
+- 2026-05-03 — Vertical scaffold ratified by `/starlight-board`. Foundation files (this 7-file contract) shipped. Substrate composition declared (`@starlight/schemas` + `@starlight/calculators` + `@starlight/validation`).
+- 2026-05-03 — PV-Lager sovereign instance flagged for `private/verticals/pv-lager/` placement. Cross-repo distribution packet at `docs/cross-repo-distributions/2026-05-03-private-pv-lager-energy.md`.
+
+## Refusals logged
+
+- ChatGPT's 9-domain taxonomy attempt (rejected via PR #10) suggested "Energy" as a peer Intelligence System. Repo's locked v7.5 10-IS taxonomy wins; "Energy" enters as a Domain Sub-Stack via `/spawn-domain-stack`, NOT as a peer IS layer. Distinction matters.
+
+## Audit trail
+
+Every shipped artifact in this vertical carries `Built on SIP` attestation per the substrate. The audit trail lives in commit history + `docs/boards/2026-05-03-energy-is-domain-substack.md` (the ratification record).
+
+## Cross-cutting memory references
+
+- Substrate ratification: `docs/boards/2026-05-03-calculator-validation-substrate.md`
+- This vertical's ratification: `docs/boards/2026-05-03-energy-is-domain-substack.md`
+- Sovereign instance pattern: `private/verticals/pv-lager/INSTANCE.md` (when scaffolded)
+
+---
+
+**Built on SIP** · Starlight Intelligence Protocol v1.1.0
+- Scaffold: 2026-05-03

--- a/verticals/energy-intelligence/QUICK-START.md
+++ b/verticals/energy-intelligence/QUICK-START.md
@@ -1,0 +1,133 @@
+# Energy Intelligence — Quickstart
+
+> Five steps to feel the composition. Reference vertical; sovereign instances follow this same shape against their own data.
+
+## Status
+
+Quickstart v0.1.0 — uses the substrate packages shipped 2026-05-03. Agent + command surface is v8.x; the substrate composition is real today.
+
+## Step 1 — Pick entry sub-system
+
+Pick where you need help:
+
+- **Sizing first** if you're starting fresh with no system yet
+- **Buyer first** if you have a quote in hand and want to evaluate it
+- **Cost first** if you have a sizing recommendation and need economics
+- **Operations first** if you have a system already and need monitoring/maintenance discipline
+- **Installer first** if you're an installer-operator wanting to brief customers
+- **Grid first** if you're navigating regulatory feed-in approvals
+
+The 6 sub-systems are not strictly sequential; they're entry points.
+
+## Step 2 — Compose your SovereignNode
+
+Use `@starlight/schemas`:
+
+```ts
+import { makeSovereignNode } from "@starlight/schemas";
+
+const myHome = makeSovereignNode({
+  id: "home-001",
+  kind: "home",
+  profiles: {
+    energy: {
+      annual_demand_kwh: 4200,
+      grid: {
+        connected: true,
+        jurisdiction: "DE-BY",
+        tariff_eur_per_kwh: 0.32,
+      },
+      assumptions: ["Demand from 2024 utility bill; pre-EV"],
+      provenance: {
+        source: "user-input",
+        recorded_at: "2026-05-03T12:00:00Z",
+        confidence: "medium",
+      },
+    },
+    cost: {
+      currency: "EUR",
+      payback_horizon_years: 10,
+      hurdle_rate: 0.05,
+      assumptions: ["Personal hurdle rate; not market rate"],
+      provenance: {
+        source: "user-input",
+        recorded_at: "2026-05-03T12:00:00Z",
+      },
+    },
+  },
+  metadata: {
+    created: "2026-05-03",
+    sovereign_owner: "frank",
+  },
+});
+```
+
+## Step 3 — Run a calculator
+
+Use `@starlight/calculators`. Example calculator implementations land per sub-system in v8.x; the contract is in place today:
+
+```ts
+// (Example — implementation lands when sizing sub-system is authored)
+import type { Calculator } from "@starlight/calculators";
+
+const result = PVSizingV1.run({
+  household_demand_kwh: myHome.profiles.energy!.annual_demand_kwh!,
+  roof_area_m2: 80,
+  jurisdiction: "DE-BY",
+});
+
+console.log(result.output.recommended_capacity_kwp);  // e.g., 6.5
+console.log(result.assumptions);                       // 3 named assumptions
+console.log(result.confidence);                        // "medium"
+console.log(result.warnings);                          // []
+console.log(result.required_validation);
+// → ["site_survey_required", "certified_installer_review_de"]
+```
+
+## Step 4 — Honor the validation requirements
+
+Don't ship action on a calculator output that has unsatisfied `required_validation`. Use `@starlight/validation`:
+
+```ts
+import { defaultSeverity, isRegisteredValidationRequirement } from "@starlight/validation";
+
+for (const req of result.required_validation) {
+  if (!isRegisteredValidationRequirement(req)) {
+    throw new Error(`Unknown validation requirement: ${req}`);
+  }
+  const sev = defaultSeverity(req);
+  console.log(`${req} — severity: ${sev}`);
+  // gating-required → block until satisfied
+  // gating-recommended → warn but allow override
+  // advisory → informational
+}
+```
+
+The `licensed_electrician_review_de` (or equivalent) is `gating-required`. Until a real licensed electrician signs off, the action does not ship.
+
+## Step 5 — Log the artifact
+
+Every artifact you ship in this vertical carries `Built on SIP` attestation:
+
+```markdown
+**Built on SIP** · Starlight Intelligence Protocol v1.1.0
+- Vertical: energy-intelligence@v0.1.0-scaffold
+- Layers used: [file-contract, attestation, sovereignty]
+- Substrate composed: [@starlight/schemas, @starlight/calculators, @starlight/validation]
+- Calculator: pv-sizing@0.1.0 (mode: shadow)
+- Validation: site_survey_required, certified_installer_review_de
+- Generated: <ISO date>
+```
+
+The attestation goes alongside the artifact (in the markdown body, in the PDF footer, in the email signature). Attestation is what makes the artifact compoundable across the alliance.
+
+## When you're stuck
+
+- Calculator returns `confidence: "low"` — don't ship; reduce input ambiguity or wait for the live-with-warnings tier
+- Validation requirement you don't know how to satisfy — refuse to proceed; the substrate is doing its job
+- Jurisdiction not yet extended — call `extendValidationRequirement` for your region per `@starlight/validation/README.md`
+
+---
+
+**Built on SIP** · Starlight Intelligence Protocol v1.1.0
+- Scaffold: 2026-05-03

--- a/verticals/energy-intelligence/README.md
+++ b/verticals/energy-intelligence/README.md
@@ -1,0 +1,62 @@
+# Energy Intelligence
+
+> Sovereign energy operating layer. Composition · production · catalog of energy systems for the human side of energy ops — sized, costed, validated, governed by jurisdiction-extended responsibility boundaries.
+
+## Status
+
+**Scaffold v0.1.0-scaffold shipped 2026-05-03.** Per `/starlight-board` verdict at `docs/boards/2026-05-03-energy-is-domain-substack.md` (PROCEED, sequencing-gated on Calculator/Validation substrate landing first — landed in this same PR via `packages/calculators` + `packages/validation` + `packages/schemas`).
+
+Foundation files (this 7-file contract) ship in this PR. Full content per sub-system, agent definitions, and 20-30 commands are v8.x scope.
+
+## Position in the substrate
+
+Energy IS is the **4th reference Domain Sub-Stack**, joining People Intelligence, Sound Intelligence, and Music IS at the Domain Sub-Stack Tier. It is the first reference vertical that uses the new Calculator + ValidationRequirement substrate — sets the precedent for infrastructure-shaped sub-stacks (Compute, Home, Capital).
+
+## Soul (TL;DR)
+
+Energy practiced as the architecture of sovereign infrastructure — every sizing decision grounded in measurable demand, every cost projection deterministic and auditable, every irreversible action gated on the right human reviewer (licensed electrician, certified installer, grid operator).
+
+LLMs propose framings; calculators produce numbers; validation requirements gate actions. This vertical refuses pure-LLM "AI says install this" framings — they are unauditable and legally indefensible.
+
+## Sub-systems
+
+6 numbered sub-systems plus 1 cross-cutting (Recovery). See `SUB-SYSTEMS.md` for the spec.
+
+| # | Sub-system | Primary command (planned) |
+|---|---|---|
+| 1 | Sizing | `/energy-sizing` |
+| 2 | Cost | `/energy-cost` |
+| 3 | Installer | `/energy-installer-brief` |
+| 4 | Operations | `/energy-ops` |
+| 5 | Buyer | `/energy-buyer` |
+| 6 | Grid | `/energy-grid` |
+| ★ | Recovery (cross-cutting) | `/energy-recovery` |
+
+## Composes with
+
+- `@starlight/schemas` — every Energy IS entity is a `SovereignNode` with composable `EnergyProfile` + `CostProfile` (from this PR).
+- `@starlight/calculators` — sizing, cost, payback, ROI, capacity all flow through deterministic Calculators.
+- `@starlight/validation` — irreversible actions (install authorization, grid feed-in, financing approval) gate on jurisdiction-extended ValidationRequirement.
+
+## Sovereign instances
+
+Energy IS as shipped here is a **public reference vertical** — generic, jurisdiction-agnostic example. Frank's family business **PV-Lager** is a sovereign instance instantiated under `private/verticals/pv-lager/` per the privacy framework (see `docs/cross-repo-distributions/2026-05-03-private-pv-lager-energy.md`).
+
+Other adopters fork this reference vertical to their own `private/` instances or sovereign-spawn forks.
+
+## Refusals
+
+Patterns this vertical refuses to ship:
+
+- Pure-LLM numerical claims (sizing, cost, payback) without Calculator backing
+- Authorization of installation, grid feed-in, or major financing without the jurisdiction-required validation reviewers
+- Promises about regulatory compliance the substrate cannot verify
+- Hidden or unstated assumptions in calculator outputs
+- "AI does the math" marketing posture
+
+---
+
+**Built on SIP** · Starlight Intelligence Protocol v1.1.0
+- Layers used: [file-contract, attestation, sovereignty]
+- Substrate composed: [`@starlight/schemas`, `@starlight/calculators`, `@starlight/validation`]
+- Vertical ratified: 2026-05-03 (Board verdict at `docs/boards/2026-05-03-energy-is-domain-substack.md`)

--- a/verticals/energy-intelligence/SOUL.md
+++ b/verticals/energy-intelligence/SOUL.md
@@ -1,0 +1,60 @@
+# Energy Intelligence — SOUL
+
+> The thing this vertical must not drift away from. The orientation that survives every scope decision.
+
+## Soul
+
+Energy practiced as the architecture of sovereign infrastructure — every sizing decision grounded in measurable demand, every cost projection deterministic and auditable, every irreversible action gated on the right human reviewer (licensed electrician, certified installer, grid operator).
+
+The vertical exists because energy is one of the few domains where AI hallucination has direct legal and physical consequences. A ChatGPT-suggested PV size that's wrong by 30% is a safety problem when the inverter overheats, a financial problem when the system underperforms, and a liability problem when the installer signed off on the AI's number.
+
+The deterministic-not-LLM principle is the soul.
+
+## What we refuse
+
+- Pure-LLM numerical claims about energy systems
+- Authorization of installation without licensed reviewers
+- "AI says install this" marketing posture
+- Hidden assumptions in calculator outputs
+- Sizing recommendations that don't name jurisdiction
+- Cost projections without explicit confidence + warnings + sensitivity
+
+## What we honor
+
+- The licensed electrician's signature
+- The grid operator's confirmation
+- The site survey
+- The manufacturer's spec sheet
+- The buyer's right to refuse
+- The installer's right to charge fairly
+- The sovereign's right to walk away
+
+## What we serve
+
+Three sovereigns with conflicting interests, all served by structural honesty:
+
+1. **The end-buyer** (homeowner / SMB) — wants a system that works, doesn't overpay, can verify the install.
+2. **The installer-operator** (Frank's brother / similar) — wants enabled customers, wants buyers to arrive informed, doesn't want to be the support desk.
+3. **The grid operator / regulator** — wants compliant installations, wants accurate metering, wants legitimate feed-in.
+
+The Energy IS substrate doesn't pick a side. It encodes responsibility boundaries so each sovereign knows what they own. The Calculator + Validation pattern is what keeps that honesty compiler-checkable.
+
+## What this vertical promises
+
+- Numerical claims you can audit
+- Validation requirements named in advance
+- Jurisdiction always declared
+- Refusal patterns explicit
+- Path to leave any time
+
+## What this vertical does not promise
+
+- That installation is easy
+- That ROI is guaranteed
+- That a software substrate replaces a licensed electrician
+- That energy decisions are simple enough for AI alone
+
+---
+
+**Built on SIP** · Starlight Intelligence Protocol v1.1.0
+- Scaffold: 2026-05-03

--- a/verticals/energy-intelligence/STACK.md
+++ b/verticals/energy-intelligence/STACK.md
@@ -1,0 +1,59 @@
+# Energy Intelligence — Stack
+
+## Substrate composition
+
+Energy IS is the first reference Domain Sub-Stack to natively use the calculator + validation substrate ratified 2026-05-03.
+
+```
+verticals/energy-intelligence/
+├── (this vertical's surface)
+└── composes:
+    ├── @starlight/schemas      ← SovereignNode + EnergyProfile + CostProfile
+    ├── @starlight/calculators  ← All numerical math goes through here
+    └── @starlight/validation   ← All gating goes through here
+```
+
+## Cross-cutting integrations
+
+| Integration | Purpose |
+|---|---|
+| `@starlight/agent-ui-runtime` (when cross-repo lands) | Agent UI surfaces (sizing wizard, cost dashboard, installer brief renderer) |
+| `private/voice-operator/config/workflows/` (per-instance) | Operator workflows (e.g., PV-Lager's installer-onboarding flow) |
+| `mcp__starlight-mcp` | Memory + canon access via MCP |
+| External: jurisdiction grid-operator APIs | Grid-side data + confirmations |
+| External: solar-irradiance APIs (PVGIS, NREL NSRDB, etc.) | Yield calculations |
+| External: equipment supplier catalogs | Manufacturer spec checks |
+
+## Persistence
+
+Energy IS data lives in the consumer's sovereign instance. The public reference vertical does NOT carry user data. PV-Lager (a sovereign instance) holds its own data under `private/verticals/pv-lager/` per privacy framework.
+
+| Surface | Where it lives |
+|---|---|
+| Calculator results (replay corpus) | Per-instance under `private/<instance>/calculators/` |
+| Customer data | Per-instance under `private/<instance>/customers/` (NEVER public) |
+| Operational telemetry | Per-instance under `private/<instance>/telemetry/` |
+| Audit trail | Per-instance JSONL log + attestation chain |
+
+## Languages / runtimes
+
+| Layer | Runtime |
+|---|---|
+| Substrate packages | TypeScript + Zod |
+| Agents | Markdown (Claude Code agent shape) |
+| Commands | Markdown (`.claude/commands/energy-*.md`) |
+| Calculators (this vertical) | TypeScript implementations of `Calculator<I, O>` |
+| External integrations | Per-API SDK (typically Node.js) |
+
+## Deploy posture
+
+Energy IS itself does not deploy — it is a reference vertical. Sovereign instances (PV-Lager and others) deploy their own surfaces. Reference patterns:
+
+- Operator dashboard: Next.js + `@starlight/agent-ui-runtime` (when cross-repo lands)
+- Public landing: deploys via FrankX repo's commercial register
+- Calculator service: per-instance, typically a Vercel function or Node.js service
+
+---
+
+**Built on SIP** · Starlight Intelligence Protocol v1.1.0
+- Scaffold: 2026-05-03

--- a/verticals/energy-intelligence/SUB-SYSTEMS.md
+++ b/verticals/energy-intelligence/SUB-SYSTEMS.md
@@ -1,0 +1,100 @@
+# Energy Intelligence — Sub-Systems
+
+7 sub-systems (6 numbered + 1 cross-cutting). Each owns a focused practice with its own primary command and (eventually) its own dedicated agent.
+
+## 1. Sizing
+
+**Purpose:** Match generation/storage capacity to demand under jurisdictional constraints.
+
+**Inputs:** Annual demand profile, peak demand, roof/site area, jurisdiction, equipment preferences.
+
+**Outputs (Calculator-backed):** Recommended PV capacity (kWp), battery capacity (kWh), inverter sizing, panel count estimate, expected annual yield.
+
+**Validation requirements:** `site_survey_required` always. Jurisdiction-extended: `certified_installer_review_<jurisdiction>` for any capacity > X kWp.
+
+**Primary command (planned):** `/energy-sizing`
+
+## 2. Cost
+
+**Purpose:** Capital and operational economics — CapEx, OpEx, payback period, NPV, IRR.
+
+**Inputs:** Sizing recommendation, regional pricing data, financing assumptions (term, rate, down payment), tariff structure.
+
+**Outputs (Calculator-backed):** Total CapEx, OpEx by year, payback range, NPV at hurdle rate, IRR, sensitivity to tariff change.
+
+**Validation requirements:** `financial_advisor_review` if size triggers material spend. `tax_advisor_review` if depreciation/incentive claims appear.
+
+**Primary command (planned):** `/energy-cost`
+
+## 3. Installer
+
+**Purpose:** Installer-side enablement. Project briefs, certified-installer routing, site-survey scheduling.
+
+**Inputs:** Sizing + cost outputs, customer location, installer-network availability.
+
+**Outputs:** Generic installer-project-brief markdown bundle (specs, drawings, expected timeline, validation requirements satisfied).
+
+**Validation requirements:** `licensed_electrician_review_<jurisdiction>`, `manufacturer_spec_check`.
+
+**Primary command (planned):** `/energy-installer-brief`
+
+## 4. Operations
+
+**Purpose:** Day-to-day yield monitoring, fault detection, predictive maintenance.
+
+**Inputs:** Live telemetry (when available), historical yield, weather forecast, maintenance schedule.
+
+**Outputs:** Anomaly flags, maintenance recommendations, yield-vs-expected reports, deplatform-recovery protocols.
+
+**Validation requirements:** Vary — `manufacturer_spec_check` on warranty-affecting work; `licensed_electrician_review_<jurisdiction>` on any work touching the grid-tied side.
+
+**Primary command (planned):** `/energy-ops`
+
+## 5. Buyer
+
+**Purpose:** Buyer-side clarity. What to ask, what to refuse, what to verify when receiving an installer's quote.
+
+**Inputs:** Quote received from a third-party installer, customer's profile.
+
+**Outputs:** Quote-validation report, list of red flags, list of verifications buyer should perform, list of negotiation positions.
+
+**Validation requirements:** `human_review` always. Optional `legal_review` if quote involves long-term lease or PPA.
+
+**Primary command (planned):** `/energy-buyer`
+
+## 6. Grid
+
+**Purpose:** Grid-side compliance — feed-in tariffs, regulatory approvals, grid-operator confirmations.
+
+**Inputs:** Installation specs, jurisdiction.
+
+**Outputs:** Required grid-operator forms, expected approval timeline, compliance checklist, feed-in tariff projections.
+
+**Validation requirements:** `grid_operator_confirmation_<jurisdiction>` always. `legal_review` for non-residential / commercial scale.
+
+**Primary command (planned):** `/energy-grid`
+
+## ★ Recovery (cross-cutting)
+
+**Purpose:** Storm, grid-failure, battery-fault, deplatform recovery protocols. Cross-cutting because resilience needs to be designed at every sub-system interface.
+
+**Inputs:** Operational telemetry + scenario specification.
+
+**Outputs:** Recovery playbook per scenario, communication templates for stakeholders, post-incident review structure.
+
+**Validation requirements:** Vary by recovery action.
+
+**Primary command (planned):** `/energy-recovery`
+
+## Composition rules
+
+- **Sizing before Cost.** Cost is meaningless without a size to cost. Sizing must run (even in shadow mode) before Cost is invoked.
+- **Validation gates ARE the user's permission.** A Calculator output with unsatisfied `required_validation` is NOT a green-light.
+- **Buyer-side and Installer-side are mirror sub-systems.** Same equation, different sovereign on each side. Buyer protects the buyer; Installer protects the installer. Both are honest.
+- **Recovery runs continuously.** It is not a phase, it is a posture. Every other sub-system designs its outputs assuming Recovery will need to use them in adverse scenarios.
+
+---
+
+**Built on SIP** · Starlight Intelligence Protocol v1.1.0
+- Substrate composed: [`@starlight/schemas`, `@starlight/calculators`, `@starlight/validation`]
+- Scaffold: 2026-05-03


### PR DESCRIPTION
## Summary

Substrate ratification + foundation ship per Frank's 2026-05-03 directive ("do it all"). Three `/starlight-board` verdicts captured + foundation packages built + Energy IS scaffold ratified — all in one PR.

**Diff:** 24 new files, ~1,700 LOC.

## Three board verdicts (in `docs/boards/`)

| Proposal | Verdict |
|---|---|
| SovereignNode + Calculator + ValidationRequirement substrate | PROCEED-WITH-REVISE |
| Energy IS as 4th Domain Sub-Stack | PROCEED (gated on calc/val) |
| CopilotKit as standardized agent-UI runtime | PROCEED-WITH-REVISE |

REVISE items captured in each verdict; foundations encode them.

## Substrate packages (NEW: `packages/`)

- **`@starlight/schemas`** — SovereignNode (10 kinds) + 6 composable Profiles (Energy/Compute/Storage/Workflow/Security/Cost). Zod, provenance baked in.
- **`@starlight/validation`** — Core ValidationRequirement members + jurisdiction extension API (Board REVISE) + severity hints.
- **`@starlight/calculators`** — `Calculator<I, O>` + `CalculatorResult<T>` + promotion pipeline modes (`shadow` → `live-with-warnings` → `live` → `deprecated`, Board REVISE) + replay harness.
- **`@starlight/agent-ui-runtime`** — Scaffold + `BOUNDARY.md` (Board REVISE: required artifact) + provider-pattern interfaces. Full impl cross-repo (Arcanea golden-ref).

Plus `packages/README.md` as the substrate composition guide.

## Energy IS — 4th reference Domain Sub-Stack (NEW: `verticals/energy-intelligence/`)

7-file contract: README · SUB-SYSTEMS (6+1) · AGENTS (7 planned) · SOUL · STACK · CANON · MEMORY · QUICK-START.

Composes natively with all 3 new substrate packages. Sovereign instances (PV-Lager) instantiate under `private/` per privacy framework.

## What's still pending after this PR

- Per-sub-system content authoring (v8.x scope)
- Agent file authoring at `agents/starlight-energy-*.md` (v8.x)
- Command file authoring at `.claude/commands/energy-*.md` (v8.x)
- CI lint rule for `@starlight/agent-ui-runtime` boundary (separate PR)
- CopilotKit golden-ref impl (cross-repo: Arcanea)
- PV-Lager sovereign instance scaffolding (Frank-driven, `private/`)

## Authority context

The 3 `/starlight-board` verdicts ARE the ratification artifacts required by board-before-tag invariant. Future substrate proposals follow standard board-before-tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced foundational infrastructure packages: deterministic calculator substrate with promotion pipeline (`shadow` → `live` stages), canonical `SovereignNode` entity model, and validation requirement system for gating irreversible actions.
  * Added `@starlight/agent-ui-runtime` with strong boundary enforcement and provider-pattern injection for memory, canon, identity, and calculator access.
  * Launched Energy Intelligence vertical reference implementation featuring calculator-driven subsystems, agent patterns, and jurisdiction-extensible validation requirements.

* **Documentation**
  * Published board decisions and implementation guidance for substrate composition, calculator promotion, and domain sub-stack patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->