### PR TITLE
Multi-agent ecosystem validation: reconcile claims with evidence, safe npm publish set, full report + blueprint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Every task is either substrate-level or operational-level. Decide before acting.
 **Operational-level** (anything inside this repo's reference build):
 - Use `agents/AGENT_REGISTRY.md` for the current 144-agent registry and existing skill auto-activation.
 - Voice: Frank DNA (above).
-- Triggers: vault writes, MCP server work (`src/`), the core commands in `commands/` (`/council`, `/navigate`, `/starlight`, `/synthesize`, `/transmit`, `/vault`, and the rest of the 14), skill edits, agent edits, site edits.
+- Triggers: vault writes, MCP server work (`src/`), the core commands in `commands/` (`/council`, `/navigate`, `/starlight`, `/synthesize`, `/transmit`, `/vault`, and the rest of the 25 — authoritative index: `commands/COMMAND_SYSTEM.md`), skill edits, agent edits, site edits.
 
 **Ambiguous** → default to substrate; substrate decisions constrain operational, never the reverse.
 
@@ -202,6 +202,12 @@ Skill definitions: mixed layout — `skills/{domain}/{skill-name}/SKILL.md` (31 
 | `/dispatch` | Multi-CLI dispatch — route a task to a sibling CLI (Codex / Gemini / OpenCode) via the cognition router. |
 | `/vault-desire` | Write a desire/intention atom to the vault loop (paired with `/vault-proof`). |
 | `/vault-proof` | Write a proof/receipt atom closing a desire in the vault loop. |
+| `/starlight-king` / `/starlight-queen` / `/starlight-swarm` | Swarm-tier session commands — sovereign coordination (King), swarm leadership (Queen), and swarm construct dispatch. |
+| `/estate-army-deploy` / `/estate-provision` | Estate Factory — provision and deploy a sovereign agent estate (see DELIVERY.md §7). |
+| `/si` / `/so` / `/sq` | Multi-CLI routing shorthands (cognition router / image routing / quick status). |
+| `/agent-creator` / `/workflow-skill-creator` / `/starlight-architect` | Authoring tier — generate new agents, workflow skills, and architecture briefs. |
+
+Authoritative command index: `commands/COMMAND_SYSTEM.md` (25 command files as of v8.3.0).
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Every task is either substrate-level or operational-level. Decide before acting.
 **Operational-level** (anything inside this repo's reference build):
 - Use `agents/AGENT_REGISTRY.md` for the current 144-agent registry and existing skill auto-activation.
 - Voice: Frank DNA (above).
-- Triggers: vault writes, MCP server work (`src/`), the core commands in `commands/` (`/council`, `/navigate`, `/starlight`, `/synthesize`, `/transmit`, `/vault`, and the rest of the 25 — authoritative index: `commands/COMMAND_SYSTEM.md`), skill edits, agent edits, site edits.
+- Triggers: vault writes, MCP server work (`src/`), the core commands in `commands/` (`/council`, `/navigate`, `/starlight`, `/synthesize`, `/transmit`, `/vault`, and the rest of the 25 files there — distinct from the 121 installed slash commands in `.claude/commands/`), skill edits, agent edits, site edits.
 
 **Ambiguous** → default to substrate; substrate decisions constrain operational, never the reverse.
 
@@ -207,7 +207,7 @@ Skill definitions: mixed layout — `skills/{domain}/{skill-name}/SKILL.md` (31 
 | `/si` / `/so` / `/sq` | Multi-CLI routing shorthands (cognition router / image routing / quick status). |
 | `/agent-creator` / `/workflow-skill-creator` / `/starlight-architect` | Authoring tier — generate new agents, workflow skills, and architecture briefs. |
 
-Authoritative command index: `commands/COMMAND_SYSTEM.md` (25 command files as of v8.3.0).
+Command surface as of v8.3.0: 25 command files in `commands/` (this table), plus 121 installed slash commands in `.claude/commands/` (9 of them substrate-tier). `commands/COMMAND_SYSTEM.md` is the architecture doc for the 13 core commands; the directory listing is the ground truth for the rest.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -38,18 +38,20 @@ node dist/cli.js init --vaults
 
 > **Note:** npm currently serves v6.0.1 of `@arcanea/starlight-intelligence-system` — two major versions behind this repo. Use the git path above until v8.x is published.
 
-Then add to your MCP config (Claude Code, Cursor, Codex, Gemini, etc.):
+Then add to your MCP config (Claude Code, Cursor, Codex, Gemini, etc.), pointing at the `dist/mcp-server.js` inside your clone:
 
 ```json
 {
   "mcpServers": {
     "starlight": {
       "command": "node",
-      "args": ["node_modules/@arcanea/starlight-intelligence-system/dist/mcp-server.js", "--vault-dir", "~/.starlight/vaults"]
+      "args": ["/path/to/Starlight-Intelligence-System/dist/mcp-server.js", "--vault-dir", "~/.starlight/vaults"]
     }
   }
 }
 ```
+
+(If you installed via npm instead, the path is `node_modules/@arcanea/starlight-intelligence-system/dist/mcp-server.js` — but see the version note above.)
 
 Restart your client. Every agent now shares the same memory. Thirteen `sis_*` tools appear instantly (verified by JSON-RPC handshake, 2026-07-12).
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Then point your MCP client at that directory:
     "starlight": {
       "command": "node",
       "args": [
-        "node_modules/@arcanea/starlight-intelligence-system/dist/mcp-server.js",
+        "/path/to/Starlight-Intelligence-System/dist/mcp-server.js",
         "--vault-dir",
         "~/.starlight/vaults"
       ]
@@ -198,6 +198,8 @@ Then point your MCP client at that directory:
   }
 }
 ```
+
+For an npm installation, use `node_modules/@arcanea/starlight-intelligence-system/dist/mcp-server.js` instead; the clone path above is required for the current v8.x workflow.
 
 Restart Claude Code. You now have thirteen `sis_*` tools available in every session.
 (If you skip the seed step the server still works — it auto-seeds an empty
@@ -257,7 +259,7 @@ Each vault is a JSONL file. Human-readable. Git-versionable. Greppable.
 - **Contradiction detection** — `src/contradiction.ts` finds conflicting entries via word-trigram Jaccard with opposing-signal boosting.
 - **Dreaming** — `src/dreaming.ts` processes session transcripts in the background.
 - **Five platform adapters** — Claude Code, Cursor, Codex, Gemini CLI, OpenCode share the same vaults.
-- **MCP v2** — `src/mcp-server.ts` ships ten tools over JSON-RPC 2.0 stdio.
+- **MCP v2** — `src/mcp-server.ts` ships thirteen tools over JSON-RPC 2.0 stdio.
 
 ### MCP tools
 
@@ -273,6 +275,9 @@ Each vault is a JSONL file. Human-readable. Git-versionable. Greppable.
 | `sis_invalidate` | Mark an entry as expired |
 | `sis_contradict` | Flag two entries as contradictory |
 | `sis_stale` | List entries not confirmed within a threshold |
+| `sis_goal_status` | Read the current state of a tracked goal |
+| `sis_goal_update` | Update a tracked goal with attested state |
+| `sis_goal_log` | Append progress evidence to a tracked goal |
 
 ### Platform adapters
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,12 @@ Use just the memory layer in your current tools. Adopt the protocol. Or run the 
 ## 60-second start
 
 ```bash
-npx -p @arcanea/starlight-intelligence-system starlight init --vaults
+git clone https://github.com/frankxai/Starlight-Intelligence-System
+cd Starlight-Intelligence-System && npm install && npm run build
+node dist/cli.js init --vaults
 ```
+
+> **Note:** npm currently serves v6.0.1 of `@arcanea/starlight-intelligence-system` — two major versions behind this repo. Use the git path above until v8.x is published.
 
 Then add to your MCP config (Claude Code, Cursor, Codex, Gemini, etc.):
 
@@ -47,7 +51,7 @@ Then add to your MCP config (Claude Code, Cursor, Codex, Gemini, etc.):
 }
 ```
 
-Restart your client. Every agent now shares the same memory. Ten `sis_*` tools appear instantly.
+Restart your client. Every agent now shares the same memory. Thirteen `sis_*` tools appear instantly (verified by JSON-RPC handshake, 2026-07-12).
 
 ---
 
@@ -75,7 +79,7 @@ See [CHANGELOG.md](CHANGELOG.md) for history.
 flowchart TB
   Human["Human intent"] --> Vaults["6 semantic vaults (JSONL truth)"]
   Vaults --> Index["SQLite + FTS5 index"]
-  Index --> MCP["MCP server (10 sis_* tools)"]
+  Index --> MCP["MCP server (13 sis_* tools)"]
   MCP --> Adapters["Every CLI you use"]
   Adapters --> Work["Safer, consistent, memory-aware work"]
   Work --> Vaults
@@ -133,11 +137,11 @@ Full workflow and templates: `docs/delivery/estate-army-commissioning-workflow.m
 | [`MEMORY.md`](MEMORY.md) | Template for per-instance state. |
 | [`REGISTRY.md`](REGISTRY.md) | MCP server registry. |
 | [`SKILL.md`](SKILL.md) | Substrate-layer behavior (what AI adopts when working at this layer). |
-| `.claude/commands/` | 9 reference slash commands (`/sip-attest`, `/alliance-forge`, `/alliance-reflect`, `/alliance-decide`, `/vertical-spawn`, `/luminor-board`, `/sovereign-signal`, `/openclaw-audit`, `/wealth-dpi`). |
+| `.claude/commands/` | 9 substrate-tier slash commands (`/sip-attest`, `/alliance-forge`, `/alliance-reflect`, `/alliance-decide`, `/vertical-spawn`, `/luminor-board`, `/sovereign-signal`, `/openclaw-audit`, `/wealth-dpi`) among 121 total command files. |
 
 ![SIP 6-Layer Protocol — the contract that preserves sovereignty while enabling composition.](docs/visuals/12-sip-layers.jpg)
 
-![MCP Server — 10 sis_* tools exposed uniformly to every platform adapter.](docs/visuals/11-mcp-tools.jpg)
+![MCP Server — 13 sis_* tools exposed uniformly to every platform adapter.](docs/visuals/11-mcp-tools.jpg)
 
 ### Forge an alliance, spawn a vertical
 
@@ -171,7 +175,8 @@ First, seed your vault directory so the system has somewhere to read from
 (a fresh install has no `~/.starlight/vaults` yet):
 
 ```bash
-npx -p @arcanea/starlight-intelligence-system starlight init --vaults
+# From a git clone of this repo (npm registry is at stale v6.0.1 — see note above):
+node dist/cli.js init --vaults
 # → seeds the six JSONL vaults in ~/.starlight/vaults (welcome entry + public examples)
 ```
 
@@ -192,14 +197,14 @@ Then point your MCP client at that directory:
 }
 ```
 
-Restart Claude Code. You now have ten `sis_*` tools available in every session.
+Restart Claude Code. You now have thirteen `sis_*` tools available in every session.
 (If you skip the seed step the server still works — it auto-seeds an empty
 `--vault-dir` on first boot so the empty state is never silently broken.)
 
 **Option 2: As a library**
 
 ```bash
-npm install @arcanea/starlight-intelligence-system
+npm install @arcanea/starlight-intelligence-system  # registry serves v6.0.1 — for v8.x, install from the git clone until republished
 ```
 
 ```ts
@@ -293,7 +298,7 @@ Voice archetypes are abstract; named agents are specific implementations. Anyone
 |------------------|------|-------|
 | Adopt SIP for your own creator stack | `SIP.md`, `SKILL.md`, `VOICES.md`, `.claude/commands/sip-attest.md`, `.claude/commands/alliance-forge.md` | Everything in `agents/`, `memory/`, `skills/`, `src/` |
 | Use the MCP memory server, no protocol | `src/`, `dist/`, npm package | Substrate spec files |
-| Forge an alliance under SIP | `SIP.md`, `ALLIANCE.md`, `VOICES.md`, all 9 commands in `.claude/commands/` | Operational layer |
+| Forge an alliance under SIP | `SIP.md`, `ALLIANCE.md`, `VOICES.md`, the 9 substrate commands in `.claude/commands/` | Operational layer |
 | Run the full reference build | All of it | Nothing |
 
 ---
@@ -323,7 +328,7 @@ Voice archetypes are abstract; named agents are specific implementations. Anyone
                              │  JSON-RPC 2.0 over stdio
                              ▼
             ┌─────────────────────────────────────────┐
-            │  MCP server  (10 sis_* tools)           │
+            │  MCP server  (13 sis_* tools)           │
             └────────────────┬────────────────────────┘
                              │
         ┌────────────────────┼────────────────────────┐

--- a/docs/validation/2026-07-13-multiagent-ecosystem-validation.md
+++ b/docs/validation/2026-07-13-multiagent-ecosystem-validation.md
@@ -1,0 +1,76 @@
+# Starlight Ecosystem — Multi-Agent Validation Report
+
+**Date:** 2026-07-13 · **Method:** 8-agent validation swarm (7 parallel domain validators + 1 completeness critic), ~934k tokens, 207 tool calls · **Branch:** `claude/starlight-multiagent-validation-gxd3bp`
+**Scope:** Starlight-Intelligence-System, starlight-swarm, starlight-agent-skills, starlight-cosmos-engine, starlight-evals, the npm registry surface, the fresh-adopter journey, and the 42-repo cross-reference graph.
+
+Every claim below is backed by a command that actually ran in this session. Per the Metrics Truth Rule, unverifiable claims are labeled as such.
+
+---
+
+## 1. Executive verdict
+
+**The substrate is real. The edges leak credibility.**
+
+| Repo | Verdict | Evidence |
+|---|---|---|
+| **Starlight-Intelligence-System** | ✅ Substantially honest | 144 agents counted exactly (137 + 7 council). 84 skills = 31 dir + 53 flat, all rules resolve. 6 vaults present, palace.json valid. `npm run build` exit 0, **1,142 tests / 0 failures**. site/ + console/ both build. All 29 README links resolve. Both MCP bins pass a live JSON-RPC handshake (see §2). |
+| **starlight-swarm** | ✅ Real code, one broken script | typecheck/build/41 tests/dry-run all pass. Queens, workers, escalation classifier, fail-closed payments adapter exist as tested TypeScript. `npm run lint` was broken (no ESLint config — fixed in this PR). |
+| **starlight-agent-skills** | ✅ Cleanest repo in the family | 26/26 skills validate, `make check` exits 0 end-to-end, adapters/templates/agents all resolve. |
+| **starlight-cosmos-engine** | ⚠️ Honest scaffold, vacuous green | All 5 root scripts exit 0, but 38 of 40 workspaces are 2-line stubs. The 9 "MCP servers" have **no MCP protocol wiring** (no SDK, no handshake, process exits immediately). Pipelines contain no DAG definitions. |
+| **starlight-evals** | ⚠️ Real data, self-violating contract | Rounds contain genuine per-task eval data; 4-PASS payments scorecard reproduced live. But the staleness banner said "🟢 current" 3 days past its own due date, and `npm run probe` overwrote the committed receipt in place (both fixed in this PR). |
+| **npm registry** | 🔴 The critical gap | Of 22 ecosystem package names queried, **only 2 are published**: `@arcanea/starlight-intelligence-system` at **6.0.1** (local: 8.3.0) and `arcanea` at 3.4.0. The README quickstart silently delivered a two-major-versions-stale product to every newcomer (README fixed in this PR; republish is a human decision, see §5). |
+| **Cross-repo graph** | ⚠️ Real hub, frayed edges | 210 doc-level edges across 42 local repos. SIS is the hub (~24 inbound referrers). 37 referenced repo names have no local clone (35 unverifiable from this sandbox — session-403, **not** proven nonexistent). Three "canonical" ecosystem maps contradict each other. Income family missing "Built on SIP" attestation. |
+
+## 2. MCP servers — live handshake (new evidence, closes the critic's gap)
+
+Both hand-rolled SIS MCP bins were started and driven over stdio JSON-RPC (initialize → initialized → tools/list), 2026-07-12:
+
+| Bin | serverInfo | Protocol | Tools |
+|---|---|---|---|
+| `dist/mcp-server.js` | `starlight-sis` 8.3.0 | 2024-11-05 | **13** `sis_*` tools (`sis_vault_search`, `sis_recent_entries`, `sis_stats`, `sis_append_entry`, `sis_entry_types`, `sis_search`, `sis_confirm`, `sis_invalidate`, `sis_contradict`, `sis_stale`, `sis_goal_status`, `sis_goal_update`, `sis_goal_log`) |
+| `dist/starlight-mcp.js` | `starlight-substrate-mcp` 1.1.1 | 2024-11-05 | 4 substrate tools (`starlight_registry_query`, `starlight_verticals_list`, `starlight_attestation_verify`, `starlight_alliance_status`) |
+
+The 1,548 lines of hand-rolled protocol code speak real MCP. README previously undersold this ("ten tools") — corrected to 13.
+
+## 3. Fixes shipped in this branch
+
+| # | Repo | Fix | Why |
+|---|---|---|---|
+| 1 | SIS | README quickstart: npx → git-clone path, with an explicit stale-registry note; tool counts 10→13; command counts corrected (9 substrate among 121 total) | The npx path silently installed 6.0.1 with exit 0 — the verified first wall for every adopter |
+| 2 | SIS | `package.json` files: removed `context/` from the publish set (kept `public-vault/` — required by `src/seed.ts` at runtime) | One authorized `npm publish` would have shipped cross-repo operational state snapshots to the public registry |
+| 3 | SIS | CLAUDE.md commands table: added the 11 undocumented commands (King/Queen/Swarm tier, Estate Factory, routing shorthands, authoring tier) + authoritative index pointer; deleted zero-byte `$null` artifact | Agents reading the contract underestimated the operational command surface |
+| 4 | starlight-evals | Staleness banner → 🔴 STALE; harness writes to gitignored `out/` instead of over the committed receipt; CI now parses the *committed* scorecard before the harness runs and asserts `git diff --exit-code scorecards/` after | A repo whose pitch is "staleness is shown, never hidden" was violating its own contract; one careless commit could destroy published 4-PASS evidence |
+| 5 | starlight-swarm | Removed broken `lint` script (no ESLint config/dependency existed; it dropped into an interactive prompt and hangs CI) | Check surface now matches reality; re-adding eslint-config-next is a separate deliberate change |
+
+All evals fixes verified live: `npm run validate` 6/6, harness run wrote `out/income-payments-safety-2026-07-13.json`, `git diff scorecards/` clean.
+
+## 4. Findings that need decisions (not code)
+
+1. **Publish 8.3.0 to npm — or don't, deliberately.** `prepublishOnly` exists and works; `files` is now safe. This is a one-command human decision that resolves the single worst adopter experience in the ecosystem.
+2. **`affiliate-agent-skills` (23 references, the declared L4 income engine)** has no local clone and is not session-accessible. *Unverifiable from this sandbox* — verify `gh api repos/frankxai/affiliate-agent-skills` from an unrestricted machine. If it doesn't exist, the income family's documented architecture rests on a phantom.
+3. **Three contradictory "canonical" ecosystem maps.** ECOSYSTEM_ARCHITECTURE.md (48 agents/71 skills, v2.0 2026-06-10) vs CLAUDE.md/README (144/84, v8.3.0) vs repos-manifest.json. The hard count says 144/84 is correct **today**; ECOSYSTEM_ARCHITECTURE.md needs a v3 revision or a "historical snapshot" banner, per the Metrics Truth Rule.
+4. **"Built on SIP" attestation is absent from the entire income + payment-skills family** while mind/marine/mesh manifests validate cleanly. Either the attestation is ambient-by-doctrine (then the docs saying so are wrong) or the rollout stalled.
+5. **cosmos-engine's 9 MCP servers need either implementation or renaming.** They are module manifests, not servers. The pattern that works is already in-repo at SIS `src/mcp-server.ts` — port it or rename the directory to `modules/`.
+6. **Domain posture:** `starlightintelligence.org` responds; `starlight-intelligence.org` is NXDOMAIN. Whether it is *available to register* was not verified from this sandbox (RDAP check needed). Repos consistently reference the former; keep it canonical.
+
+## 5. Forward blueprint — Starlight Intelligence Lab buildout
+
+Grounded next moves, in dependency order. Each is a verifiable target, not a vibe.
+
+**Layer 0 — Truth (this PR + decisions above).** One canonical metrics source (`metrics/current.json`) feeding README/CLAUDE/ECOSYSTEM counts; CI check that greps for hardcoded agent/skill counts outside it. Kill the three-way map contradiction.
+
+**Layer 1 — Distribution.** Republish `@arcanea/starlight-intelligence-system@8.3.0` (files field now safe). Then the quickstart flips back to `npx` and the 60-second start becomes true again. Candidate second package: extract `starlight-substrate-mcp` as a tiny standalone (`npx starlight-substrate-mcp`) — the 4-tool substrate server is the lowest-friction "try SIP in 30 seconds" surface that exists today.
+
+**Layer 2 — Proof.** starlight-evals is the credibility engine: wire the staleness banner to be *derived* from the newest scorecard's `nextRunDue` in CI (this PR made it honest manually; automation makes it stay honest). Publish the eval methodology as the public artifact — open, reproducible scorecards are the rarest asset in the agent-framework space and the strongest differentiator vs. every closed "we have 100 agents" claim.
+
+**Layer 3 — Swarm consolidation.** starlight-swarm's Queens/workers/escalation-classifier is real, tested code — it is the reference swarm construct. cosmos-engine should consume it rather than parallel-scaffold. One swarm kernel, many domain deployments (the 144-agent registry is the roster; the swarm kernel is the runtime; keep them decoupled exactly as they are now).
+
+**Layer 4 — Preservation surfaces (the mission layer).** The knowledge-preservation ambition (science, wisdom, poetry, language, cultures) already has its substrate primitives: the six vaults + JSONL truth + SIP attestation + the horizon vault. The credible v1 is not a blockchain — it is: (a) a public, versioned, attested corpus repo per domain using the existing vault schema; (b) Hugging Face dataset mirrors of those corpora (HF gives DOI-like citability, download stats, and community reach for zero infra); (c) content-addressing (sha256 in the attestation block, already supported by `starlight_attestation_verify`) so any mirror can be verified. On-chain anchoring of attestation hashes is a cheap later add (single merkle root per release, any chain) — do it after two corpora exist, not before.
+
+**Layer 5 — Adoption loop.** The adopter journey that *already passes* is git-clone → npm install → 1,142 green tests → MCP config → 13 tools live. Make that the demo. Every README in the family gets the same three-block structure (what this is / 60-second verified start / what "Built on SIP" means), and `starlight-agent-skills` (the cleanest repo) becomes the template for the other satellite repos' CI gates (`make check` pattern).
+
+---
+
+*Validated by an 8-agent swarm under the Starlight Intelligence Lab. All checks reproducible from the commands cited in the swarm journal.*
+
+**Built on SIP** — Starlight Intelligence Protocol.

--- a/memory/vaults/operational-vault.md
+++ b/memory/vaults/operational-vault.md
@@ -587,3 +587,12 @@ Public/private boundary: public repos may contain doctrine, generic routing tabl
 Follow-up guide: `starlight-automation-agent-skills/docs/automation-operating-guide.md` now serves as the human-and-agent manual for understanding when to use native connectors, Codex automations, Hermes/retrieval agents, MCP, Make.com, n8n, Starlight swarm queues, and scripts/GitHub Actions. It includes cost model, decision protocol, observability, eval types, maintenance cadence, evolution ladder, and the agent working agreement. Use `templates/automation-decision-record.md` before durable workflow creation.
 
 Verification performed during setup: skill bundle validator passed, all six Codex skills passed official quick validation, plugin manifest validation passed, MCP example validation passed, n8n example validation passed, redaction self-test passed, and public-safety scans passed for both new public repos.
+
+## 2026-07-13 - Multi-agent ecosystem validation (8-agent swarm)
+
+**Category:** validation-ops
+**Confidence:** 0.97
+**Source:** Claude Code remote session, branch claude/starlight-multiagent-validation-gxd3bp
+**Related:** `docs/validation/2026-07-13-multiagent-ecosystem-validation.md`, starlight-swarm, starlight-evals, starlight-agent-skills, starlight-cosmos-engine
+
+Hard-count verdicts (all reproduced by command): 144 agents exact (137 + 7 council), 84 skills reconcile (31 dir + 53 flat), 1,142 tests / 0 failures, both MCP bins pass live JSON-RPC handshake — starlight-sis 8.3.0 serves 13 sis_* tools (not 10 as README said), starlight-substrate-mcp 1.1.1 serves 4. npm registry serves stale 6.0.1 — README quickstart was the #1 adopter wall (fixed to git path; republish is a pending human decision). cosmos-engine's 9 "MCP servers" have no protocol wiring — scaffold, not servers. starlight-evals staleness banner violated its own contract and the probe harness overwrote the committed 4-PASS receipt (both fixed: harness → out/, CI guards committed scorecards). Three canonical ecosystem maps contradicted each other (48/71 vs 144/84 vs manifest) — 144/84 is correct as of this run; ECOSYSTEM_ARCHITECTURE.md needs a v3 pass. affiliate-agent-skills (23 refs, L4 income engine) unverifiable from sandbox — check from unrestricted network. Income + payment-skills family missing Built-on-SIP attestation. Full report + forward blueprint (5 layers: truth, distribution, proof, swarm consolidation, preservation surfaces) in the validation doc.

--- a/package.json
+++ b/package.json
@@ -140,7 +140,6 @@
   },
   "files": [
     "dist/",
-    "context/",
     "public-vault/",
     "README.md"
   ],


### PR DESCRIPTION
## What this is

An 8-agent validation swarm (7 parallel domain validators + 1 completeness critic) ran across the Starlight ecosystem — this repo, starlight-swarm, starlight-agent-skills, starlight-cosmos-engine, starlight-evals, the live npm registry, the fresh-adopter journey, and the 42-repo cross-reference graph. Every claim was tested by actually running the commands. Full report: `docs/validation/2026-07-13-multiagent-ecosystem-validation.md`.

## Headline verdicts

- ✅ **The substrate is real**: 144 agents counted exactly, 84 skills reconcile, 1,142 tests / 0 failures, site/ + console/ build, all 29 README links resolve
- ✅ **Both MCP bins pass a live JSON-RPC handshake**: `starlight-sis` 8.3.0 serves **13** `sis_*` tools (README said 10 — undersold); `starlight-substrate-mcp` 1.1.1 serves 4
- 🔴 **npm registry serves stale 6.0.1** while the repo is at 8.3.0 — the README `npx` quickstart silently delivered a two-major-versions-old product to every newcomer

## Changes

- **README**: quickstart switched to the verified git-clone path with an explicit stale-registry note; `sis_*` tool count 10 → 13; command counts corrected (9 substrate-tier among 121 total)
- **package.json**: `context/` (cross-repo operational state snapshots) removed from the publish `files` set — one authorized `npm publish` would have shipped it to the public registry. `public-vault/` kept (required by `src/seed.ts` at runtime; verified via `npm pack --dry-run`)
- **CLAUDE.md**: the 11 undocumented commands added (King/Queen/Swarm tier, Estate Factory, routing + authoring tiers) with `commands/COMMAND_SYSTEM.md` as the authoritative index
- **docs/validation/**: full validation report + 5-layer forward blueprint (truth → distribution → proof → swarm consolidation → preservation surfaces)
- **operational vault**: session entry per memory protocol
- Zero-byte `$null` artifact removed

## Decisions this PR surfaces (not code)

1. Republish `@arcanea/starlight-intelligence-system@8.3.0` — files field is now safe
2. `affiliate-agent-skills` (23 refs, declared L4 income engine) is unverifiable from the sandbox — confirm existence from an unrestricted machine
3. Three contradictory canonical ecosystem maps (48/71 vs 144/84 vs manifest) — hard count says 144/84 today; ECOSYSTEM_ARCHITECTURE.md needs a v3 pass

Companion PRs: frankxai/starlight-evals + frankxai/starlight-swarm (same branch name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYLKNfybke8GJ7qq74BAD9

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYLKNfybke8GJ7qq74BAD9)_