### PR TITLE
feat(memory): spatial memory-palace index over the six vaults (pilot)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,13 @@ Update the appropriate vault with:
 
 Memory consolidation merges duplicates, elevates patterns, archives stale data, and strengthens cross-references. Run periodically or when vault size exceeds threshold.
 
+### Spatial index (pilot)
+
+`memory/palace/palace.json` is a walkable spatial index over the six vaults' most current entries,
+built with the [mind-palace-agent-skills](https://github.com/frankxai/mind-palace-agent-skills)
+Memory Palace suite. It is a companion view, not a replacement — the vaults remain authoritative.
+See `memory/palace/MEMORY_PALACE.md` for what it is and how to maintain it.
+
 ---
 
 ## Skills

--- a/memory/palace/MEMORY_PALACE.md
+++ b/memory/palace/MEMORY_PALACE.md
@@ -1,0 +1,65 @@
+# The Starlight Vault Palace — a spatial index over the six vaults
+
+> A pilot, not a replacement. The six vaults remain the source of truth; this is a
+> navigable, walkable index over them, built with the
+> [mind-palace-agent-skills](https://github.com/frankxai/mind-palace-agent-skills)
+> Memory Palace suite (`agent-memory-palace` + `memory-palace-architect` + `loci-encoder`).
+
+## What this is
+
+[`palace.json`](palace.json) maps each of the six Starlight Vaults to one room in a six-wing
+observatory, following the schema in
+[`spec/palace.schema.json`](https://github.com/frankxai/mind-palace-agent-skills/blob/main/spec/palace.schema.json):
+
+| Vault | Room | Surface |
+|---|---|---|
+| Strategic | Strategic Wing | obsidian |
+| Technical | Technical Wing | slate |
+| Creative | Creative Wing | aurora |
+| Operational | Operational Deck | glass |
+| Wisdom | Wisdom Dome | bronze |
+| Horizon | Horizon Balcony | marble |
+
+Each room holds a handful of the vault's real, current entries as stations. Every locus carries:
+
+- **`fact`** — a one-line, verifiable summary of the real vault entry (not a substitute for reading it).
+- **`refs`** — a pointer back to the source vault file/section, per `agent-memory-palace`'s
+  discipline: *memory is a cache, the source is the truth.* Nothing here is invented.
+- **`image`** — a vivid mnemonic encoding (bizarreness, multisensory detail, motion), so the same
+  file is walkable by a human, not just indexable by an agent.
+
+## Why this exists
+
+The vaults are excellent durable memory but are flat markdown — finding "what do we know about
+memory patterns" means opening technical-vault.md and reading. A spatial index gives:
+
+1. **A human-walkable overview** — render `palace.json` with the
+   [standalone viewer](https://github.com/frankxai/mind-palace-agent-skills/blob/main/assets/palace-viewer/index.html)
+   (`?src=` a raw URL to this file, or drag-and-drop it in) to see the whole memory system as one
+   navigable space, oldest-to-newest, wing by wing.
+2. **A pattern for agent memory** — `agent-memory-palace`'s room=domain / station=topic / locus=fact
+   mapping applied to a real, already-existing memory system, proving the pattern works on
+   production data rather than a toy example.
+
+## What this is *not*
+
+- **Not synced automatically.** This is a curated snapshot (13 loci across representative entries,
+  not exhaustive). When a vault gains a significant new entry worth indexing, add a locus by hand
+  or via the `agent-memory-palace` skill's write protocol — don't treat this file as authoritative
+  over the vaults themselves.
+- **Not a new vault.** It doesn't have its own retention policy or writers; it inherits from
+  whatever it points at via `refs`.
+
+## Maintaining it
+
+When a vault's index changes meaningfully:
+
+1. Add a `locus` to the corresponding room's station (or a new station), with a real `target`,
+   `fact`, and `refs` pointing at the vault entry.
+2. Optionally add an `image` if the locus is worth memorizing, not just indexing.
+3. Re-validate: `python3 -c "import json; json.load(open('memory/palace/palace.json'))"` (or run
+   `mind-palace-agent-skills`' `scripts/validate_skills.py` structural checks against the schema).
+
+---
+
+Built on SIP · Starlight Intelligence System · Memory Palace Method v0.1

--- a/memory/palace/palace.json
+++ b/memory/palace/palace.json
@@ -1,0 +1,146 @@
+{
+  "type": "memory-palace",
+  "version": "0.1",
+  "id": "starlight-vault-palace",
+  "title": "The Starlight Vault Palace",
+  "owner": "frankxai",
+  "locus": {
+    "kind": "imagined",
+    "basis": "an observatory built around the six Starlight Vaults",
+    "route": "strategic wing -> technical wing -> creative wing -> operational deck -> wisdom dome -> horizon balcony"
+  },
+  "rooms": [
+    {
+      "id": "strategic-vault",
+      "name": "Strategic Wing",
+      "order": 0,
+      "surface": "obsidian",
+      "accent": "#7da3ff",
+      "stations": [
+        {"id": "architecture-decisions", "name": "The decision table", "order": 0, "loci": [
+          {"id": "sis-architecture", "target": "Starlight Intelligence System Architecture Decision",
+           "fact": "Configuration-first, seven-agent model, five/six-vault memory, skill auto-activation, transmission channels, progressive disclosure.",
+           "image": {"text": "A obsidian table with six brass gears locking into place one by one, each stamped with a founding decision, until the whole table hums and lights from within.", "techniques": ["motion", "multisensory"]},
+           "refs": ["memory/vaults/strategic-vault.md#2026-02-10-starlight-intelligence-system-architecture-decision"]}
+        ]},
+        {"id": "integration-strategy", "name": "The map on the far wall", "order": 1, "loci": [
+          {"id": "ecosystem-integration", "target": "Ecosystem Integration Strategy",
+           "fact": "How Starlight connects to ACOS, Arcanea, and AI-Ops as the shared intelligence backbone.",
+           "image": {"text": "Glowing threads stretch from a pin labeled 'Starlight' out to three distant pins on a wall map, each thread pulsing as if carrying current.", "techniques": ["multisensory", "motion"]},
+           "refs": ["memory/vaults/strategic-vault.md#ecosystem-integration-strategy"]}
+        ]}
+      ]
+    },
+    {
+      "id": "technical-vault",
+      "name": "Technical Wing",
+      "order": 1,
+      "surface": "slate",
+      "accent": "#9aa1ad",
+      "stations": [
+        {"id": "config-pattern", "name": "The blueprint drafting table", "order": 0, "loci": [
+          {"id": "configuration-first", "target": "Configuration-First Pattern",
+           "fact": "Markdown and JSON over code — zero-install-friction deployment.",
+           "image": {"text": "Blueprints on the slate table redraw themselves in real time as plain text is typed onto them, no ink, no code — just words becoming structure.", "techniques": ["bizarreness", "dual-coding"]},
+           "refs": ["memory/vaults/technical-vault.md#configuration-first-pattern"]}
+        ]},
+        {"id": "memory-hierarchy", "name": "The layered shelf", "order": 1, "loci": [
+          {"id": "memory-hierarchy-pattern", "target": "Memory Hierarchy Pattern",
+           "fact": "Working, episodic, semantic memory layered like sediment — each layer feeding the one above.",
+           "image": {"text": "A shelf of slate slabs stacked like sediment; the bottom slab glows briefly whenever the top slab is touched, showing the flow of memory upward.", "techniques": ["motion", "multisensory"]},
+           "refs": ["memory/vaults/technical-vault.md#memory-hierarchy-pattern"]}
+        ]}
+      ]
+    },
+    {
+      "id": "creative-vault",
+      "name": "Creative Wing",
+      "order": 2,
+      "surface": "aurora",
+      "accent": "#c9b6ff",
+      "stations": [
+        {"id": "luminor-integration", "name": "The prism alcove", "order": 0, "loci": [
+          {"id": "luminor-wisdom", "target": "The Luminor Wisdom Integration",
+           "fact": "Arcanea's Luminor archetypes lend creative-intelligence patterns into Starlight's own agents.",
+           "image": {"text": "A prism in the aurora-lit alcove splits one beam of light into seven colored threads, each thread coiling into the shape of a small figure.", "techniques": ["bizarreness", "multisensory"]},
+           "refs": ["memory/vaults/creative-vault.md#the-luminor-wisdom-integration"]}
+        ]},
+        {"id": "voice-pattern", "name": "The echo chamber", "order": 1, "loci": [
+          {"id": "frank-dna-voice", "target": "Frank DNA Voice Pattern",
+           "fact": "Direct, technical, warm, playful — the voice every generated artifact inherits.",
+           "image": {"text": "A single spoken word echoes off the aurora walls and returns four times, each echo dressed in a different tone but unmistakably the same voice.", "techniques": ["multisensory", "motion"]},
+           "refs": ["memory/vaults/creative-vault.md#frank-dna-voice-pattern"]}
+        ]}
+      ]
+    },
+    {
+      "id": "operational-vault",
+      "name": "Operational Deck",
+      "order": 3,
+      "surface": "glass",
+      "accent": "#7de3c8",
+      "stations": [
+        {"id": "build-handoff", "name": "The handoff console", "order": 0, "loci": [
+          {"id": "v01-build-handoff", "target": "SIS v0.1 Build Handoff + Memory Health Gate",
+           "fact": "The build-to-verification handoff that gates a release on memory-health, not just green tests.",
+           "image": {"text": "A glass console on the deck shows a green checkmark that only lights up after a second, smaller gauge behind the glass also fills to full — one gate waiting on the other.", "techniques": ["multisensory", "motion"]},
+           "refs": ["memory/vaults/operational-vault.md#sis-v0-1-build-handoff-memory-health-gate"]}
+        ]},
+        {"id": "overnight-ship", "name": "The rolling ledger", "order": 1, "loci": [
+          {"id": "overnight-deep-ship", "target": "Overnight Deep Ship — Codex v01 integration + v84 symmetry + MEMORY.md compaction",
+           "fact": "A rolling operational-state entry — recent, not permanent, and due to age out per the vault's 90-day retention.",
+           "image": {"text": "Glass panels on the deck slowly frost over at the edges, the oldest entries fading first while the newest stays perfectly clear.", "techniques": ["motion", "exaggeration"]},
+           "refs": ["memory/vaults/operational-vault.md#overnight-deep-ship-codex-v01-integration-v84-symmetry-memory-md-compaction"]}
+        ]}
+      ]
+    },
+    {
+      "id": "wisdom-vault",
+      "name": "Wisdom Dome",
+      "order": 4,
+      "surface": "bronze",
+      "accent": "#f4c97a",
+      "stations": [
+        {"id": "infrastructure-principle", "name": "The central pillar", "order": 0, "loci": [
+          {"id": "intelligence-as-infrastructure", "target": "Intelligence as Infrastructure",
+           "fact": "Intelligence is wired into every layer, not bolted on as a feature.",
+           "image": {"text": "A bronze pillar in the dome's center has wiring running through visible cracks in the metal, humming faintly, load-bearing rather than decorative.", "techniques": ["multisensory", "bizarreness"]},
+           "refs": ["memory/vaults/wisdom-vault.md#intelligence-as-infrastructure"]}
+        ]},
+        {"id": "memory-is-power", "name": "The bronze mirror", "order": 1, "loci": [
+          {"id": "memory-is-power", "target": "Memory is Power",
+           "fact": "A system that remembers compounds; one that forgets starts over every session.",
+           "image": {"text": "A bronze mirror shows not a reflection but a growing tower of the same block, one block taller each time it's glanced at.", "techniques": ["bizarreness", "motion"]},
+           "refs": ["memory/vaults/wisdom-vault.md#memory-is-power"]}
+        ]},
+        {"id": "files-over-ephemera", "name": "The engraved floor", "order": 2, "loci": [
+          {"id": "files-over-ephemera", "target": "Files over Ephemera",
+           "fact": "Durable files outlast any single conversation — write it down or it didn't happen.",
+           "image": {"text": "Footsteps across the dome floor burn away instantly except where a name has been engraved — those steps leave a permanent, glowing print.", "techniques": ["bizarreness", "multisensory"]},
+           "refs": ["memory/vaults/wisdom-vault.md#files-over-ephemera"]}
+        ]},
+        {"id": "compound-intelligence", "name": "The dome's oculus", "order": 3, "loci": [
+          {"id": "compound-intelligence-effect", "target": "The Compound Intelligence Effect",
+           "fact": "Each interaction makes the system smarter because it builds on everything before it.",
+           "image": {"text": "Light enters the oculus as a single thin beam but ricochets off every bronze surface in the dome, doubling in brightness with each bounce before it reaches the floor.", "techniques": ["motion", "exaggeration"]},
+           "refs": ["memory/vaults/wisdom-vault.md#the-compound-intelligence-effect"]}
+        ]}
+      ]
+    },
+    {
+      "id": "horizon-vault",
+      "name": "Horizon Balcony",
+      "order": 5,
+      "surface": "marble",
+      "accent": "#ffe5cc",
+      "stations": [
+        {"id": "first-entry", "name": "The open railing", "order": 0, "loci": [
+          {"id": "horizon-first-entry", "target": "The First Entry",
+           "fact": "Public, append-only, human hopes and AI reasoning recorded side by side — designed to outlast this system.",
+           "image": {"text": "A marble railing overlooking open sky; a single sealed letter rests on it, weatherproof, addressed to no one in particular and everyone eventually.", "techniques": ["emotion", "self-reference"]},
+           "refs": ["memory/vaults/horizon-vault.md#2026-02-10--the-first-entry"]}
+        ]}
+      ]
+    }
+  ]
+}

--- a/memory/palace/palace.json
+++ b/memory/palace/palace.json
@@ -27,7 +27,7 @@
           {"id": "ecosystem-integration", "target": "Ecosystem Integration Strategy",
            "fact": "How Starlight connects to ACOS, Arcanea, and AI-Ops as the shared intelligence backbone.",
            "image": {"text": "Glowing threads stretch from a pin labeled 'Starlight' out to three distant pins on a wall map, each thread pulsing as if carrying current.", "techniques": ["multisensory", "motion"]},
-           "refs": ["memory/vaults/strategic-vault.md#ecosystem-integration-strategy"]}
+           "refs": ["memory/vaults/strategic-vault.md#2026-02-10-ecosystem-integration-strategy"]}
         ]}
       ]
     },
@@ -42,13 +42,13 @@
           {"id": "configuration-first", "target": "Configuration-First Pattern",
            "fact": "Markdown and JSON over code — zero-install-friction deployment.",
            "image": {"text": "Blueprints on the slate table redraw themselves in real time as plain text is typed onto them, no ink, no code — just words becoming structure.", "techniques": ["bizarreness", "dual-coding"]},
-           "refs": ["memory/vaults/technical-vault.md#configuration-first-pattern"]}
+           "refs": ["memory/vaults/technical-vault.md#2026-02-10-configuration-first-pattern"]}
         ]},
         {"id": "memory-hierarchy", "name": "The layered shelf", "order": 1, "loci": [
           {"id": "memory-hierarchy-pattern", "target": "Memory Hierarchy Pattern",
            "fact": "Working, episodic, semantic memory layered like sediment — each layer feeding the one above.",
            "image": {"text": "A shelf of slate slabs stacked like sediment; the bottom slab glows briefly whenever the top slab is touched, showing the flow of memory upward.", "techniques": ["motion", "multisensory"]},
-           "refs": ["memory/vaults/technical-vault.md#memory-hierarchy-pattern"]}
+           "refs": ["memory/vaults/technical-vault.md#2026-02-10-memory-hierarchy-pattern"]}
         ]}
       ]
     },
@@ -63,13 +63,13 @@
           {"id": "luminor-wisdom", "target": "The Luminor Wisdom Integration",
            "fact": "Arcanea's Luminor archetypes lend creative-intelligence patterns into Starlight's own agents.",
            "image": {"text": "A prism in the aurora-lit alcove splits one beam of light into seven colored threads, each thread coiling into the shape of a small figure.", "techniques": ["bizarreness", "multisensory"]},
-           "refs": ["memory/vaults/creative-vault.md#the-luminor-wisdom-integration"]}
+           "refs": ["memory/vaults/creative-vault.md#2026-02-10-the-luminor-wisdom-integration"]}
         ]},
         {"id": "voice-pattern", "name": "The echo chamber", "order": 1, "loci": [
           {"id": "frank-dna-voice", "target": "Frank DNA Voice Pattern",
            "fact": "Direct, technical, warm, playful — the voice every generated artifact inherits.",
            "image": {"text": "A single spoken word echoes off the aurora walls and returns four times, each echo dressed in a different tone but unmistakably the same voice.", "techniques": ["multisensory", "motion"]},
-           "refs": ["memory/vaults/creative-vault.md#frank-dna-voice-pattern"]}
+           "refs": ["memory/vaults/creative-vault.md#2026-02-10-frank-dna-voice-pattern"]}
         ]}
       ]
     },
@@ -84,13 +84,13 @@
           {"id": "v01-build-handoff", "target": "SIS v0.1 Build Handoff + Memory Health Gate",
            "fact": "The build-to-verification handoff that gates a release on memory-health, not just green tests.",
            "image": {"text": "A glass console on the deck shows a green checkmark that only lights up after a second, smaller gauge behind the glass also fills to full — one gate waiting on the other.", "techniques": ["multisensory", "motion"]},
-           "refs": ["memory/vaults/operational-vault.md#sis-v0-1-build-handoff-memory-health-gate"]}
+           "refs": ["memory/vaults/operational-vault.md#2026-05-11-sis-v01-build-handoff-memory-health-gate"]}
         ]},
         {"id": "overnight-ship", "name": "The rolling ledger", "order": 1, "loci": [
           {"id": "overnight-deep-ship", "target": "Overnight Deep Ship — Codex v01 integration + v84 symmetry + MEMORY.md compaction",
            "fact": "A rolling operational-state entry — recent, not permanent, and due to age out per the vault's 90-day retention.",
            "image": {"text": "Glass panels on the deck slowly frost over at the edges, the oldest entries fading first while the newest stays perfectly clear.", "techniques": ["motion", "exaggeration"]},
-           "refs": ["memory/vaults/operational-vault.md#overnight-deep-ship-codex-v01-integration-v84-symmetry-memory-md-compaction"]}
+           "refs": ["memory/vaults/operational-vault.md#2026-05-13-overnight-deep-ship-codex-v01-integration-v84-symmetry-memory-md-compaction"]}
         ]}
       ]
     },
@@ -105,25 +105,25 @@
           {"id": "intelligence-as-infrastructure", "target": "Intelligence as Infrastructure",
            "fact": "Intelligence is wired into every layer, not bolted on as a feature.",
            "image": {"text": "A bronze pillar in the dome's center has wiring running through visible cracks in the metal, humming faintly, load-bearing rather than decorative.", "techniques": ["multisensory", "bizarreness"]},
-           "refs": ["memory/vaults/wisdom-vault.md#intelligence-as-infrastructure"]}
+           "refs": ["memory/vaults/wisdom-vault.md#2026-02-10-intelligence-as-infrastructure"]}
         ]},
         {"id": "memory-is-power", "name": "The bronze mirror", "order": 1, "loci": [
           {"id": "memory-is-power", "target": "Memory is Power",
            "fact": "A system that remembers compounds; one that forgets starts over every session.",
            "image": {"text": "A bronze mirror shows not a reflection but a growing tower of the same block, one block taller each time it's glanced at.", "techniques": ["bizarreness", "motion"]},
-           "refs": ["memory/vaults/wisdom-vault.md#memory-is-power"]}
+           "refs": ["memory/vaults/wisdom-vault.md#2026-02-10-memory-is-power"]}
         ]},
         {"id": "files-over-ephemera", "name": "The engraved floor", "order": 2, "loci": [
           {"id": "files-over-ephemera", "target": "Files over Ephemera",
            "fact": "Durable files outlast any single conversation — write it down or it didn't happen.",
            "image": {"text": "Footsteps across the dome floor burn away instantly except where a name has been engraved — those steps leave a permanent, glowing print.", "techniques": ["bizarreness", "multisensory"]},
-           "refs": ["memory/vaults/wisdom-vault.md#files-over-ephemera"]}
+           "refs": ["memory/vaults/wisdom-vault.md#2026-02-10-files-over-ephemera"]}
         ]},
         {"id": "compound-intelligence", "name": "The dome's oculus", "order": 3, "loci": [
           {"id": "compound-intelligence-effect", "target": "The Compound Intelligence Effect",
            "fact": "Each interaction makes the system smarter because it builds on everything before it.",
            "image": {"text": "Light enters the oculus as a single thin beam but ricochets off every bronze surface in the dome, doubling in brightness with each bounce before it reaches the floor.", "techniques": ["motion", "exaggeration"]},
-           "refs": ["memory/vaults/wisdom-vault.md#the-compound-intelligence-effect"]}
+           "refs": ["memory/vaults/wisdom-vault.md#2026-02-10-the-compound-intelligence-effect"]}
         ]}
       ]
     },


### PR DESCRIPTION
Wires the new [mind-palace-agent-skills](https://github.com/frankxai/mind-palace-agent-skills) Memory Palace suite into a real repo, as the concrete "agent memory in production" demonstration Frank asked for.

## What this adds
- `memory/palace/palace.json` — a walkable spatial index over the six Starlight Vaults' current entries (6 rooms, one per vault, all six distinct shared-vocabulary surfaces used; 13 loci drawn from real vault index entries with vivid mnemonic encodings).
- `memory/palace/MEMORY_PALACE.md` — what it is, why it exists, and how to maintain it.
- One new subsection in `CLAUDE.md`'s Memory Protocol pointing to it.

## Design constraints (why this is safe)
- **Purely additive.** No vault file is touched, restructured, or duplicated wholesale.
- **Every locus carries `refs`** pointing back to its real source vault entry — per `agent-memory-palace`'s own discipline ("memory is a cache, the source is the truth"), nothing here is invented or treated as authoritative over the vaults.
- **Explicitly framed as a pilot/snapshot**, not an auto-synced system — `MEMORY_PALACE.md` documents how to extend it by hand as vaults grow.
- View it with the [standalone viewer](https://github.com/frankxai/mind-palace-agent-skills/blob/main/assets/palace-viewer/index.html) from the sibling repo (`?src=` this file's raw URL, or drag-and-drop) — no code duplicated into this repo.

Draft for review.

https://claude.ai/code/session_01VL8sxNF2knVwCW1L7Ria2H

---
_Generated by [Claude Code](https://claude.ai/code/session_01VL8sxNF2knVwCW1L7Ria2H)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “Spatial index (pilot)” section explaining the palace index as a companion view and linking to maintenance guidance.
  * Published a new guide describing the memory palace structure, how the six vaults are organized, what each station should include, and how to keep it updated.
  * Added a complete palace index file with a fixed traversal route, six ordered rooms, and linked stations with facts, references, and image details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->