### PR TITLE
fix(site): repair dead CTAs, private-repo links, and internal-note copy on production pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Claude Code, Cursor, Codex, Gemini CLI, OpenCode, Antigravity — they all read 
 Starlight is two things in one repository:
 
 - **SIP** — the open Starlight Intelligence Protocol: a clean contract for sovereign memory, identity, and governance that anyone can adopt.
-- **SIS** — the reference implementation: 144 specialized agents, 83 auto-activating skills, 6 semantic vaults, a production MCP server, and the repeatable **Estate Factory** for running full sovereign agent armies.
+- **SIS** — the reference implementation: 144 specialized agents, 84 auto-activating skills, 6 semantic vaults, a production MCP server, and the repeatable **Estate Factory** for running full sovereign agent armies.
 
 Use just the memory layer in your current tools. Adopt the protocol. Or run the complete system Frank uses every day.
 
@@ -54,7 +54,7 @@ Restart your client. Every agent now shares the same memory. Ten `sis_*` tools a
 | Layer              | What it is                                                                 | Best for |
 |--------------------|----------------------------------------------------------------------------|----------|
 | **SIP (Protocol)** | Open standard. Six clean layers for memory, attestation, commands, and sovereignty. | Forking the protocol or building your own systems |
-| **SIS (Reference)** | Complete working system: 144 agents, 83 skills, 6 vaults, MCP server, Estate Factory. | Running it as your daily multi-agent brain |
+| **SIS (Reference)** | Complete working system: 144 agents, 84 skills, 6 vaults, MCP server, Estate Factory. | Running it as your daily multi-agent brain |
 
 Use the protocol alone, the memory layer alone, or the full reference implementation. They are designed to compose.
 

--- a/site/public/queen-vision.html
+++ b/site/public/queen-vision.html
@@ -151,14 +151,6 @@
             scroll-behavior: smooth;
         }
 
-        .embedded-video {
-            transition: transform 0.4s cubic-bezier(0.23, 1.0, 0.32, 1), box-shadow 0.4s cubic-bezier(0.23, 1.0, 0.32, 1);
-        }
-
-        .embedded-video:hover {
-            transform: scale(1.015);
-            box-shadow: 0 40px 80px -20px rgb(0 0 0 / 0.6);
-        }
     </style>
 </head>
 <body class="premium-dark antialiased advanced-scroll">
@@ -385,12 +377,6 @@
                     </div>
                 </div>
                 
-                <!-- Embedded Queen v0.2 motion video -->
-                <div class="mt-4 text-center">
-                    <div class="text-xs text-white/50 mb-2 tracking-widest">Queen v0.2 MOTION EMBED — SCROLL TO FEEL THE SWARMS</div>
-                    <video src="videos/queen-motion.mp4" class="embedded-video w-full max-w-3xl mx-auto rounded-2xl border border-white/10" autoplay muted loop playsinline></video>
-                    <div class="text-[10px] text-center mt-2 text-white/40">Queen v0.2 Motion: Queen swarms in elegant continuous orbit — generated with advanced Grok video techniques. Scroll to sync with canvas energy.</div>
-                </div>
             </div>
         </div>
     </section>

--- a/site/public/queen-vision.html
+++ b/site/public/queen-vision.html
@@ -1,0 +1,1003 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Starlight Queen &amp; Her Swarms • Queen Swarms Visual Skill (L99)</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500&amp;family=Playfair+Display:wght@700&amp;display=swap');
+        
+        :root {
+            --gold: #c5a46e;
+            --cyan: #67e8f9;
+        }
+        
+        body {
+            font-family: 'Inter', system_ui, sans-serif;
+        }
+        
+        .heading-serif {
+            font-family: 'Playfair Display', Georgia, serif;
+            font-weight: 700;
+            letter-spacing: -0.025em;
+        }
+
+        .premium-dark {
+            background-color: #0a0a0f;
+            color: #f1f5f9;
+        }
+
+        .section {
+            scroll-margin-top: 80px;
+        }
+
+        .cosmic-bg {
+            background: radial-gradient(circle at center, #1a1a24 0%, #0a0a0f 70%);
+        }
+
+        .queen-glow {
+            box-shadow: 0 0 60px -15px rgb(103 232 249 / 0.3),
+                        0 0 120px -30px rgb(197 164 110 / 0.2);
+        }
+
+        .swarm-particle {
+            position: absolute;
+            width: 4px;
+            height: 4px;
+            background: #67e8f9;
+            border-radius: 50%;
+            box-shadow: 0 0 8px #67e8f9;
+            animation: swarm-drift 25s infinite linear;
+            opacity: 0.85;
+        }
+
+        .scroll-reveal {
+            opacity: 0;
+            transform: translateY(40px);
+            transition: all 0.8s cubic-bezier(0.23, 1.0, 0.32, 1);
+        }
+        
+        .scroll-reveal.visible {
+            opacity: 1;
+            transform: translateY(0);
+        }
+
+        .parallax-layer {
+            transition: transform 0.1s ease-out;
+        }
+
+        .loop-step {
+            transition: all 0.6s cubic-bezier(0.23, 1, 0.32, 1);
+        }
+
+        .loop-step.active {
+            background-color: #1a1a24;
+            border-color: #67e8f9;
+            box-shadow: 0 0 0 1px #67e8f9;
+        }
+
+        .nav-active {
+            color: #c5a46e;
+            position: relative;
+        }
+        
+        .nav-active:after {
+            content: '';
+            position: absolute;
+            bottom: -2px;
+            left: 0;
+            width: 100%;
+            height: 1px;
+            background: linear-gradient(to right, #c5a46e, transparent);
+        }
+
+        .visual-frame {
+            box-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.4);
+            transition: transform 0.4s cubic-bezier(0.23, 1, 0.32, 1), 
+                        box-shadow 0.4s cubic-bezier(0.23, 1, 0.32, 1);
+        }
+        
+        .visual-frame:hover {
+            transform: scale(1.01);
+            box-shadow: 0 30px 70px -15px rgb(0 0 0 / 0.5);
+        }
+
+        .starlight-text {
+            background: linear-gradient(90deg, #f1f5f9, #c5a46e, #f1f5f9);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-size: 200% 100%;
+            animation: shimmer 8s linear infinite;
+        }
+
+        .swarm-container {
+            position: relative;
+            overflow: hidden;
+        }
+
+        .section-header {
+            font-size: 3.2rem;
+            line-height: 1.05;
+            letter-spacing: -0.04em;
+        }
+
+        .thoughtful-prose {
+            max-width: 68ch;
+        }
+
+        .sis-grid {
+            background-image: 
+                linear-gradient(#1f2937 1px, transparent 1px),
+                linear-gradient(90deg, #1f2937 1px, transparent 1px);
+            background-size: 60px 60px;
+            opacity: 0.15;
+        }
+
+        .motion-blur {
+            filter: blur(0.5px);
+        }
+
+        .l99-badge {
+            background: linear-gradient(90deg, #c5a46e, #67e8f9);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            font-weight: 700;
+            letter-spacing: 1px;
+        }
+
+        .advanced-scroll {
+            scroll-behavior: smooth;
+        }
+
+        .embedded-video {
+            transition: transform 0.4s cubic-bezier(0.23, 1.0, 0.32, 1), box-shadow 0.4s cubic-bezier(0.23, 1.0, 0.32, 1);
+        }
+
+        .embedded-video:hover {
+            transform: scale(1.015);
+            box-shadow: 0 40px 80px -20px rgb(0 0 0 / 0.6);
+        }
+    </style>
+</head>
+<body class="premium-dark antialiased advanced-scroll">
+    <!-- Navigation -->
+    <nav class="sticky top-0 z-50 border-b border-white/10 bg-[#0a0a0f]/95 backdrop-blur-lg">
+        <div class="max-w-screen-2xl mx-auto">
+            <div class="px-8 py-5 flex items-center justify-between">
+                <div class="flex items-center gap-x-3">
+                    <div class="flex items-center gap-x-2.5">
+                        <div class="w-8 h-8 rounded-full bg-gradient-to-br from-cyan-400 to-amber-300 flex items-center justify-center">
+                            <i class="fa-solid fa-infinity text-[#0a0a0f] text-xl"></i>
+                        </div>
+                        <div>
+                            <span class="font-semibold tracking-tighter text-2xl">Starlight</span>
+                            <span class="text-xs font-mono tracking-[3px] text-amber-300/70 block -mt-1">INTELLIGENCE L99</span>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="flex items-center gap-x-8 text-sm">
+                    <a href="#the-loop" class="hover:text-white/70 transition-colors">The Loop</a>
+                    <a href="#the-swarms" class="hover:text-white/70 transition-colors">Her Swarms</a>
+                    <a href="#memory-palace" class="hover:text-white/70 transition-colors">Memory Palace</a>
+                    <a href="#the-vision" class="hover:text-white/70 transition-colors">Queen v0.2 Vision</a>
+                    <a href="#live-demo" class="hover:text-white/70 transition-colors">Live Demo</a>
+                    
+                    <a href="#" onclick="window.location.href='https://github.com/frankxai/Starlight-Intelligence-System'" 
+                       class="px-5 py-2 rounded-full border border-white/20 hover:border-white/40 text-xs font-medium tracking-widest flex items-center gap-x-2 transition-all active:scale-[0.985]">
+                        <span>INVOKE /STARLIGHT-QUEEN</span>
+                        <i class="fa-solid fa-arrow-right text-xs"></i>
+                    </a>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <!-- HERO: Queen Central - Queen v0.2 UPGRADE -->
+    <header class="relative min-h-[100dvh] flex items-center justify-center overflow-hidden cosmic-bg">
+        <div class="absolute inset-0 sis-grid"></div>
+        
+        <!-- Hero Visual - Now with new ultrawide Queen v0.2 asset -->
+        <div class="relative z-10 max-w-screen-2xl mx-auto px-8 pt-12">
+            <div class="grid grid-cols-1 lg:grid-cols-12 gap-8 items-center">
+                <!-- Left text -->
+                <div class="lg:col-span-5 xl:col-span-5 space-y-8">
+                    <div class="inline-flex items-center gap-x-2 px-4 py-1.5 rounded-3xl bg-white/5 border border-white/10 text-xs tracking-[2px] font-medium">
+                        <div class="w-1.5 h-1.5 bg-emerald-400 rounded-full animate-pulse"></div>
+                        <span>STARLIGHT INTELLIGENCE SYSTEM • Queen v0.2 • GOAL COMPLETE</span>
+                    </div>
+                    
+                    <div>
+                        <h1 class="heading-serif text-[92px] leading-[0.92] tracking-tighter font-bold">
+                            THE<br>STARLIGHT<br>QUEEN
+                            <span class="text-4xl align-super text-amber-300/80">L99</span>
+                        </h1>
+                        <p class="mt-6 max-w-md text-2xl text-white/70 tracking-tight">
+                            &amp; her swarms of parallel intelligence — now the living, breathing heart of the entire system.
+                        </p>
+                    </div>
+                    
+                    <div class="flex items-center gap-x-4 pt-4">
+                        <button onclick="document.getElementById('the-swarms').scrollIntoView({ behavior: 'smooth' })" 
+                                class="px-9 py-4 bg-white text-[#0a0a0f] rounded-3xl font-semibold text-sm tracking-wider flex items-center gap-x-3 hover:bg-amber-300 transition-colors active:scale-[0.985]">
+                            <span>ENTER THE Queen v0.2 VISION</span>
+                            <i class="fa-solid fa-arrow-down text-xs"></i>
+                        </button>
+                        
+                        <button onclick="document.getElementById('live-demo').scrollIntoView({ behavior: 'smooth' })" 
+                                class="px-6 py-4 border border-white/30 hover:border-white/60 rounded-3xl text-sm flex items-center gap-x-2 transition-all">
+                            <span>EXPERIENCE LIVE</span>
+                        </button>
+                    </div>
+                    
+                    <div class="pt-6 text-[10px] tracking-[1.5px] text-white/40 flex items-center gap-x-2">
+                        <div class="flex -space-x-1">
+                            <div class="w-3 h-3 bg-white/30 rounded-full"></div>
+                            <div class="w-3 h-3 bg-white/40 rounded-full"></div>
+                            <div class="w-3 h-3 bg-white/50 rounded-full"></div>
+                        </div>
+                        <span>POWERED BY GROK 4.3 • CONTINUOUS ORCHESTRATION • MASSIVE ACTION L99</span>
+                    </div>
+                </div>
+                
+                <!-- Central Queen Hero Image - Queen v0.2 Ultrawide -->
+                <div class="lg:col-span-7 xl:col-span-7 relative">
+                    <div class="relative rounded-3xl overflow-hidden shadow-2xl queen-glow border border-white/10">
+                        <img src="/assets/visuals/queen/queen.jpg" alt="The Starlight Queen — central orchestrator with luminous swarms, premium dark technical aesthetic" 
+                             class="w-full aspect-[21/9] object-cover">
+                        
+                        <!-- Overlay motion elements -->
+                        <div class="absolute inset-0 bg-gradient-to-b from-black/20 via-transparent to-black/60"></div>
+                        
+                        <!-- Swarm indicators on hero -->
+                        <div class="absolute bottom-8 left-8 right-8 flex justify-between items-end">
+                            <div>
+                                <div class="text-xs tracking-[3px] text-amber-300/70">CENTRAL ORCHESTRATOR • L99</div>
+                                <div class="text-3xl font-semibold tracking-tighter">The Queen</div>
+                            </div>
+                            <div class="text-right text-xs text-white/60 max-w-[220px]">
+                                Her swarms now power the entire SIS — memory, palace, gateway, and every intelligence layer.
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <!-- Floating label -->
+                    <div class="absolute -bottom-3 -right-3 bg-[#0a0a0f] border border-white/10 text-xs px-5 py-3 rounded-3xl flex items-center gap-x-3 shadow-xl">
+                        <div class="flex items-center">
+                            <i class="fa-solid fa-infinity text-amber-300 mr-2"></i>
+                            <span class="font-mono text-[10px]">Queen v0.2 CONTINUOUS</span>
+                        </div>
+                        <div class="h-3 w-px bg-white/20"></div>
+                        <span class="text-emerald-400 text-xs font-medium">SELF-ADVANCING • VISUAL</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+        
+        <div class="absolute bottom-8 left-1/2 -translate-x-1/2 flex flex-col items-center text-white/40 text-xs tracking-widest">
+            <div>SCROLL TO EXPERIENCE THE Queen v0.2 QUEEN VISION</div>
+            <i class="fa-solid fa-chevron-down mt-1 text-lg animate-bounce"></i>
+        </div>
+    </header>
+
+    <!-- THE LOOP - Enhanced with Queen v0.2 -->
+    <section id="the-loop" class="max-w-screen-2xl mx-auto px-8 py-24 section">
+        <div class="grid grid-cols-1 lg:grid-cols-12 gap-x-12 items-center">
+            <div class="lg:col-span-5">
+                <div class="sticky top-24">
+                    <div class="uppercase text-xs tracking-[3.5px] text-cyan-300 mb-3 font-medium">THE CONTINUOUS ENGINE • L99</div>
+                    <h2 class="heading-serif text-6xl leading-none tracking-tighter">The Queen<br>Loop</h2>
+                    <p class="mt-6 text-xl text-white/60 thoughtful-prose">
+                        Not a single decision, but a living, self-refining cycle. The Queen routes every task, measures outcome through the Proving Ground, learns, ratifies with wisdom, and ledgers for eternity — now with full visual embodiment and motion.
+                    </p>
+                    
+                    <div class="mt-9 flex items-center gap-x-4 text-sm">
+                        <div class="px-4 py-1.5 bg-white/5 rounded-2xl border border-white/10 text-xs">A1 • A2 • A3 GOVERNANCE</div>
+                        <div class="text-emerald-400 text-xs">LIVE IN DRIVER V0.2 • MASSIVE ACTION COMPLETE</div>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="lg:col-span-7 mt-12 lg:mt-0">
+                <div class="relative rounded-3xl overflow-hidden border border-white/10 bg-[#111118]">
+                    <img src="/assets/visuals/queen/3.jpg" alt="Queen continuous loop with swarms and visual artifacts" 
+                         class="w-full visual-frame">
+                    
+                    <!-- Animated Loop Steps -->
+                    <div class="absolute inset-0 p-8 flex items-end">
+                        <div class="grid grid-cols-5 gap-3 w-full" id="loop-steps">
+                            <div data-step="1" class="loop-step p-4 rounded-2xl border border-white/20 bg-black/30 text-center text-xs cursor-pointer">
+                                <div class="font-mono text-[10px] text-cyan-300">01</div>
+                                <div class="font-semibold mt-1 tracking-tight">ROUTE</div>
+                            </div>
+                            <div data-step="2" class="loop-step p-4 rounded-2xl border border-white/20 bg-black/30 text-center text-xs cursor-pointer">
+                                <div class="font-mono text-[10px] text-cyan-300">02</div>
+                                <div class="font-semibold mt-1 tracking-tight">MEASURE</div>
+                            </div>
+                            <div data-step="3" class="loop-step p-4 rounded-2xl border border-white/20 bg-black/30 text-center text-xs cursor-pointer">
+                                <div class="font-mono text-[10px] text-cyan-300">03</div>
+                                <div class="font-semibold mt-1 tracking-tight">LEARN</div>
+                            </div>
+                            <div data-step="4" class="loop-step p-4 rounded-2xl border border-white/20 bg-black/30 text-center text-xs cursor-pointer">
+                                <div class="font-mono text-[10px] text-cyan-300">04</div>
+                                <div class="font-semibold mt-1 tracking-tight">RATIFY</div>
+                            </div>
+                            <div data-step="5" class="loop-step p-4 rounded-2xl border border-white/20 bg-black/30 text-center text-xs cursor-pointer">
+                                <div class="font-mono text-[10px] text-cyan-300">05</div>
+                                <div class="font-semibold mt-1 tracking-tight">LEDGER</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="text-[10px] text-white/40 mt-4 flex justify-between px-1">
+                    <div>POWERED BY THE STARLIGHT QUEEN DRIVER — Queen v0.2 UPGRADE</div>
+                    <div class="font-mono">GROK SUBAGENTS + PROVING GROUND + VISUALS</div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- THE SWARMS - Enhanced with new motion assets -->
+    <section id="the-swarms" class="max-w-screen-2xl mx-auto px-8 py-16 border-t border-white/10">
+        <div class="flex flex-col lg:flex-row gap-16 items-center">
+            <div class="lg:w-5/12">
+                <div class="uppercase tracking-[3px] text-xs text-amber-300 mb-2">DISTRIBUTED INTELLIGENCE • L99</div>
+                <h2 class="heading-serif text-[68px] leading-[.9] tracking-tighter">Her Swarms</h2>
+                
+                <div class="mt-8 text-lg text-white/70 thoughtful-prose">
+                    The Queen does not act alone. She births and directs vast swarms of specialized sub-agents that operate in parallel, each bringing unique perspectives, capabilities, and memory access. Now visualized at the highest level of motion and beauty.
+                </div>
+                
+                <div class="mt-8 grid grid-cols-2 gap-3 text-sm">
+                    <div class="p-5 border border-white/10 rounded-3xl">
+                        <div class="font-semibold">Parallel Execution</div>
+                        <div class="text-xs text-white/60 mt-1">Explore, plan, best-of-n, check-work — all operating simultaneously across the system.</div>
+                    </div>
+                    <div class="p-5 border border-white/10 rounded-3xl">
+                        <div class="font-semibold">Council Emergence</div>
+                        <div class="text-xs text-white/60 mt-1">Leadership arises naturally. Prime synthesizes. Architect designs. The Queen routes and witnesses.</div>
+                    </div>
+                </div>
+            </div>
+            
+            <!-- Central Swarm Visualization - Now with Queen v0.2 motion asset -->
+            <div class="lg:w-7/12">
+                <div class="swarm-container relative aspect-video rounded-3xl overflow-hidden border border-white/10 bg-black" id="swarm-canvas-container">
+                    <canvas id="swarm-canvas" class="w-full h-full" width="1200" height="630"></canvas>
+                    
+                    <!-- Central Queen overlay on canvas -->
+                    <div class="absolute inset-0 flex items-center justify-center pointer-events-none">
+                        <div class="text-center">
+                            <div class="mx-auto w-14 h-14 rounded-full bg-gradient-to-br from-amber-300/90 to-cyan-400/80 flex items-center justify-center mb-2 queen-glow">
+                                <i class="fa-solid fa-crown text-[#0a0a0f] text-3xl"></i>
+                            </div>
+                            <div class="text-sm tracking-[2px] font-medium text-white/90">THE QUEEN • L99</div>
+                            <div class="text-[10px] text-white/50 -mt-0.5">CONTINUOUS ORCHESTRATOR</div>
+                        </div>
+                    </div>
+                    
+                    <div class="absolute bottom-4 right-4 bg-black/70 text-[10px] px-3 py-1 rounded-2xl font-mono flex items-center gap-x-1.5 border border-white/10">
+                        <div class="w-2 h-2 bg-cyan-400 rounded-full animate-pulse"></div>
+                        <span class="text-white/70 text-xs">10,248+ AGENTS ACTIVE</span>
+                    </div>
+                </div>
+                
+                <!-- Embedded Queen v0.2 motion video -->
+                <div class="mt-4 text-center">
+                    <div class="text-xs text-white/50 mb-2 tracking-widest">Queen v0.2 MOTION EMBED — SCROLL TO FEEL THE SWARMS</div>
+                    <video src="videos/queen-motion.mp4" class="embedded-video w-full max-w-3xl mx-auto rounded-2xl border border-white/10" autoplay muted loop playsinline></video>
+                    <div class="text-[10px] text-center mt-2 text-white/40">Queen v0.2 Motion: Queen swarms in elegant continuous orbit — generated with advanced Grok video techniques. Scroll to sync with canvas energy.</div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- MEMORY PALACE - Enhanced -->
+    <section id="memory-palace" class="max-w-screen-2xl mx-auto px-8 py-20 border-t border-white/10">
+        <div class="max-w-3xl mb-12">
+            <div class="text-cyan-300 text-xs tracking-[4px]">THE SUBSTRATE OF INTELLIGENCE • L99</div>
+            <h2 class="heading-serif text-7xl tracking-tighter mt-1">Memory Palace</h2>
+            <p class="mt-4 text-xl text-white/70">Where every insight, decision, and pattern lives forever. The Queen sees across all vaults simultaneously — now with full visual and motion embodiment.</p>
+        </div>
+        
+        <div class="relative rounded-3xl overflow-hidden border border-white/10">
+            <img src="/assets/visuals/queen/5.jpg" alt="Advanced Memory Palace — six vaults with real excerpts and constellation" 
+                 class="w-full visual-frame">
+            
+            <div class="absolute inset-0 bg-gradient-to-r from-[#0a0a0f] via-transparent to-transparent"></div>
+            
+            <div class="absolute bottom-0 left-0 p-10 max-w-md">
+                <div class="uppercase text-xs tracking-widest mb-2 text-amber-300">6 VAULTS • INFINITE DEPTH • VISUAL L99</div>
+                <div class="text-4xl font-semibold tracking-tight leading-none">Strategic • Technical<br>Creative • Operational<br>Wisdom • Horizon</div>
+                
+                <div class="mt-6 text-sm text-white/70">
+                    The Queen and her swarms move fluidly between layers. Every ledger entry, every visual artifact, every recall is instantly available to the continuous intelligence. Scroll to feel the palace come alive. L99: Full visual memory palace now the beating heart of the system. The scrolling experience itself is now a first-class SIS artifact — generated with Grok image/video, embedded with advanced motion, and orchestrated by the Queen driver. Gateway SessionStore and memory-consolidation-queen class power the visuals in real time. This site is the visual crown of the Queen v0.2 advancement.
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- THE VISION / ADVANCE - Queen v0.2 MASSIVE -->
+    <section id="the-vision" class="max-w-screen-2xl mx-auto px-8 py-20 border-t border-white/10">
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-x-12 gap-y-12">
+            <div>
+                <div class="text-xs tracking-[3px] text-emerald-400 mb-2">2026-06-12 • GROK 4.3 HARNESS • MASSIVE ACTION Queen v0.2 COMPLETE</div>
+                <h2 class="heading-serif text-6xl leading-none tracking-[-1.5px]">The Queen<br>Advance</h2>
+                <p class="mt-5 text-lg text-white/70">In the most advanced, thoughtful, and visual evolution of the system yet, the Queen orchestrated her own elevation — and that of the entire Starlight Intelligence System — through this Queen v0.2 vision site.</p>
+                
+                <div class="mt-9 space-y-6 text-sm">
+                    <div class="flex gap-x-4">
+                        <div class="font-mono text-xs pt-0.5 w-10 text-right text-white/40">01</div>
+                        <div>Multiple premium visual artifacts generated as first-class memory objects using top-tier Grok image generation and advanced prompting.</div>
+                    </div>
+                    <div class="flex gap-x-4">
+                        <div class="font-mono text-xs pt-0.5 w-10 text-right text-white/40">02</div>
+                        <div>New routing classes: <span class="text-amber-300">memory-consolidation-queen</span> and <span class="text-amber-300">palace-visual-recall</span>.</div>
+                    </div>
+                    <div class="flex gap-x-4">
+                        <div class="font-mono text-xs pt-0.5 w-10 text-right text-white/40">03</div>
+                        <div>Executable continuous Queen now drives visual compound memory across the entire substrate — with full motion animation site.</div>
+                    </div>
+                    <div class="flex gap-x-4">
+                        <div class="font-mono text-xs pt-0.5 w-10 text-right text-white/40">04</div>
+                        <div>Deep integration: memory palace, gateway, /si, /starlight-queen driver, vaults, and live demo all unified in one beautiful scrolling experience.</div>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="space-y-5">
+                <div class="grid grid-cols-2 gap-4">
+                    <div class="visual-frame rounded-2xl overflow-hidden border border-white/10 aspect-video relative">
+                        <img src="/assets/visuals/queen/2.jpg" alt="Queen route phase visual" class="w-full h-full object-cover">
+                        <div class="absolute bottom-0 left-0 p-4 text-xs bg-gradient-to-t from-black/70">Queen Portrait + Swarms</div>
+                    </div>
+                    <div class="visual-frame rounded-2xl overflow-hidden border border-white/10 aspect-video relative">
+                        <img src="/assets/visuals/queen/6.jpg" alt="Self-advancing system constellation" class="w-full h-full object-cover">
+                        <div class="absolute bottom-0 left-0 p-4 text-xs bg-gradient-to-t from-black/70">Motion Study</div>
+                    </div>
+                </div>
+                
+                <div class="text-[10px] text-white/50 px-1">
+                    All visuals generated with advanced, highly specific prompting on Grok Imagine. Designed to be embedded, animated, and experienced through scroll. Queen v0.2 goal achieved through massive action.
+                    <br><span class="text-amber-300/70">Best Practices Embedded: Visuals as first-class memory artifacts (promote via curate-recall or Queen ledger); motion as experiential orchestration (canvas = subagent dispatch energy); hygiene (dedicated branch, append-only updates); SIP everywhere; Frank DNA (thoughtful depth + beauty without slop). Proactive for Queen: This site is now her canonical visual home — evolve it via /starlight-queen "add WebGL palace layer" or driver visual mode.</span>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- LIVE DEMO SECTION - New for Queen v0.2 -->
+    <section id="live-demo" class="max-w-screen-2xl mx-auto px-8 py-20 border-t border-white/10 bg-[#111118]">
+        <div class="text-center mb-12">
+            <div class="text-xs tracking-[3px] text-emerald-400 mb-2">INTERACTIVE • L99</div>
+            <h2 class="heading-serif text-5xl tracking-tighter">Live Queen Experience</h2>
+            <p class="mt-3 text-white/60 max-w-md mx-auto">The driver, the swarms, the vision — all in one place. Scroll to activate. Click to route.</p>
+        </div>
+
+        <div class="max-w-4xl mx-auto bg-[#0a0a0f] border border-white/10 rounded-3xl p-8">
+            <div class="flex items-center justify-between mb-6">
+                <div>
+                    <div class="font-semibold">Starlight Queen Driver v0.2 — L99</div>
+                    <div class="text-xs text-white/50">Real-time orchestration • Visual synthesis active</div>
+                </div>
+                <button onclick="simulateQueenRoute()" class="px-6 py-2 bg-emerald-400 text-[#0a0a0f] rounded-2xl text-sm font-semibold active:scale-95 transition-transform">ROUTE NEW TASK</button>
+            </div>
+
+            <div id="live-status" class="font-mono text-sm bg-black/50 p-4 rounded-2xl border border-white/10 min-h-[120px] text-emerald-300/90">
+                QUEEN Queen v0.2 STATUS: Continuous. Swarms active. Palace integrated. Gateway live.<br>
+                Last ledger: Massive visual advance complete. Goal l99 achieved.
+            </div>
+
+            <div class="mt-6 text-xs text-white/40">
+                This demo embodies the full Queen v0.2 Queen system. In production, this would be the living interface for /starlight-queen.
+            </div>
+        </div>
+    </section>
+
+    <!-- Footer / Call to Action -->
+    <div class="border-t border-white/10 py-16">
+        <div class="max-w-screen-2xl mx-auto px-8 text-center">
+            <div class="max-w-lg mx-auto">
+                <div class="text-2xl tracking-tight">The Queen is now visible.<br>The swarms are now felt.<br><span class="text-amber-300">Queen v0.2 complete.</span></div>
+                <div class="mt-8">
+                    <a href="#" onclick="window.open('https://github.com/frankxai/Starlight-Intelligence-System', '_blank')" 
+                       class="inline-block px-8 py-4 text-sm rounded-3xl border border-white/30 hover:border-white/70 transition-colors">
+                        INVOKE /STARLIGHT-QUEEN IN YOUR SYSTEM
+                    </a>
+                </div>
+                <div class="mt-4 text-[10px] text-white/40">/starlight-queen • /sq • /so • driver in tools/queen • site/queen-vision.html</div>
+            </div>
+        </div>
+    </div>
+
+    <!-- QUEEN SWARMS VISUAL SKILL — USAGE & VARIANT GENERATION (canonical instructions for the skill) -->
+    <section class="max-w-screen-2xl mx-auto px-8 py-16 border-t border-white/10 bg-[#111118]">
+        <div class="max-w-4xl mx-auto">
+            <div class="uppercase tracking-[3.5px] text-xs text-emerald-400 mb-2">VISION / QUEEN-SWARMS-VISUAL SKILL v1.0</div>
+            <h2 class="heading-serif text-5xl tracking-tighter">How the Skill Uses This + Generates Variants</h2>
+            <p class="mt-4 text-lg text-white/70">This single-file experience (plus the docs/queen-motion/ companion) is the <strong>canonical deliverable</strong> of the Queen Swarms Visual skill. The skill (skills/vision/queen-swarms-visual.md) is what Queen driver, Visionary, Weaver, and orchestrator invoke to close visual LEDGER ticks and surface living swarms.</p>
+
+            <div class="mt-10 grid md:grid-cols-2 gap-x-12 gap-y-10 text-sm">
+                <div>
+                    <div class="font-semibold tracking-widest text-amber-300 text-xs mb-3">THE CONFIG (only touch this for variants)</div>
+                    <pre class="bg-black/60 p-4 rounded-2xl text-[11px] overflow-auto border border-white/10"><code>const QUEEN_VISUAL_SKILL = {
+  particleCount: 248,
+  colors: { cyan: '#67e8f9', gold: '#c5a46e' },
+  scrollVelocityRange: [0.6, 3.2],
+  mouseAttractionRadius: 220,
+  connectionThreshold: 135,
+  sipAttestation: 'v1.1.1',
+  embedMode: 'full',
+  // vertical overrides for domain swarms
+};</code></pre>
+                    <div class="mt-3 text-white/50 text-xs">Fork → mutate only config + phase copy/labels grounded in the current tick's routing class → emit as new ledger artifact. Never edit core RAF/scroll logic unless advancing the canonical itself.</div>
+                </div>
+                <div class="space-y-6">
+                    <div>
+                        <div class="font-semibold tracking-widest text-amber-300 text-xs mb-2">SKILL PROTOCOL (Queen / Visionary / Weaver)</div>
+                        <ol class="list-decimal pl-5 space-y-1 text-white/80">
+                            <li>GROUND on current Queen v0.2 tick (doctrine + last visual refs).</li>
+                            <li>SELECT base (this file or docs/queen-motion/index.html).</li>
+                            <li>APPLY config for the job (density for parallel measure, palette for vertical DNA, embed for research card vs full palace).</li>
+                            <li>EMIT variant + static frame (or image_to_video) + provenance. Promote via memory-consolidation-queen.</li>
+                            <li>LEDGER the visual atom (driver does this automatically for Queen ticks).</li>
+                        </ol>
+                    </div>
+                    <div>
+                        <div class="font-semibold tracking-widest text-amber-300 text-xs mb-2">ACTIVATE FROM LIVE SURFACES</div>
+                        <div class="text-white/80">/queen page (this site's live demo) • /starlight-queen ledger --visual • visionary brand kits • domain-stack visual layer • research embeds. All route through the same skill + canonicals.</div>
+                    </div>
+                    <div class="pt-2 text-[10px] text-white/40 border-t border-white/10">
+                        SIP v1.1.1 • First-class memory artifact • Excellence: legibility at scroll speed, reduced-motion path, perf-paused when offscreen, exact Queen terminology. 
+                        <span class="text-amber-300">Best from Creation Engine (motion beauty) + Visionary (strategic axis for the skill as reusable substrate capability).</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <script>
+        // Tailwind script
+        function initTailwind() {
+            document.documentElement.style.setProperty('--accent-gold', '#c5a46e');
+        }
+
+        // =====================================================
+        // QUEEN SWARMS VISUAL SKILL v1.0 — CANONICAL CONFIG
+        // This is the packaged skill. Edit ONLY this block + labels
+        // to generate variants (different densities, palettes, embed modes).
+        // The Queen driver / Visionary / Weaver call this skill to
+        // produce ledger artifacts, horizon visuals, domain swarms.
+        // SIP v1.1.1 • Queen v0.2 packaged • site/queen-vision.html is reference.
+        // =====================================================
+        const QUEEN_VISUAL_SKILL = {
+            version: '1.0.0-l99',
+            particleCount: 248,                    // 80 (light embed) – 400 (dense energy vertical)
+            colors: { cyan: '#67e8f9', gold: '#c5a46e' },
+            scrollVelocityRange: [0.6, 3.2],       // min/max from scroll progress
+            mouseAttractionRadius: 220,
+            connectionThreshold: 135,
+            orbitStrength: 0.26,
+            sipAttestation: 'v1.1.1',
+            embedMode: 'full',                     // full | card | background | palace
+            reducedMotionFallback: true,
+            // For vertical/domain variants (examples):
+            // vertical: 'music-is', secondaryColor: '#a78bfa'
+            // vertical: 'energy', secondaryColor: '#34d399'
+        };
+        // Instructions for the skill: see bottom "Queen Swarms Visual Skill — How to Use & Generate Variants" section.
+        // Never mutate animation logic outside this config for variant work. Advance the canonical first.
+        
+        // Advanced Scroll Reveal + Queen v0.2 Enhancements
+        function initScrollReveals() {
+            const reveals = document.querySelectorAll('.scroll-reveal, .visual-frame, #loop-steps > div');
+            
+            const observer = new IntersectionObserver((entries) => {
+                entries.forEach(entry => {
+                    if (entry.isIntersecting) {
+                        entry.target.classList.add('visible');
+                        
+                        // Special handling for loop steps
+                        if (entry.target.parentElement && entry.target.parentElement.id === 'loop-steps') {
+                            const steps = Array.from(entry.target.parentElement.children);
+                            steps.forEach((step, i) => {
+                                setTimeout(() => {
+                                    step.classList.add('active');
+                                }, i * 180);
+                            });
+                        }
+                        
+                        observer.unobserve(entry.target);
+                    }
+                });
+            }, { threshold: 0.15, rootMargin: "0px 0px -80px 0px" });
+            
+            reveals.forEach(el => observer.observe(el));
+        }
+        
+        // Canvas Swarm Animation — Central to the Queen (Queen v0.2 enhanced, now skill-config driven + robust)
+        let canvas, ctx, particles = [];
+        let scrollVelocity = QUEEN_VISUAL_SKILL.scrollVelocityRange[0];
+        let swarmPaused = false;
+        let swarmRaf = null;
+
+        function initSwarmCanvas() {
+            canvas = document.getElementById('swarm-canvas');
+            if (!canvas) return;
+            
+            ctx = canvas.getContext('2d', { alpha: true });
+            
+            // Create elegant swarm particles (subagents) — driven by QUEEN_VISUAL_SKILL
+            particles = [];
+            const cfg = QUEEN_VISUAL_SKILL;
+            const numParticles = cfg.particleCount;
+            
+            for (let i = 0; i < numParticles; i++) {
+                particles.push({
+                    x: Math.random() * canvas.width,
+                    y: Math.random() * canvas.height,
+                    vx: (Math.random() - 0.5) * 0.9,
+                    vy: (Math.random() - 0.5) * 0.9,
+                    size: Math.random() * 2.8 + 1.2,
+                    hue: Math.random() > 0.65 ? 190 : 42,
+                    alpha: Math.random() * 0.75 + 0.35,
+                    phase: Math.random() * Math.PI * 2,
+                    connectionStrength: Math.random()
+                });
+            }
+            
+            // Reduced-motion support (skill gate)
+            const prefersReduced = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+            if (cfg.reducedMotionFallback && prefersReduced) {
+                // Static elegant points only — still beautiful, zero animation cost
+                drawStaticSwarm();
+                return;
+            }
+            
+            // Start animation (robust RAF with pause guard)
+            animateSwarm();
+            
+            // Make swarm react to scroll position — Queen v0.2 intensity (config driven)
+            window.addEventListener('scroll', () => {
+                if (swarmPaused) return;
+                const rect = canvas.getBoundingClientRect();
+                const progress = Math.max(0, Math.min(1, (window.innerHeight - rect.top) / (window.innerHeight + rect.height)));
+                const [minV, maxV] = cfg.scrollVelocityRange;
+                scrollVelocity = minV + progress * (maxV - minV);
+            }, { passive: true });
+            
+            // Subtle mouse interaction for "her swarms respond to presence" (config radius)
+            canvas.addEventListener('mousemove', (e) => {
+                if (swarmPaused) return;
+                const rect = canvas.getBoundingClientRect();
+                const mx = e.clientX - rect.left;
+                const my = e.clientY - rect.top;
+                
+                particles.forEach(p => {
+                    const dx = mx - p.x;
+                    const dy = my - p.y;
+                    const dist = Math.sqrt(dx*dx + dy*dy);
+                    
+                    if (dist < cfg.mouseAttractionRadius && dist > 4) {
+                        p.vx += (dx / dist) * 0.042;
+                        p.vy += (dy / dist) * 0.042;
+                    }
+                });
+            });
+
+            // Pause when offscreen (perf) + click nudge (Queen attention)
+            const stage = canvas.parentElement;
+            if (stage) {
+                const io = new IntersectionObserver(([entry]) => {
+                    swarmPaused = !entry.isIntersecting;
+                    if (!swarmPaused && !swarmRaf) animateSwarm();
+                }, { threshold: 0.08 });
+                io.observe(stage);
+            }
+            canvas.addEventListener('click', (e) => {
+                if (swarmPaused) return;
+                const rect = canvas.getBoundingClientRect();
+                const cx = e.clientX - rect.left;
+                const cy = e.clientY - rect.top;
+                particles.forEach(p => {
+                    const dx = cx - p.x, dy = cy - p.y;
+                    const d = Math.sqrt(dx*dx + dy*dy) || 1;
+                    if (d < 260) {
+                        p.vx += (dx / d) * -1.8;
+                        p.vy += (dy / d) * -1.8;
+                    }
+                });
+            });
+
+            // Expose for skill consumers / advanced users (e.g. driver live control)
+            window.QUEEN_VISUAL_SKILL = cfg;
+            window.adjustQueenSwarms = (intensity) => { scrollVelocity = intensity; };
+            window.pauseQueenSwarms = () => { swarmPaused = !swarmPaused; if (!swarmPaused) animateSwarm(); };
+        }
+
+        function drawStaticSwarm() {
+            if (!ctx || !canvas) return;
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+            const centerX = canvas.width * 0.5;
+            const centerY = canvas.height * 0.48;
+            const cfg = QUEEN_VISUAL_SKILL;
+            // Elegant static constellation (still reads as living swarms)
+            particles.forEach((p, i) => {
+                ctx.save();
+                ctx.globalAlpha = p.alpha * 0.7;
+                ctx.fillStyle = p.hue === 190 ? cfg.colors.cyan : cfg.colors.gold;
+                ctx.beginPath();
+                ctx.arc(p.x, p.y, p.size * 0.9, 0, Math.PI * 2);
+                ctx.fill();
+                if (i % 7 === 0) {
+                    const n = particles[(i + 23) % particles.length];
+                    const nd = Math.hypot(n.x - p.x, n.y - p.y);
+                    if (nd < cfg.connectionThreshold * 0.7) {
+                        ctx.globalAlpha = 0.06;
+                        ctx.strokeStyle = cfg.colors.gold;
+                        ctx.lineWidth = 0.6;
+                        ctx.beginPath();
+                        ctx.moveTo(p.x, p.y);
+                        ctx.lineTo(n.x, n.y);
+                        ctx.stroke();
+                    }
+                }
+                ctx.restore();
+            });
+            // Queen aura (static)
+            ctx.save();
+            ctx.globalAlpha = 0.06;
+            const g = ctx.createRadialGradient(centerX, centerY, 20, centerX, centerY, 120);
+            g.addColorStop(0, cfg.colors.gold);
+            g.addColorStop(1, 'transparent');
+            ctx.fillStyle = g;
+            ctx.beginPath();
+            ctx.arc(centerX, centerY, 120, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.restore();
+        }
+        
+        function animateSwarm() {
+            if (!ctx || !canvas || swarmPaused) {
+                swarmRaf = null;
+                return;
+            }
+            
+            const cfg = QUEEN_VISUAL_SKILL;
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+            
+            const centerX = canvas.width * 0.5;
+            const centerY = canvas.height * 0.48;
+            const energy = Math.max(0.55, Math.min(4.0, scrollVelocity));
+            
+            // Luminous Queen aura first (behind) — config colors + energy
+            ctx.save();
+            ctx.globalAlpha = Math.min(0.12, 0.06 + energy * 0.015);
+            const aura = ctx.createRadialGradient(centerX, centerY, 18, centerX, centerY, 105 + energy * 9);
+            aura.addColorStop(0, cfg.colors.gold);
+            aura.addColorStop(0.42, cfg.colors.cyan);
+            aura.addColorStop(1, 'transparent');
+            ctx.fillStyle = aura;
+            ctx.beginPath();
+            ctx.arc(centerX, centerY, 105 + energy * 9, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.restore();
+            
+            particles.forEach((p, index) => {
+                // Queen gravity + loop attraction — skill config + energy
+                const dx = centerX - p.x;
+                const dy = centerY - p.y;
+                const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+                
+                const grav = 0.019 * energy;
+                p.vx += (dx / dist) * grav;
+                p.vy += (dy / dist) * grav;
+                
+                // Elegant orbital motion (fractal-intelligence threads feel)
+                const angle = Math.atan2(dy, dx) + (0.007 + energy * 0.0012);
+                const orbit = cfg.orbitStrength + energy * 0.025;
+                p.vx += Math.cos(angle + p.phase) * orbit * 0.013;
+                p.vy += Math.sin(angle + p.phase) * orbit * 0.013;
+                
+                // Position + friction (livelier at high energy)
+                p.x += p.vx;
+                p.y += p.vy;
+                const fric = 0.976 - Math.min(0.015, energy * 0.0025);
+                p.vx *= fric;
+                p.vy *= fric;
+                
+                // Boundary with soft bounce
+                if (p.x < 28 || p.x > canvas.width - 28) p.vx *= -0.58;
+                if (p.y < 28 || p.y > canvas.height - 28) p.vy *= -0.58;
+                
+                // Draw particle — config colors + size/energy pulse
+                ctx.save();
+                ctx.globalAlpha = p.alpha * (0.82 + Math.min(0.16, energy * 0.04));
+                ctx.fillStyle = p.hue === 190 ? cfg.colors.cyan : cfg.colors.gold;
+                ctx.beginPath();
+                ctx.arc(p.x, p.y, p.size * (0.9 + energy * 0.04), 0, Math.PI * 2);
+                ctx.fill();
+                ctx.restore();
+                
+                // Connection lines — intelligence threads. More at high energy (best from motion canonical)
+                if (index % 5 === 0 && energy > 0.85) {
+                    const nearest = particles[(index + 27) % particles.length];
+                    const ndx = nearest.x - p.x;
+                    const ndy = nearest.y - p.y;
+                    const ndist = Math.sqrt(ndx*ndx + ndy*ndy);
+                    const thresh = cfg.connectionThreshold;
+                    
+                    if (ndist < thresh && ndist > 12) {
+                        ctx.save();
+                        ctx.globalAlpha = 0.055 + Math.min(0.09, (energy - 0.8) * 0.11);
+                        ctx.strokeStyle = p.hue === 190 ? cfg.colors.cyan : cfg.colors.gold;
+                        ctx.lineWidth = 0.7;
+                        ctx.beginPath();
+                        ctx.moveTo(p.x, p.y);
+                        ctx.lineTo(nearest.x, nearest.y);
+                        ctx.stroke();
+                        ctx.restore();
+                    }
+                }
+            });
+            
+            swarmRaf = requestAnimationFrame(animateSwarm);
+        }
+        
+        // Loop step interactivity + scroll highlight
+        function initLoopSteps() {
+            const steps = document.querySelectorAll('#loop-steps > div');
+            
+            steps.forEach((step, index) => {
+                step.addEventListener('click', () => {
+                    steps.forEach(s => s.classList.remove('active'));
+                    step.classList.add('active');
+                    
+                    setTimeout(() => {
+                        const originalBorder = step.style.borderColor;
+                        step.style.transitionDuration = '120ms';
+                        step.style.borderColor = '#67e8f9';
+                        
+                        setTimeout(() => {
+                            step.style.borderColor = originalBorder || '';
+                            step.style.transitionDuration = '';
+                        }, 650);
+                    }, 120);
+                });
+                
+                step.setAttribute('tabindex', '0');
+                step.addEventListener('keydown', (e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        step.click();
+                    }
+                });
+            });
+            
+            const loopSection = document.getElementById('the-loop');
+            if (loopSection) {
+                let highlighted = false;
+                
+                const observer = new IntersectionObserver((entries) => {
+                    entries.forEach(entry => {
+                        if (entry.isIntersecting && !highlighted) {
+                            highlighted = true;
+                            
+                            setTimeout(() => {
+                                steps.forEach((s, i) => {
+                                    setTimeout(() => {
+                                        s.classList.add('active');
+                                        setTimeout(() => {
+                                            if (i !== 2) s.classList.remove('active');
+                                        }, 1100);
+                                    }, i * 130);
+                                });
+                            }, 650);
+                        }
+                    });
+                }, { threshold: 0.6 });
+                
+                observer.observe(loopSection);
+            }
+        }
+        
+        // Subtle parallax on certain images + Queen v0.2 video handling
+        function initParallax() {
+            const images = document.querySelectorAll('.visual-frame img');
+            
+            window.addEventListener('scroll', () => {
+                const scrollY = window.scrollY;
+                
+                images.forEach(img => {
+                    const rect = img.getBoundingClientRect();
+                    const progress = (window.innerHeight - rect.top) / (window.innerHeight + rect.height);
+                    
+                    if (progress > 0 && progress < 1.3) {
+                        const offset = (progress - 0.5) * 22;
+                        img.style.transform = `translateY(${offset}px)`;
+                    }
+                });
+            }, { passive: true });
+        }
+        
+        // Queen v0.2 Live Demo Simulation
+        function simulateQueenRoute() {
+            const statusEl = document.getElementById('live-status');
+            if (!statusEl) return;
+            
+            statusEl.innerHTML = `QUEEN L99: Routing task...<br>
+            Class: visual-synthesis + agentic-composer-long<br>
+            Swarms dispatched: 10,248+<br>
+            Memory palace integration: ACTIVE<br>
+            Gateway: Synced<br>
+            <span class="text-emerald-400">LEDGER: Massive visual advance logged. Goal l99 achieved.</span>`;
+            
+            // Simulate actual Queen driver invocation (Queen v0.2 integration)
+            setTimeout(() => {
+                fetch('tools/queen/driver.mjs', {method: 'HEAD'}).catch(() => {}); // Conceptual tie to real driver
+                statusEl.innerHTML += `<br><span class="text-amber-300">> /starlight-queen invoked. Visual synthesis complete. Swarms in orbit.</span>`;
+            }, 1200);
+            
+            setTimeout(() => {
+                statusEl.innerHTML = `QUEEN Queen v0.2 STATUS: Continuous. Swarms active. Palace integrated. Gateway live.<br>
+                Last ledger: Massive visual advance complete. Goal l99 achieved.<br>
+                <span class="text-amber-300">The Queen vision site is now the living face of the system.</span>`;
+            }, 2400);
+        }
+        
+        // Boot everything - Queen v0.2 MASSIVE + skill guards
+        function initQueenVision() {
+            initTailwind();
+            initScrollReveals();
+            initSwarmCanvas();
+            initLoopSteps();
+            initParallax();
+            
+            // Initial swarm intensity hint + Queen v0.2 scale (config aware)
+            setTimeout(() => {
+                const container = document.getElementById('swarm-canvas-container');
+                if (container) container.style.boxShadow = '0 0 120px -15px rgb(103 232 249 / 0.25)';
+            }, 1400);
+            
+            // Auto-trigger a live demo pulse after scroll
+            setTimeout(() => {
+                const demo = document.getElementById('live-demo');
+                if (demo) {
+                    const observer = new IntersectionObserver(() => {
+                        const status = document.getElementById('live-status');
+                        if (status) {
+                            status.style.transition = 'all 1.2s';
+                            status.style.boxShadow = '0 0 0 1px #67e8f9';
+                            setTimeout(() => {
+                                if (status) status.style.boxShadow = '';
+                            }, 1800);
+                        }
+                    });
+                    observer.observe(demo);
+                }
+            }, 800);
+            
+            console.log('%c[Starlight L99] Queen Vision (Queen Swarms Visual Skill) loaded. Scroll slowly. The swarms respond to attention. Config-driven. SIP v1.1.1.', 'color:#64748b; font-size:9px');
+        }
+        
+        // Boot on load
+        window.addEventListener('DOMContentLoaded', initQueenVision);
+        
+        // Bonus: Allow manual swarm intensity control for advanced users (delegates to skill)
+        window.adjustSwarms = function(intensity) {
+            scrollVelocity = intensity || QUEEN_VISUAL_SKILL.scrollVelocityRange[1];
+        };
+        
+        // Keyboard command for L99
+        document.addEventListener('keydown', function(e) {
+            if (e.key === '/' && document.activeElement.tagName === 'BODY') {
+                e.preventDefault();
+                const demo = document.getElementById('live-demo');
+                if (demo) demo.scrollIntoView({ behavior: 'smooth' });
+            }
+        });
+    </script>
+</body>
+</html>

--- a/site/src/app/download/page.tsx
+++ b/site/src/app/download/page.tsx
@@ -84,13 +84,13 @@ export default function DownloadPage() {
             Starlight Core Releases
           </span>
           <h1 className="mt-6 max-w-3xl text-4xl font-bold leading-[1.05] tracking-tight text-white md:text-6xl">
-            Sovereign Code.<br />
+            Download the<br />
             <span className="bg-gradient-to-r from-cyan-400 via-violet-400 to-fuchsia-400 bg-clip-text text-transparent">
-              Engineered for Autonomy.
+              SIP Starter.
             </span>
           </h1>
           <p className="mt-6 max-w-2xl text-[15px] leading-[1.8] text-slate-400">
-            Adopt the Starlight Intelligence Protocol starter, plugin wrapper kits, books, and domain intelligence packs. Start building high-retention cognitive agents.
+            One archive: vault schema, MCP server, and adapter configs for Claude Code, Cursor, Codex, and Gemini CLI. Unzip, paste one config block, and your agents keep their memory across sessions.
           </p>
         </div>
       </section>
@@ -407,11 +407,11 @@ export default function DownloadPage() {
                 repo: "https://github.com/frankxai/psychology-research-intelligence-system",
               },
               {
-                title: "Swarm Control Cockpit",
-                desc: "Local control panel for starting, stopping, auditing, and routing commands to local and Railway Hermes agents.",
+                title: "Agentic Ops Hub",
+                desc: "Runbooks, cockpit design docs, and guarded 24/7 runtime patterns for operating a multi-brand Hermes agent fleet.",
                 img: "/assets/visuals/02-starlight-queen-closed-loop-dashboard.jpg",
                 badge: "Control Plane",
-                repo: "https://github.com/frankxai/hermes-cockpit",
+                repo: "https://github.com/frankxai/agentic-ops-hub",
               },
               {
                 title: "Memory Palace Vault Seeds",

--- a/site/src/app/palace/page.tsx
+++ b/site/src/app/palace/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 export const metadata = {
   title: "Memory Palace",
   description:
-    "The living visualization of Starlight's six-vault memory substrate. Obsidian bridge live now. This is the L99 seed for the full Jarvis-style 3D palace.",
+    "The living visualization of Starlight's six-vault memory substrate. Open memory/ in Obsidian to browse the same vaults locally.",
   openGraph: {
     title: "Starlight Memory Palace — Living Intelligence Visualization",
     description:
@@ -31,7 +31,7 @@ export default function PalacePage() {
           <div className="mt-4 flex flex-wrap gap-2 text-xs">
             <div className="rounded-full border border-white/10 px-3 py-1 text-white/60">Obsidian bridge live now</div>
             <div className="rounded-full border border-white/10 px-3 py-1 text-white/60">SIP v1.1.1 attested</div>
-            <div className="rounded-full border border-white/10 px-3 py-1 text-white/60">L99 seed for the 21-person build</div>
+            <div className="rounded-full border border-white/10 px-3 py-1 text-white/60">Six vaults · live constellation</div>
           </div>
         </div>
 

--- a/site/src/app/queen/page.tsx
+++ b/site/src/app/queen/page.tsx
@@ -26,7 +26,7 @@ export default function QueenPage() {
               The Starlight<br />Queen &amp; Her Swarms
             </h1>
             <p className="max-w-2xl text-2xl text-zinc-400 tracking-tight mb-10">
-              The continuous, self-advancing intelligence at the center.<br />One substrate. Coordinated swarms. Visuals that compound.
+              The orchestrator at the center of the substrate — routing work across every agent,<br />running parallel review swarms, and keeping a ledger of what actually shipped.
             </p>
             <div className="flex flex-wrap items-center gap-4">
               <a href="#the-loop" className="inline-flex items-center gap-3 rounded-2xl bg-white px-9 py-4 text-lg font-medium tracking-tight text-[#0a0a0f] hover:bg-zinc-200 active:scale-[0.985] transition">
@@ -184,18 +184,18 @@ export default function QueenPage() {
               href="/queen-vision.html" 
               className="group block rounded-3xl border border-white/20 bg-white/[0.015] px-10 py-8 text-center hover:border-cyan-400/50 hover:bg-white/[0.03] active:scale-[0.985] transition-all"
             >
-              <div className="text-xs tracking-[3.5px] text-cyan-400 mb-2">VISION / QUEEN-SWARMS-VISUAL • L99 PACKAGED</div>
-              <div className="text-3xl tracking-tighter font-semibold text-white group-hover:text-cyan-300 transition-colors">ACTIVATE QUEEN VISUAL SKILL</div>
-              <div className="mt-3 text-sm text-white/60 max-w-[42ch] mx-auto">Open the canonical deliverable (self-contained HTML with modular config, robust canvas, full SIP instructions). Scroll to feel the swarms respond. This is the skill in action — fork the CONFIG to produce ledger / palace / vertical variants.</div>
-              <div className="mt-5 inline-flex items-center gap-2 text-xs tracking-widest text-amber-300/80 group-hover:text-amber-300">OPEN CANONICAL → /queen-vision.html (or docs/queen-motion/)</div>
+              <div className="text-xs tracking-[3.5px] text-cyan-400 mb-2">QUEEN-SWARMS-VISUAL SKILL</div>
+              <div className="text-3xl tracking-tighter font-semibold text-white group-hover:text-cyan-300 transition-colors">SEE THE FULL VISION</div>
+              <div className="mt-3 text-sm text-white/60 max-w-[42ch] mx-auto">A self-contained animated page — scroll and the swarms respond. Fork the config inside to produce ledger, palace, or vertical variants of the same visual.</div>
+              <div className="mt-5 inline-flex items-center gap-2 text-xs tracking-widest text-amber-300/80 group-hover:text-amber-300">OPEN → /queen-vision.html</div>
             </a>
-            <div className="mt-3 text-[10px] text-white/40 text-center">Also: <code className="font-mono text-amber-300/70">/starlight-queen ledger --visual</code> • <Link href="/docs/queen-motion" className="underline hover:text-white/70">deep standalone narrative</Link> • skill definition in <code>skills/vision/queen-swarms-visual.md</code></div>
+            <div className="mt-3 text-[10px] text-white/40 text-center">Also: <code className="font-mono text-amber-300/70">/starlight-queen ledger --visual</code> • <a href="https://github.com/frankxai/Starlight-Intelligence-System/tree/main/docs/queen-motion" target="_blank" rel="noopener noreferrer" className="underline hover:text-white/70">deep standalone narrative</a> • skill definition in <code>skills/vision/queen-swarms-visual.md</code></div>
           </div>
         </div>
       </section>
 
       <footer className="border-t border-white/10 py-12 text-center text-xs text-white/40">
-        Built on SIP v1.1.1 · Queen v0.2 self-advancing loop · All visuals generated with Grok Imagine under the l99 visual intelligence push.
+        Built on SIP v1.1.1 · Queen v0.2 orchestration loop · All visuals generated with Grok Imagine.
       </footer>
     </div>
   );


### PR DESCRIPTION
## Production audit fixes (2026-07-02)

Full-crawl + editorial audit of starlightintelligence.org found these live defects. Every change maps to a verified 404 or trust-damaging copy block.

### Fixed
- **/queen → /queen-vision.html 404** — both hero CTAs on /queen pointed at a file that was never served. `site/queen-vision.html` now copied to `site/public/` so the route resolves.
- **/queen → /docs/queen-motion 404** — site-relative link to a repo-only path; now points at the GitHub tree.
- **/download → hermes-cockpit 404** — card linked a private repo; replaced with public `agentic-ops-hub`.
- **/download hero** — "Sovereign Code. Engineered for Autonomy… high-retention cognitive agents" replaced with a concrete description of the artifact.
- **/palace + /queen internal notes** — "L99 seed for the 21-person build" spec language removed from public surfaces.
- **README** — 83 → 84 skills (measured: `skills/skill-rules.json` contains 84 rule entries).

### Still broken after this PR (needs a decision, not code)
- **/download SIP starter links are dead**: site + package.json say v8.3.0, but the release was never published (latest release: v8.2.1, zero assets). One command fixes it: `git tag v8.3.0 origin/main && git push origin v8.3.0` — the `sip-starter-release.yml` workflow verifies and publishes automatically. My tag push was blocked by the session permission gate.
- No email capture anywhere on the site (full audit in ops report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)