### PR TITLE
feat(cosmos): constellation star maps + 11-card encyclopedia wave (v2)

### DIFF
--- a/docs/superpowers/specs/2026-07-13-cosmos-platform-expansion.md
+++ b/docs/superpowers/specs/2026-07-13-cosmos-platform-expansion.md
@@ -1,0 +1,62 @@
+# Starlight Cosmos — Platform Expansion Spec
+
+> 2026-07-13 · Operational-tier (site surfaces + plan doc). Extends `2026-06-11-starlight-cosmos-design.md`.
+> Built on SIP. Captures Frank's platform vision (encyclopedia · visual exploration · story + research agents · multi-surface apps · monetization · network visualization) as a phased, falsifiable plan.
+
+---
+
+## 1. What shipped this session (v2 — Constellations & Spacecraft wave)
+
+- **Encyclopedia +11 cards** (19 → 30): 4 constellations (Orion, Ursa Major, Crux, Cassiopeia), 3 named stars (Betelgeuse, Sirius, Proxima Centauri), 2 spacecraft (Voyager 1, ISS), 2 concepts (Fusion on Earth, What Stars Teach — the philosophy layer, kept honest by physics).
+- **Two new card kinds**: `constellation`, `spacecraft` — the registry now spans 12 kinds.
+- **First visual-exploration surface**: `/cosmos/constellations` — deterministic SVG star maps projected from real J2000 RA/Dec, zero client JS, three reading layers per chart (science / myth / navigation).
+- **Dual-track prompts**: every new card carries a systems prompt, a research trail, and a story seed — the same substrate serves scientific exploration and fiction worldbuilding without mixing the two.
+
+## 2. The thesis, restated
+
+The cosmos surfaces are the public, beautiful proof of the SIS claim: knowledge as agent-consumable substrate. Humans get an encyclopedia with taste; agents get the same registry as MCP resources; the prompts are the bridge between them. Everything below scales that one loop — never a second, disconnected product.
+
+## 3. Vision → workstreams
+
+| # | Workstream | What it is | Status |
+|---|---|---|---|
+| W1 | **Encyclopedia scale-out** | 30 → 100+ cards: planets complete, key moons, more constellations (zodiac, southern sky), spacecraft fleet (Hubble, Cassini, New Horizons, Artemis), stellar lifecycle chain, philosophy-of-science cards | Continuous, every session |
+| W2 | **Visual exploration** | Constellations page (✅) → spacecraft schematic explorer → 3D starfield (r3f, HYG subset, per prior spec S+4) → orbital mechanics playground | Phase-gated |
+| W3 | **Agents on the substrate** | Cosmos MCP v0.1 in `starlight-cosmos-engine` (cards as `cosmos://cards/{slug}` resources, prompts as MCP prompts, NASA fetchers as tools) → story-forge + research-companion agent presets consuming it | S+2 per prior spec — next code session in cosmos-engine |
+| W4 | **Site agent** | "Ask the Cosmos" — an embedded agent on starlightintelligence.org answering from the card corpus (Vercel AI SDK, RAG over registry + markdown, cite cards). Gate: W3 first, so the agent consumes the same MCP the public gets | After W3 |
+| W5 | **Multi-surface** | Expo/React Native app (offline card library + tonight's-sky view), desktop (Tauri preferred over Electron for footprint) — one content pipeline, three renderers | After 100+ cards (content moat first, apps second) |
+| W6 | **Network visualization** | Starlight Network view: SIP nodes, protocol flows, attestation chains rendered like the knowledge-tree graph. Honest framing: visualization of the real SIS/SIP topology — no blockchain claims until an actual chain integration exists | Design doc first |
+| W7 | **Monetization** | See §4 | Decision needed |
+
+## 4. Monetization — honest options, one recommendation
+
+Constraints: the encyclopedia must stay free (it's the distribution + SEO engine and the proof of the thesis); no paywall in front of knowledge cards; OSS substrate stays MIT.
+
+| Model | What's paid | Risk |
+|---|---|---|
+| A. Cosmos Pro subscription | Site agent (W4) with generous free tier, saved exploration trails, exports | Low — standard SaaS on top of free content |
+| B. Templates & packs | Story-universe starter kits, research-workflow templates, agent presets — one-time purchases | Low — matches existing FrankX template motion |
+| C. Community lifetime | Founding-member lifetime tier for the builder community around the cosmos engine | Medium — lifetime pricing caps LTV; cap seat count |
+| D. OSS + paid cloud | Cosmos engine/MCP free to self-host; hosted+managed version paid | Medium — ops burden before product-market fit |
+
+**Recommendation: B now, A when W4 ships, C as a launch event, D last.** Templates monetize the existing audience without new infrastructure; the subscription needs the agent to exist first. Do not build billing before the thing billed for exists.
+
+## 5. Sequencing (each phase falsifiable before the next)
+
+1. **P1 — Substrate depth** (now → 100 cards): W1 continuous. Falsifier: no organic-traffic growth by 50+ cards → SEO thesis wrong, pause W5.
+2. **P2 — Agent surface**: W3 Cosmos MCP v0.1 + story/research presets. Falsifier: no external MCP installs/stars in 60 days → distribution problem, fix before W4.
+3. **P3 — Live agent + first revenue**: W4 site agent + monetization B→A.
+4. **P4 — Multi-surface**: W5 Expo app (content pipeline already proven), W2 3D layer.
+5. **P5 — Network layer**: W6 visualization; any chain/token work requires its own `/starlight-board` gate (sovereign-class).
+
+## 6. Guardrails carried forward
+
+- Facts: established figures only; estimates labeled; fast-moving numbers dated ("as of 2026") — Metrics Truth Rule applies to cosmos cards.
+- Myth and science both present, never mixed — the constellation pages set the pattern (three labeled layers).
+- Zero new runtime deps for content surfaces; three.js only at W2's 3D gate.
+- Every surface additive; no URL renames.
+- Board gates: anything touching SIP/attestation/chain economics is substrate-tier → `/starlight-board` before commit.
+
+---
+
+*Next session pick-up: W1 wave (planets + zodiac constellations) or W3 (Cosmos MCP v0.1 in starlight-cosmos-engine — consolidate the mcp-nasa-media / mcp-esa-webb / mcp-arxiv-space stubs into one `mcp-cosmos` server).*

--- a/site/content/cosmos/betelgeuse.md
+++ b/site/content/cosmos/betelgeuse.md
@@ -1,0 +1,23 @@
+Betelgeuse is the red supergiant marking Orion's eastern shoulder — an M-type star so large that, placed where the Sun sits, its surface would extend past the asteroid belt and possibly out near Jupiter's orbit. It is one of the very few stars whose disk we can resolve from Earth, and almost everything about it comes with an honest error bar. That uncertainty is not a footnote here; it is the story.
+
+## A star with error bars
+
+Start with the distance: roughly 430 to 640 light-years, commonly quoted around 550. Betelgeuse is too far for clean geometric parallax and too bright and bloated for the usual tricks — its own convection cells shift its apparent position enough to contaminate the measurement. Because luminosity and physical size are derived from distance, the diameter estimates swing too: somewhere from around 640 to over 900 times the Sun's radius, depending on the adopted distance and the observing wavelength. A red supergiant has no crisp surface; its outer layers thin gradually into space, so "the edge" is partly a matter of definition. Mass estimates land around 15 to 20 solar masses. Any single confident number you see quoted for Betelgeuse is hiding a range.
+
+It is also a semiregular variable — it brightens and dims on overlapping timescales, roughly 400 days and about six years, driven by pulsations and enormous convection cells. Variability is its normal state.
+
+## How you measure a star that big and blurry
+
+In 1920, Albert Michelson and Francis Pease mounted a 20-foot interferometer on the 100-inch telescope at Mount Wilson and measured Betelgeuse's angular diameter — about 0.047 arcseconds. It was the first star other than the Sun whose size was directly measured. The trick was interference: combine light from two separated apertures, and the fringe pattern encodes spatial detail far finer than either aperture could resolve alone. Modern instruments like ESO's VLTI and ALMA use the same principle at higher precision, and they do not just measure the disk — they image it, revealing bright hotspots and an asymmetric, boiling surface.
+
+## The Great Dimming
+
+Between late 2019 and early 2020, Betelgeuse faded to roughly a third of its usual brightness — the faintest it had been in over a century of photometric records. Public speculation jumped straight to supernova. The instruments told a calmer story: Hubble caught a burst of hot material moving outward through the atmosphere in the months before the dimming, and the VLT's SPHERE imager showed the star's southern hemisphere darkened behind an obscuring cloud. The star had ejected a mass of gas from its surface; as it cooled, it condensed into dust and blocked part of the disk from our line of sight. Betelgeuse recovered. The event was a rare, close-up look at how red supergiants shed mass — the process that seeds galaxies with heavy elements.
+
+## The supernova, honestly
+
+Betelgeuse will explode as a core-collapse supernova — but "soon" means astronomical soon, likely within the next 100,000 years or so, not next Tuesday. Nothing observed, including the Great Dimming, indicates an imminent explosion. When it does go, it will be spectacular and safe: at hundreds of light-years, it will briefly rival the Moon in brightness and be visible in daylight for weeks, with no meaningful hazard to Earth.
+
+## Why it matters to a builder
+
+Betelgeuse is a masterclass in working with uncertainty instead of hiding it. Its distance, size, and fate are all ranges, and astronomers publish the ranges — conclusions carry their confidence intervals with them, the way good benchmarks and estimates should. The 1920 interferometry result is the deeper lesson: when no single instrument can resolve the problem, combine small ones and exploit correlation — the same architecture as phased arrays, aperture synthesis, and every distributed system that beats a monolith. And the Great Dimming is an incident postmortem done right: competing hypotheses, discriminating observations, root cause published. Panic said supernova; instrumentation said dust.

--- a/site/content/cosmos/cassiopeia.md
+++ b/site/content/cosmos/cassiopeia.md
@@ -1,0 +1,23 @@
+Cassiopeia is the bright W of five stars circling the north celestial pole opposite the Big Dipper — and it happens to contain the loudest object in the radio sky. Point a radio telescope anywhere beyond the solar system and nothing outshines Cassiopeia A, the expanding wreckage of a star that died about 340 years ago, as seen from Earth.
+
+## The W is a projection
+
+Like almost every constellation, the W is a line-of-sight accident. Caph (Beta Cassiopeiae) is an F-type star only about 55 light-years away. Ruchbah (Delta) sits at roughly 99 light-years. Schedar (Alpha), a K-type orange giant, is about 228 light-years out. Segin (Epsilon) is roughly 400 light-years away, and Gamma Cassiopeiae — the middle of the W, bright enough that it carries the astronaut-era nickname "Navi" — is an unstable, rapidly spinning B-type star at roughly 550 light-years that flings material into a disk around itself and varies in brightness unpredictably. A factor of ten in distance across five stars; the W exists only from here.
+
+## Two dead stars that changed the field
+
+In November 1572 a new star blazed in Cassiopeia, briefly outshining Venus. Tycho Brahe measured it carefully, showed it had no parallax — meaning it lay far beyond the Moon — and published the result. That single observation cracked the Aristotelian doctrine that the heavens were perfect and unchanging. We now know it as SN 1572, a white-dwarf (Type Ia) supernova, and its remnant is still expanding.
+
+Cassiopeia A is the younger sibling: a massive-star supernova whose light reached Earth around the 1690s, oddly with no confirmed contemporary sighting — the explosion was likely dimmed by surrounding dust. Its remnant, about 11,000 light-years away, is the brightest radio source in the sky after the Sun and a standard calibration target for radio astronomy. JWST images of Cas A now resolve the debris field in enough detail to map individual knots of newly forged oxygen, argon, and neon being thrown into the galaxy — supernova nucleosynthesis, photographed.
+
+## The queen on the throne
+
+In Greek myth Cassiopeia was the queen of Aethiopia who boasted that she (or her daughter Andromeda) outshone the sea nymphs. Poseidon's punishment structured a whole region of the sky: Andromeda chained for the sea monster Cetus, Perseus arriving to intervene — all neighboring constellations. Cassiopeia's own sentence was to circle the pole forever strapped to her throne, hanging upside down for half of every rotation. Arabic tradition read the same stars differently — as a kneeling camel, or as "the tinted hand," a henna-stained hand — and Chinese astronomy assigned them to Wangliang, a famed charioteer, with a nearby star as his whip.
+
+## The counterweight to the Dipper
+
+From mid-northern latitudes Cassiopeia is circumpolar, and it sits across Polaris from the Big Dipper — when one rides high, the other hangs low. That makes it the standard fallback for finding north: on autumn evenings when the Dipper scrapes the horizon or drops behind trees, the W is near the zenith, with its open side facing toward Polaris. Navigators also read the pair as a rough clock, since the two asterisms sweep around the pole once per sidereal day.
+
+## Why it matters to a builder
+
+Cassiopeia rewards redundancy and calibration thinking. Navigation by the Dipper alone fails for part of every night; adding a second landmark on the opposite side of the pole gives the system full coverage — the same reason you run failover across zones rather than scaling one. And Cas A shows what a good reference signal is worth: radio astronomers measure instruments against it precisely because it is bright, stable in position, and thoroughly characterized. Every system needs its Cas A — a known-good source you trust enough to calibrate everything else against.

--- a/site/content/cosmos/crux.md
+++ b/site/content/cosmos/crux.md
@@ -1,0 +1,21 @@
+Crux, the Southern Cross, is the smallest of the 88 constellations and the most heavily used piece of sky in the southern hemisphere. Four bright stars in a compact kite shape do the job that Polaris does in the north — except there is no bright south pole star, so Crux earns its keep as a pointer instead of a beacon.
+
+## Four stars, four different distances
+
+The cross is another line-of-sight pattern, not a physical group. Acrux, the foot, is a multiple system of hot B-type stars roughly 320 light-years away. Mimosa (Beta Crucis), the left arm, is a B-type giant at about 280 light-years. Gacrux, the top, breaks the pattern visually and physically: it is an M-type red giant only about 89 light-years away — the nearest red giant to the Sun — and its warm color is obvious to the naked eye against its blue-white neighbors. Delta Crucis rounds out the cross at roughly 345 light-years. Four stars, spanning a factor of about four in distance, unrelated except from our vantage point.
+
+## The Coalsack and the Jewel Box
+
+Crux sits in one of the richest bands of the southern Milky Way, which makes its two flagship deep-sky objects a study in contrast. The Coalsack is a dark nebula roughly 600 light-years away — a cloud of dust dense enough to blot out the starfield behind it, visible to the naked eye as a black hole punched in the Milky Way's glow. Just off Mimosa lies the Jewel Box (NGC 4755), an open cluster about 6,400 light-years away, only some 14 million years old, where a single orange supergiant sits among dozens of hot blue stars — one of the finest small-telescope targets in the sky.
+
+## The Emu, the flags, and a lost northern star
+
+Aboriginal Australian astronomy reads this region in a way European tradition never did: the Emu in the Sky is a constellation made of darkness, not stars, and the Coalsack is its head, with the body stretching along the dust lanes toward Scorpius. Its seasonal orientation tracked emu breeding cycles — a calendar drawn in dark nebulae. European tradition claimed the stars late; Ptolemy catalogued them as part of Centaurus, and precession has since carried them below the horizon for most of Europe, so early modern navigators encountered the Cross as a discovery. Today it anchors national identity across the southern hemisphere: the flags of Australia, New Zealand, Brazil, Papua New Guinea, and Samoa all carry it.
+
+## Finding south
+
+The method is mechanical. Extend the long axis of the cross, from Gacrux through Acrux, about four and a half times its own length. That point is close to the south celestial pole; drop a vertical line from it to the horizon and you are facing south. Navigators cross-check with the nearby Pointers, Alpha and Beta Centauri, to avoid confusing Crux with the larger, fainter False Cross nearby — a mistake that has genuinely misled sailors.
+
+## Why it matters to a builder
+
+Crux is the pattern for deriving what you need from what you have. The southern sky offers no Polaris — no single marker sitting on the answer — so navigators built a reliable procedure that computes the pole from visible reference points, plus a known failure mode (the False Cross) and a cross-check to guard against it. That is robust system design: when no ground truth is directly observable, derive it, and ship the validation step with the procedure. The Emu adds a second lesson — the information was in the dark regions all along, and an entire tradition of astronomy was built by attending to what the standard schema treated as background.

--- a/site/content/cosmos/fusion-on-earth.md
+++ b/site/content/cosmos/fusion-on-earth.md
@@ -1,0 +1,21 @@
+The Sun confines its fusion reactor with the gravity of 2 × 10^30 kilograms of matter. Earth-bound fusion has to do the same job without the planet-crushing mass — and that single missing ingredient is why the field has been "thirty years away" for seventy years. The physics of fusion is settled. The engineering problem is confinement: holding a plasma hotter than the Sun's core, densely enough, for long enough, inside a machine that survives the experience.
+
+## Three ways to hold a star
+
+**Magnetic confinement** shapes the plasma with fields, since a 100-million-kelvin gas of charged particles will follow field lines but destroy any material wall it touches. Tokamaks and stellarators are the leading geometries. The flagship is ITER, a 35-nation project in southern France designed to produce ten times the power it puts into heating the plasma. After a 2024 rebaseline, first plasma is now expected in the mid-2030s — a timeline that has slipped before and should be read as a projection, not a promise.
+
+**Inertial confinement** skips steady-state entirely: crush a peppercorn-sized fuel capsule so fast that fusion completes before the fuel flies apart. On December 5, 2022, the National Ignition Facility achieved ignition — about 3.15 MJ of fusion energy out against 2.05 MJ of laser energy delivered to the target. The honest asterisk: the lasers drew far more energy from the wall than they delivered to the capsule, roughly two orders of magnitude more. Scientific breakeven at the target, nowhere near breakeven at the plug.
+
+**Private ventures** are betting that new technology shortens the path. Commonwealth Fusion Systems is building SPARC around high-temperature superconducting magnets, which allow far stronger fields in a far smaller machine; Helion is pursuing pulsed field-reversed configurations with direct electricity recovery; TAE is working on beam-driven plasmas with an eye toward aneutronic fuel. As of 2026, none has produced net electricity. That is the current scoreboard, stated plainly.
+
+## Why it is this hard
+
+Three constraints compound. The plasma must exceed 100 million kelvin — hotter than the Sun's core, because we cannot match the Sun's density or wait millennia for reactions to accumulate. It must be confined long enough at high enough density for fusion output to exceed losses (the Lawson criterion), while the plasma itself fights confinement with a zoo of instabilities. And the reactor structure must survive years of 14 MeV neutron bombardment that displaces atoms in any material we know how to make — arguably the least glamorous and most unsolved problem of the three.
+
+## Not the Sun's fusion
+
+Terrestrial machines do not run the Sun's reaction. The Sun fuses bare protons through the proton-proton chain — a process so slow (its first step waits on a rare weak-force decay) that a kilogram of solar core produces less power than a compost heap. The Sun compensates with volume and gravity-funded patience. We have neither, so we burn deuterium-tritium, the reaction with the fattest cross-section, at temperatures the Sun never needs. The Sun also self-regulates: run hot and the core expands and cools, run cold and it contracts and reheats — a passive feedback loop with 10-billion-year uptime. Every tokamak control system is an attempt to engineer, with sensors and actuators, the stability gravity provides the Sun for free.
+
+## Why it matters to a builder
+
+Fusion is the clearest live example of a problem where the science is proven and everything remaining is engineering — and the engineering is the hard part. The lessons transfer. Metrics can mislead: "net energy gain" meant something specific and narrow at NIF, and knowing which boundary a number is measured at is the difference between insight and hype. Constraints compound: temperature, confinement, and materials are not three problems but one coupled system, like latency, consistency, and cost in distributed systems. And nature's reference design shows what to steal: not the Sun's reaction, which we cannot afford, but its self-regulation. The best systems hold their setpoint without a controller.

--- a/site/content/cosmos/iss.md
+++ b/site/content/cosmos/iss.md
@@ -1,0 +1,21 @@
+Since November 2, 2000, there has not been a single moment when every human being was on Earth. The International Space Station has been continuously crewed for over a quarter century — long enough that an entire generation has grown up on a planet whose species permanently maintains an outpost off it. That fact gets stated so rarely it is easy to miss how strange it is.
+
+## The machine itself
+
+The ISS orbits at roughly 400 km altitude, moving at about 28,000 km/h — a full circuit of the planet every ~90 minutes, which means the crew sees 16 sunrises and 16 sunsets a day. Fully assembled, it spans roughly the length of a football field and masses about 420 tons, making it by far the largest structure humans have built in space. It was not launched; it was assembled — over 40 flights delivering modules, trusses, and solar arrays that had never been mated on the ground, connected for the first time in orbit by robotic arms and spacewalking crews. That the pieces fit is one of the great systems-integration achievements in engineering history.
+
+## The partnership that would not break
+
+Five agencies run the station: NASA, Roscosmos, ESA, JAXA, and CSA. Since the first module launched in 1998, the partnership has survived every geopolitical crisis that touched its member states — including periods when the same governments were imposing sanctions on each other. Part of the reason is deliberate architecture: the Russian and American segments are functionally interdependent, historically trading propulsion and attitude control against power generation, so neither side could simply walk away. Cooperation was not left to goodwill; it was designed into the structure.
+
+## What the lab produced
+
+The station's core value is a condition unavailable anywhere on Earth: sustained microgravity. Protein crystals grow larger and more ordered there, sharpening structure determination for drug research. Fluids behave differently — surface tension dominates where buoyancy and convection vanish, rewriting assumptions baked into Earth-side engineering. And the crew are experiment and experimenter at once: unprotected by countermeasures, astronauts lose bone density at roughly 1–1.5% per month in weight-bearing bones, which is why exercise protocols consume two hours of every crew day. Decades of that human physiology data is the foundation for any future long-duration mission — you cannot plan a Mars transit without knowing what free fall does to a body over months.
+
+## The planned ending
+
+Current plans call for deorbiting the station around 2030–2031, steered into a remote stretch of the Pacific by a dedicated deorbit vehicle. Commercial stations are intended to take over the low-Earth-orbit role — that is the plan of record, not a certainty, and both the retirement date and the readiness of successors have moved before and may move again. Either way, the ISS will end as deliberately as it was built: a controlled disposal of the most expensive single structure ever constructed.
+
+## Why it matters to a builder
+
+The ISS is a masterclass in three things builders face constantly. First, incremental assembly with no integration environment: modules built on different continents, to different standards, mated for the first time in production — interface discipline and rigorous specs made that survivable, and the same discipline is what makes distributed systems composable. Second, keeping a system alive while replacing it: 25 years of upgrades — solar arrays, computers, life support — swapped out on a platform that could never be powered down. Third, institutional design: the partnership held through crises because the architecture made defection costly and cooperation structural. When you design a system meant to outlast the conditions it was born in — technical or organizational — build the interdependence in. Goodwill is not a load-bearing component.

--- a/site/content/cosmos/orion.md
+++ b/site/content/cosmos/orion.md
@@ -1,0 +1,21 @@
+Orion is the most recognizable constellation in the sky and one of the most honest lessons in astronomy: the pattern you see is a projection, not a place. Its seven bright stars look like a coherent figure, but they span a range of well over a thousand light-years of depth — a chance alignment viewed from one specific vantage point in the galaxy.
+
+## Seven stars, no group
+
+Bellatrix, the hunter's left shoulder, is a B2 giant roughly 245 light-years away. Betelgeuse, the right shoulder, is an M-type red supergiant at roughly 550 light-years. Rigel, the left foot, is a B8 blue supergiant at about 860 light-years. The three belt stars — Alnitak, Alnilam, and Mintaka — sit far behind all of them: Alnitak and Mintaka at roughly 1,200 light-years, Alnilam farther still, with estimates of about 1,300 to 2,000 light-years. None of these stars orbit each other. Move the Sun fifty light-years in any direction and the hunter dissolves. Constellations are line-of-sight patterns, and Orion is the clearest proof.
+
+## The nursery and the endgames
+
+Below the belt hangs M42, the Orion Nebula, about 1,344 light-years away — the nearest massive star-forming region to Earth and visible to the naked eye as a fuzzy patch in the sword. Inside it, the four Trapezium stars are ionizing the gas they were born from; hundreds of protostars and protoplanetary disks have been imaged there directly. The constellation also shows you both ends of a massive star's life in one frame. Betelgeuse is a red supergiant in its final phase — its dramatic dimming in 2019-2020 turned out to be a dust cloud, not a pre-supernova signal, but it will explode on an astronomical timescale of roughly the next 100,000 years. Rigel, tens of thousands of times more luminous than the Sun, is headed the same way. One field of view: birth, midlife, and the approach to collapse.
+
+## The hunter, Osiris, and the Three Kings
+
+In Greek myth Orion is the giant hunter killed by a scorpion — which is why Orion and Scorpius sit on opposite sides of the sky, one setting as the other rises. In ancient Egypt the same stars were Sah, closely tied to Osiris, god of the dead and rebirth; some researchers have proposed alignments between the Giza pyramids and the belt, though that theory remains contested. The belt itself carries names across cultures: the Three Kings in much of Europe and Latin America, Frigg's Distaff in Scandinavia, and a canoe or trio of fishermen in several Pacific traditions. Same three stars, dozens of stories — the pattern is universal, the meaning is local.
+
+## The equatorial clock
+
+Orion straddles the celestial equator — Mintaka sits within about a third of a degree of it. That makes the belt a navigation instrument: seen from anywhere on Earth, it rises very close to due east and sets very close to due west. Sailors in both hemispheres have used it as a compass check for centuries, and its position also makes Orion one of the few constellations visible from nearly every inhabited latitude.
+
+## Why it matters to a builder
+
+Orion teaches the difference between a pattern and a system. The stars look related; they are not — the relationship exists only in the observer's projection. That is the exact failure mode of dashboards and analytics: correlations that are artifacts of viewpoint, not structure. Before you build on a pattern, ask Orion's question — do these components actually interact, or do they just happen to line up from where I'm standing? And the belt earns a second lesson: a genuinely reliable invariant (rises east, sets west, everywhere) is worth more than a hundred impressive-looking coincidences.

--- a/site/content/cosmos/proxima-centauri.md
+++ b/site/content/cosmos/proxima-centauri.md
@@ -1,0 +1,21 @@
+Proxima Centauri is the nearest star to the Sun — 4.246 light-years away — and you cannot see it. It is an M5.5Ve red dwarf carrying only about 12% of the Sun's mass, so dim that at eleventh magnitude it needs a telescope despite being closer than anything else that burns. The nearest star in the sky is invisible in it. That inversion — proximity without visibility — sets the tone: the most reachable star is one of the hardest to reckon with.
+
+## The faint third member
+
+Proxima was only discovered in 1915, by Robert Innes, long after its bright neighbors. It belongs to the Alpha Centauri system: Alpha Centauri A and B are Sun-like stars orbiting each other closely, while Proxima circles the pair from roughly 13,000 astronomical units out — about a fifth of a light-year — on an orbit of roughly half a million years. Fully convective, it mixes its entire hydrogen supply into the core and burns it with extreme thrift. Red dwarfs like Proxima have projected lifespans in the trillions of years — hundreds of times the current age of the universe. Long after the Sun has died, the Proximas will still be burning — the last stars lit anywhere will look like this one.
+
+## Planets next door
+
+In 2016, radial-velocity measurements confirmed Proxima b: a planet with a minimum mass of about 1.07 Earth masses, orbiting every 11.2 days at roughly 0.05 AU. Because Proxima is so faint, that tight orbit sits inside the habitable zone — the range where liquid water could exist on the surface. A second confirmed planet, Proxima d, is a sub-Earth (roughly a quarter of Earth's minimum mass) orbiting even closer, every five days. The nearest star has a rocky planet at a temperate distance. That fact reshaped both exoplanet science and interstellar ambitions.
+
+## The flare problem
+
+Whether Proxima b is habitable is genuinely contested. Proxima is a violent flare star: it erupts frequently, sometimes brightening dramatically in minutes, and a planet at 0.05 AU takes the full blast. Over billions of years, flares and stellar wind may have stripped Proxima b's atmosphere and irradiated its surface; the planet is also likely tidally locked, one face in permanent day. That is the pessimistic case. The optimistic case: a thick atmosphere, a strong magnetic field, or a deep ocean could shield the surface, and atmospheric circulation can redistribute heat on locked planets. Both cases are consistent with current data. Nobody knows yet — the honest answer is that Proxima b is the best nearby laboratory for finding out.
+
+## What 4.25 light-years actually means
+
+The distance sounds small until you price the propulsion. Voyager 1, the fastest object humanity has sent into interstellar space, moves at about 17 km/s; pointed at Proxima, it would need on the order of 75,000 years. Chemical rockets do not get meaningfully better. This is why Breakthrough Starshot proposes abandoning rockets entirely: gram-scale probes on light sails, pushed by a ground-based laser array to a target of 15-20% of light speed, arriving in roughly 20-30 years. Every part of the concept is a hard engineering problem — laser power in the tens of gigawatts, sail materials that survive the push, returning data across four light-years with milliwatts. But it is physics-legal, and Proxima is why it targets where it does.
+
+## Why it matters to a builder
+
+Proxima is a lesson in observability: the most important node can be the one your instruments miss. The nearest star went undiscovered until 1915 because brightness, not distance, is what surveys select for — audit what your metrics privilege, because the critical dependency may be dim. The habitability debate models good reasoning under incomplete data: hold both hypotheses, state what evidence would discriminate, and resist premature conviction. And Starshot is constraint-driven design at its purest — when the standard architecture is five orders of magnitude short, you do not optimize it, you change what you send.

--- a/site/content/cosmos/sirius.md
+++ b/site/content/cosmos/sirius.md
@@ -1,0 +1,23 @@
+Sirius is the brightest star in the night sky — apparent magnitude −1.46, an A1V main-sequence star burning white 8.6 light-years away in Canis Major. Its brightness is mostly proximity: Sirius is about 25 times more luminous than the Sun, respectable but unremarkable. What makes it one of the most consequential stars in the history of astronomy is the companion nobody could see, and the calendar an entire civilization set by its rising.
+
+## The Dog Star
+
+Sirius anchors Canis Major, the Great Dog, which is why it has been the "Dog Star" for millennia — and why the sweltering weeks of late summer, when Sirius rises with the Sun, are still called the dog days. It is hot (roughly 9,900 K at the surface, hotter than the Sun's 5,772 K), about twice the Sun's mass, and young — a few hundred million years old. From most of Earth's surface it is unmissable: a hard white point low in the winter sky, flashing colors near the horizon as the atmosphere shreds its light.
+
+## The star found by gravity
+
+In 1844, Friedrich Bessel published a strange result. Decades of precise positional measurements showed Sirius was not moving through the sky in a straight line — it wobbled, tracing a slow wave with a period around fifty years. Bessel's conclusion was audacious: Sirius has an unseen companion, massive enough to swing the brightest star in the sky around a shared center of mass. He predicted the invisible star from its gravitational signature alone — gravity used as a detection instrument, eighteen years before anyone laid eyes on the object.
+
+In 1862, telescope maker Alvan Graham Clark was testing a new 18.5-inch refractor lens and spotted a faint point in the glare exactly where Bessel's companion should be. Sirius B was real.
+
+## An impossible object
+
+Sirius B turned out to be stranger than a dim star. It carries roughly a solar mass compressed into a body about the size of Earth — the first white dwarf ever discovered. A teaspoon of its material would weigh tons. Physics of the time could not explain matter holding itself up at such density; the answer required quantum mechanics — electron degeneracy pressure, the refusal of electrons to be squeezed into identical states. Sirius B became a proving ground: its extreme surface gravity produced one of the early measurements of gravitational redshift, light losing energy climbing out of a deep gravity well, just as general relativity predicted. Sirius B is what Sirius A will become — the exposed core of a star that exhausted its fuel and shed its outer layers.
+
+## The star that ran a civilization
+
+Ancient Egypt scheduled itself by Sirius, which they called Sothis (Sopdet). Each year, after weeks of invisibility behind the Sun, Sirius reappears in the dawn sky — its heliacal rising. In Egypt that reappearance arrived close to the annual flooding of the Nile, the event the entire agricultural economy depended on. The Egyptians pinned their civil calendar to it and treated the rising as the herald of the flood. A star functioning as civil infrastructure: a free, tamper-proof, planet-scale clock that no ruler could adjust and no scribe could corrupt, reliable across dynasties.
+
+## Why it matters to a builder
+
+Bessel's 1844 prediction is the template for a whole class of engineering insight: you can detect what you cannot observe by measuring its influence on what you can. A latency wobble implies a hidden load; a residual in the data implies a missing term in the model. Trust the anomaly, characterize it quantitatively, and predict what will be found — then wait for the better instrument to confirm it. That is how Neptune and exoplanets were found, and how engineers find ghost dependencies in production. And the Egyptian calendar is the oldest example of a pattern builders still reach for: anchor your system to an external clock more reliable than anything you could build yourself.

--- a/site/content/cosmos/star-wisdom.md
+++ b/site/content/cosmos/star-wisdom.md
@@ -1,0 +1,21 @@
+The calcium in your bones and the iron in your blood did not exist when the universe began. The Big Bang made hydrogen, helium, and a trace of lithium — everything else was manufactured later, inside stars or in the violence of their deaths, and delivered here by supernova shockwaves and merging neutron stars. "We are star stuff" sounds like poetry. It is actually a supply-chain statement, and every link in the chain is measurable.
+
+## The literal supply chain
+
+Trace any heavy atom in your body backward and the provenance is specific: carbon and oxygen forged in the cores of stars that later shed their outer layers; iron built up in massive stars and scattered by core-collapse supernovae; much of the gold and iodine likely synthesized in neutron star mergers, events astronomers have now watched happen in gravitational waves and light at once. The solar system condensed from a cloud pre-enriched by earlier stellar generations — which means your body is a downstream product of manufacturing runs that completed billions of years before Earth existed. No metaphor required. The isotope ratios are the receipts.
+
+## The first infrastructure
+
+Before writing, stars were humanity's clock, calendar, compass, and database. Polynesian navigators crossed thousands of kilometers of open Pacific reading star paths against the horizon. Egyptian agriculture ran on the heliacal rising of Sirius — the first dawn the star reappears after weeks behind the Sun — which reliably preceded the Nile flood and effectively scheduled a civilization's food supply. The sky was the one display every human could see, the one reference frame nobody could tamper with, and the one system guaranteed to run tonight. Astronomy is the oldest science because the sky was the first public utility.
+
+## Looking up is looking back
+
+Starlight is old news, literally. The photons from Andromeda arriving at your retina tonight left that galaxy 2.5 million years ago, when the genus Homo was new. Light's finite speed makes every telescope a time machine and the night sky a depth-sorted archive: the farther you look, the earlier the universe you see. Deep time is not an abstraction — it is directly visible, which makes the sky the most effective perspective instrument we own. Astronauts report a version of the same recalibration from the other direction: the Overview Effect, a documented cognitive shift on seeing Earth whole against black — borders invisible, atmosphere alarmingly thin. The consistent report is not mysticism but a change in scale perception: the frame gets bigger and priorities re-sort.
+
+## The original memory palace
+
+Constellations are a data structure. Cultures across every continent, mostly independently, compressed knowledge into sky patterns: star groups bound to stories, stories carrying payloads — when to plant, where to sail, which season approaches. The pattern is mnemonic engineering: vivid narrative anchored to fixed spatial locations, which is precisely the method-of-loci technique memory athletes use today, except the loci were shared by everyone and backed up in every teller's head. Oral cultures transmitted usable astronomy across hundreds of generations with zero writing and remarkably low corruption. It is the longest-running knowledge-persistence system our species has operated.
+
+## Why it matters to a builder
+
+Every lesson here is load-bearing for someone who builds. The supply chain teaches provenance: knowing where your materials came from — atoms, data, dependencies — is what separates understanding from assumption. The first infrastructure teaches that the best reference systems are the ones nobody can tamper with and everybody can read; that is the design bar for any shared source of truth. Deep time is calibration against quarterly thinking — build against a longer axis and different decisions become obvious. And the constellation trick is the oldest proof that durable knowledge transfer needs structure: spatial anchors, narrative compression, redundancy across many minds. None of this requires believing anything beyond the physics. That is the point — the wonder survives verification, and the systems built on it lasted longer than any we have shipped since.

--- a/site/content/cosmos/ursa-major.md
+++ b/site/content/cosmos/ursa-major.md
@@ -1,0 +1,21 @@
+Ursa Major, the Great Bear, is the third-largest constellation in the sky and home to the most useful seven stars in the northern hemisphere: the Big Dipper. It is also the rare exception to the rule that constellations are optical illusions — most of the Dipper's stars really do travel together.
+
+## A real group, with two impostors
+
+The five middle stars of the Dipper — Merak, Phecda, Megrez, Alioth, and Mizar — belong to the Ursa Major Moving Group, a loose stream of stars born from the same cluster roughly 300 million years ago, now drifting through space on shared trajectories about 80 light-years from Earth. The two ends of the Dipper are the outsiders: Dubhe, a K-type giant at roughly 123 light-years, and Alkaid, a hot B-type star at about 104 light-years, are both moving in different directions. Over roughly 100,000 years, the pattern will visibly deform — the ends will swing away while the middle holds together. Most constellations are pure line-of-sight coincidence; the Dipper is about seventy percent a real system.
+
+## Doubles all the way down
+
+Look at Mizar, the bend in the handle, and a sharp eye picks out faint Alcor beside it — an eyesight test used for centuries. A telescope splits Mizar itself into two stars, making it the first telescopic binary ever recorded, in the early 1600s. Spectroscopy later split each of those again, and Alcor turned out to have a companion too: what looks like one star is a system of six. Ursa Major also hosts a pair of showpiece galaxies about 12 million light-years away — M81, a grand-design spiral, and M82, a starburst galaxy churning out stars roughly ten times faster than the Milky Way after a close pass between the two.
+
+## Bear, Plough, Sages, and the Drinking Gourd
+
+The bear identification is strikingly widespread — ancient Greece (the nymph Callisto, transformed by a jealous goddess and placed in the sky), and independently among several Indigenous North American peoples, which has led some researchers to suggest the story is many thousands of years old. Britain sees the Plough; Germany a wagon; India the Saptarishi, the Seven Sages. The most consequential reading is recent: enslaved people escaping north on the Underground Railroad in the 1800s knew the Dipper as the Drinking Gourd. "Follow the Drinking Gourd" was not a metaphor — it was an operational instruction encoding a bearing toward free states.
+
+## The pointer stars
+
+The Dipper's front edge, Merak to Dubhe, is the standard route to Polaris: extend that line about five times its own length and you land on the North Star, which sits within roughly a degree of the north celestial pole. Polaris's altitude above the horizon equals your latitude — the basis of centuries of navigation. From mid-northern latitudes the Dipper is circumpolar, never setting, so the pointer is available every clear night of the year.
+
+## Why it matters to a builder
+
+The Dipper is a lesson in verifying structure instead of assuming it. Five of its stars share provenance and motion; two just happen to be passing through the frame. That is what real systems look like — genuinely coupled components mixed with coincidental neighbors, and you cannot tell them apart by appearance, only by measuring how they move over time. And the pointer stars model good interface design: nobody navigates by memorizing Polaris in isolation. They find an unmistakable landmark and follow a simple, repeatable rule from it. When you document a system, build pointers — obvious entry points with mechanical instructions to the thing that actually matters.

--- a/site/content/cosmos/voyager-1.md
+++ b/site/content/cosmos/voyager-1.md
@@ -1,0 +1,21 @@
+Voyager 1 launched on September 5, 1977, with 69 kilobytes of memory, a transmitter about as powerful as a refrigerator light bulb, and a mission plan measured in years. As of 2026 it is roughly 25 billion kilometers from the Sun — about 167 AU, both figures approximate and growing by the day — making it the farthest human-made object in existence. It is still returning science data. Nobody who worked on the original code expected that sentence to be true in this century.
+
+## Out of the bubble
+
+On August 25, 2012, Voyager 1 crossed the heliopause — the boundary where the Sun's outflowing plasma gives way to the interstellar medium — and became the first spacecraft to sample the space between stars directly. The crossing showed up in the data as a jump in plasma density and a change in the particle environment: the solar wind's voice fading, the galaxy's static rising. Every measurement since then comes from a region no other instrument has ever touched.
+
+## Running on four fewer watts every year
+
+The spacecraft is powered by three radioisotope thermoelectric generators converting the heat of decaying plutonium-238 into electricity. That decay is relentless: the power budget shrinks by roughly 4 watts per year, and mission engineers have spent decades deciding which instrument or heater to switch off next. This is graceful degradation as a formal discipline — rank every subsystem by science value per watt, shed load in that order, and keep the core mission alive on a budget that only ever goes down.
+
+## The 2024 rescue
+
+In late 2023 Voyager 1 stopped sending intelligible data. Engineers traced the fault to a corrupted memory chip in the flight data subsystem — a hardware failure in a computer built in the early 1970s. The fix, completed in 2024: identify the affected code, relocate it in fragments to other regions of that 69 KB memory, patch the references, and uplink the changes across roughly 24 billion kilometers. One-way light time was about 22.5 hours, so every command-and-response cycle took nearly two days. They revived 46-year-old software on hardware they could never touch, using documentation written by people long retired. It worked.
+
+## The messages it carries
+
+Voyager 1 carries the Golden Record — a gold-plated copper phonograph disc holding greetings in 55 languages, music from Bach to Chuck Berry, and encoded images of Earth, curated by a committee chaired by Carl Sagan. And it took one of the most consequential photographs ever made: on February 14, 1990, at Sagan's urging, it turned its camera back and captured Earth as a fraction of a pixel — the Pale Blue Dot. The probe is both an instrument and an artifact: a data source pointed outward and a message pointed forward.
+
+## Why it matters to a builder
+
+Voyager 1 is the reference case for designing systems you can never touch again. Every principle it embodies transfers directly: budget for degradation from day one and decide in advance what sheds first; keep the system observable even in failure — Voyager's garbled telemetry still carried enough signal to localize a bad chip; write documentation for the maintainer who will not be you, decades out; and keep the core small — 69 KB was patchable precisely because a human could hold the whole memory map in their head. Most software rots in five years with the original team down the hall. This machine has run 48 years with a 22.5-hour ping. When you ship something meant to last — a protocol, a data format, an archive — Voyager is the standard for what "built for longevity" actually demands.

--- a/site/src/app/cosmos/constellations/page.tsx
+++ b/site/src/app/cosmos/constellations/page.tsx
@@ -1,0 +1,130 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Starfield } from "@/components/cosmos/Starfield";
+import { ConstellationMap } from "@/components/cosmos/ConstellationMap";
+import { CardTile } from "@/components/cosmos/CardTile";
+import { CONSTELLATIONS } from "@/lib/cosmos/constellations";
+import { CARD_BY_SLUG } from "@/lib/cosmos/cards";
+
+export const metadata: Metadata = {
+  title: "Constellations — Starlight Cosmos",
+  description:
+    "Interactive star maps of Orion, the Big Dipper, the Southern Cross, and Cassiopeia — the science, the myth, and the navigation in one view. The sky as humanity's first interface.",
+  openGraph: {
+    title: "Constellations — Starlight Cosmos",
+    description:
+      "Star maps with three reading layers: what the stars physically are, what cultures drew on them, and how travelers still navigate by them.",
+    type: "website",
+  },
+};
+
+export default function ConstellationsPage() {
+  return (
+    <div>
+      {/* ── Hero ── */}
+      <section className="relative overflow-hidden border-b border-white/[0.04]">
+        <Starfield seed={1054} count={150} />
+        <div className="relative mx-auto max-w-5xl px-6 py-20 md:py-28">
+          <p className="text-[11px] font-medium uppercase tracking-[0.25em] text-cyan-300">
+            Starlight Cosmos · Constellations
+          </p>
+          <h1 className="mt-4 max-w-3xl font-serif text-[clamp(2.2rem,5.5vw,3.8rem)] font-semibold leading-[1.05] tracking-tight text-white">
+            The sky was our first interface.
+          </h1>
+          <p className="mt-6 max-w-2xl text-[16px] leading-[1.85] text-slate-300">
+            A constellation is a line-of-sight illusion — stars hundreds of
+            light-years apart, aligned only from Earth&apos;s vantage point —
+            that humans turned into a clock, a compass, a calendar, and a
+            memory palace. Each map below reads in three layers: the physics,
+            the myth, and the navigation. All three are true at once.
+          </p>
+          <div className="mt-8 flex flex-wrap gap-3">
+            <Link
+              href="/cosmos/cards"
+              className="rounded-full bg-white px-5 py-2.5 text-[13px] font-medium text-[#060609] transition-micro hover:bg-white/90"
+            >
+              Browse all knowledge cards
+            </Link>
+            <Link
+              href="/cosmos"
+              className="rounded-full border border-white/[0.12] px-5 py-2.5 text-[13px] font-medium text-slate-200 transition-micro hover:border-white/[0.25]"
+            >
+              Back to Cosmos hub
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Maps ── */}
+      <section className="mx-auto max-w-6xl px-6 py-16">
+        <div className="grid gap-10 md:grid-cols-2">
+          {CONSTELLATIONS.map((c) => {
+            const card = CARD_BY_SLUG[c.slug];
+            return (
+              <article
+                key={c.slug}
+                className="flex flex-col rounded-2xl border border-white/[0.06] bg-white/[0.02] p-6"
+              >
+                <ConstellationMap constellation={c} seed={c.slug.length * 977} />
+                <h2 className="mt-5 text-[19px] font-semibold tracking-tight text-white">
+                  {c.name}
+                </h2>
+                <p className="mt-1 text-[13px] leading-[1.7] text-slate-400">
+                  {c.tagline}
+                </p>
+                <dl className="mt-4 space-y-3 text-[13px] leading-[1.7]">
+                  <div>
+                    <dt className="text-[10px] font-medium uppercase tracking-[0.2em] text-amber-300">
+                      Science
+                    </dt>
+                    <dd className="mt-1 text-slate-300">{c.science}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-[10px] font-medium uppercase tracking-[0.2em] text-violet-300">
+                      Myth
+                    </dt>
+                    <dd className="mt-1 text-slate-300">{c.myth}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-[10px] font-medium uppercase tracking-[0.2em] text-cyan-300">
+                      Navigation
+                    </dt>
+                    <dd className="mt-1 text-slate-300">{c.navigation}</dd>
+                  </div>
+                </dl>
+                {card && (
+                  <Link
+                    href={`/cosmos/cards/${card.slug}`}
+                    className="mt-5 text-[12px] text-slate-500 transition-micro hover:text-slate-300"
+                  >
+                    Read the {c.name.split(" ")[0]} knowledge card →
+                  </Link>
+                )}
+              </article>
+            );
+          })}
+        </div>
+      </section>
+
+      {/* ── The stars behind the patterns ── */}
+      <section className="mx-auto max-w-6xl px-6 pb-20">
+        <h2 className="font-serif text-[24px] font-semibold tracking-tight text-white">
+          The stars behind the patterns
+        </h2>
+        <p className="mt-2 max-w-2xl text-[14px] leading-[1.8] text-slate-400">
+          Zoom past the figure and every point resolves into a physical object
+          with its own story — a dying supergiant, a binary with an invisible
+          companion, the quiet red dwarf next door.
+        </p>
+        <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {["betelgeuse", "sirius", "proxima-centauri"]
+            .map((s) => CARD_BY_SLUG[s])
+            .filter(Boolean)
+            .map((card) => (
+              <CardTile key={card.slug} card={card} />
+            ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/site/src/app/cosmos/page.tsx
+++ b/site/src/app/cosmos/page.tsx
@@ -73,13 +73,13 @@ export default async function CosmosPage() {
         </div>
       </section>
 
-      {/* ── Three views, one entry ── */}
+      {/* ── Four views, one entry ── */}
       <section className="border-b border-white/[0.04] px-6 py-16 md:py-20">
         <div className="mx-auto max-w-5xl">
           <h2 className="text-[11px] font-medium uppercase tracking-widest text-slate-400">
-            One entry, three views
+            One entry, four views
           </h2>
-          <div className="mt-6 grid gap-4 sm:grid-cols-3">
+          <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
             <ViewTile
               href="/cosmos/gallery"
               title="Deep Field"
@@ -93,6 +93,13 @@ export default async function CosmosPage() {
               accent="text-rose-300"
               border="border-rose-500/[0.2]"
               body="Near-Earth asteroids passing this week, with the mining-economics lens nobody else gives you."
+            />
+            <ViewTile
+              href="/cosmos/constellations"
+              title="Star Maps"
+              accent="text-amber-300"
+              border="border-amber-500/[0.2]"
+              body="Orion, the Dipper, the Southern Cross — science, myth, and navigation on one chart."
             />
             <ViewTile
               href="/cosmos/cards"

--- a/site/src/app/sitemap.ts
+++ b/site/src/app/sitemap.ts
@@ -24,6 +24,7 @@ const STATIC_ROUTES = [
   "/cosmos",
   "/cosmos/gallery",
   "/cosmos/cards",
+  "/cosmos/constellations",
   "/asteroids",
   "/queen",
   "/palace",

--- a/site/src/components/cosmos/ConstellationMap.tsx
+++ b/site/src/components/cosmos/ConstellationMap.tsx
@@ -1,0 +1,131 @@
+// Built on SIP — deterministic SVG sky map for one constellation.
+// Server component, zero client JS: RA/Dec are flat-projected around the
+// constellation's centroid, star size scales with apparent magnitude, and a
+// seeded PRNG paints faint background stars (same technique as Starfield, so
+// SSR and client markup match). Chart-precision only — not telescope-grade.
+
+import type { Constellation } from "@/lib/cosmos/constellations";
+
+const W = 400;
+const H = 300;
+const PAD = 44;
+
+function mulberry32(seed: number) {
+  let a = seed;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Magnitude → radius. Mag 0 ≈ 6.4px, mag 3.6 ≈ 2px. */
+function starRadius(mag: number): number {
+  return Math.max(2, 6.4 - mag * 1.25);
+}
+
+export function ConstellationMap({
+  constellation,
+  seed = 42,
+}: {
+  constellation: Constellation;
+  seed?: number;
+}) {
+  const { stars, lines } = constellation;
+
+  // Flat projection centered on the constellation's centroid. RA grows
+  // eastward, which on a sky chart is to the LEFT (we look up at the sphere
+  // from inside), hence the negation. cos(dec₀) corrects RA-hour spacing
+  // for declination.
+  const ra0 = stars.reduce((s, st) => s + st.ra, 0) / stars.length;
+  const dec0 = stars.reduce((s, st) => s + st.dec, 0) / stars.length;
+  const cosD = Math.cos((dec0 * Math.PI) / 180);
+
+  const raw = stars.map((s) => ({
+    ...s,
+    px: -(s.ra - ra0) * 15 * cosD,
+    py: -(s.dec - dec0),
+  }));
+
+  const xs = raw.map((s) => s.px);
+  const ys = raw.map((s) => s.py);
+  const minX = Math.min(...xs);
+  const maxX = Math.max(...xs);
+  const minY = Math.min(...ys);
+  const maxY = Math.max(...ys);
+  const spanX = maxX - minX || 1;
+  const spanY = maxY - minY || 1;
+  // One scale for both axes so the figure keeps its true sky proportions.
+  const scale = Math.min((W - 2 * PAD) / spanX, (H - 2 * PAD) / spanY);
+  const offX = (W - spanX * scale) / 2;
+  const offY = (H - spanY * scale) / 2;
+
+  const placed = raw.map((s) => ({
+    ...s,
+    x: offX + (s.px - minX) * scale,
+    y: offY + (s.py - minY) * scale,
+  }));
+  const byId = Object.fromEntries(placed.map((s) => [s.id, s]));
+
+  // Faint deterministic background stars.
+  const rand = mulberry32(seed);
+  const dust = Array.from({ length: 46 }, () => ({
+    x: +(rand() * W).toFixed(1),
+    y: +(rand() * H).toFixed(1),
+    r: +(0.4 + rand() * 0.7).toFixed(2),
+    o: +(0.12 + rand() * 0.22).toFixed(2),
+  }));
+
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      role="img"
+      aria-label={`Star map of ${constellation.name}`}
+      className="h-auto w-full"
+    >
+      <rect width={W} height={H} rx={12} fill="#07070c" />
+      {dust.map((d, i) => (
+        <circle key={i} cx={d.x} cy={d.y} r={d.r} fill="#cbd5e1" opacity={d.o} />
+      ))}
+      {lines.map(([a, b], i) => {
+        const s1 = byId[a];
+        const s2 = byId[b];
+        if (!s1 || !s2) return null;
+        return (
+          <line
+            key={i}
+            x1={s1.x}
+            y1={s1.y}
+            x2={s2.x}
+            y2={s2.y}
+            stroke="#67e8f9"
+            strokeOpacity={0.28}
+            strokeWidth={1}
+          />
+        );
+      })}
+      {placed.map((s) => {
+        const r = starRadius(s.mag);
+        return (
+          <g key={s.id}>
+            <circle cx={s.x} cy={s.y} r={r * 2.2} fill="#e2e8f0" opacity={0.06} />
+            <circle cx={s.x} cy={s.y} r={r} fill="#f1f5f9">
+              <title>{`${s.name} — mag ${s.mag}${s.note ? ` · ${s.note}` : ""}`}</title>
+            </circle>
+            <text
+              x={s.x + r + 5}
+              y={s.y + 3}
+              fontSize={9}
+              fill="#94a3b8"
+              className="select-none"
+            >
+              {s.name}
+            </text>
+          </g>
+        );
+      })}
+    </svg>
+  );
+}

--- a/site/src/components/cosmos/ConstellationMap.tsx
+++ b/site/src/components/cosmos/ConstellationMap.tsx
@@ -34,6 +34,7 @@ export function ConstellationMap({
   seed?: number;
 }) {
   const { stars, lines } = constellation;
+  if (stars.length === 0) return null;
 
   // Flat projection centered on the constellation's centroid. RA grows
   // eastward, which on a sky chart is to the LEFT (we look up at the sphere

--- a/site/src/lib/cosmos/cards.ts
+++ b/site/src/lib/cosmos/cards.ts
@@ -22,7 +22,9 @@ export type CardKind =
   | "element"
   | "law"
   | "concept"
-  | "mission";
+  | "mission"
+  | "constellation"
+  | "spacecraft";
 
 export const KIND_LABEL: Record<CardKind, string> = {
   star: "Star",
@@ -35,6 +37,8 @@ export const KIND_LABEL: Record<CardKind, string> = {
   law: "Law",
   concept: "Concept",
   mission: "Mission",
+  constellation: "Constellation",
+  spacecraft: "Spacecraft",
 };
 
 export const KIND_ACCENT: Record<CardKind, Accent> = {
@@ -48,6 +52,8 @@ export const KIND_ACCENT: Record<CardKind, Accent> = {
   law: "cyan",
   concept: "violet",
   mission: "fuchsia",
+  constellation: "cyan",
+  spacecraft: "emerald",
 };
 
 export type CosmosCard = {
@@ -550,6 +556,303 @@ const CARDS: CosmosCard[] = [
     ],
     updated: "2026-06-11",
   },
+
+  // ── Constellations — the sky as interface ──────────────────────
+  {
+    slug: "orion",
+    title: "Orion",
+    kind: "constellation",
+    tldr: "The most recognizable pattern in the sky — seven bright stars spanning 245 to 1,300+ light-years, aligned only from Earth's point of view, plus a stellar nursery you can see with the naked eye.",
+    facts: [
+      { label: "Brightest stars", value: "Rigel (mag 0.13), Betelgeuse" },
+      { label: "The Belt", value: "Alnitak, Alnilam, Mintaka" },
+      { label: "Star distances", value: "~245 ly (Bellatrix) to ~1,300+ ly (Alnilam)" },
+      { label: "Orion Nebula (M42)", value: "~1,344 ly — nearest massive star-forming region" },
+      { label: "Visibility", value: "Both hemispheres — sits on the celestial equator" },
+    ],
+    prompts: [
+      "Orion's stars look like a group but span over 1,000 light-years of depth — the pattern exists only from Earth's vantage point. Take a 'pattern' in your data or org chart and test whether it's a real structure or a projection artifact of where you're standing.",
+      "Research trail: M42 is the nearest massive stellar nursery. Trace how astronomers use it to study star formation — what can only be learned from a nursery this close, and what has JWST added since 2022?",
+      "Story seed: nearly every culture drew a figure on these seven stars — hunter, shepherd, Osiris. Write the constellation myth for a civilization on a planet orbiting Alnilam, from where our Sun is an invisible dot and 'Orion' doesn't exist.",
+    ],
+    contentFile: "orion.md",
+    tags: ["Orion", "constellation", "Orion's Belt", "M42", "Orion Nebula", "celestial equator", "star formation"],
+    related: ["betelgeuse", "stellar-fusion", "star-wisdom"],
+    sources: [
+      { label: "NASA: Orion Nebula", url: "https://science.nasa.gov/mission/hubble/science/explore-the-night-sky/hubble-messier-catalog/messier-42/" },
+      { label: "IAU constellations", url: "https://www.iau.org/public/themes/constellations/" },
+    ],
+    updated: "2026-07-13",
+  },
+  {
+    slug: "ursa-major",
+    title: "Ursa Major & the Big Dipper",
+    kind: "constellation",
+    tldr: "The sky's most useful asterism: two of its stars point to Polaris, five of its seven stars are a genuine moving group, and it guided people escaping slavery north as the Drinking Gourd.",
+    facts: [
+      { label: "The Dipper", value: "Asterism of 7 stars inside the larger Ursa Major" },
+      { label: "Pointer stars", value: "Dubhe + Merak → line to Polaris" },
+      { label: "Moving group", value: "5 of 7 Dipper stars share real motion (not Dubhe, Alkaid)" },
+      { label: "Mizar & Alcor", value: "Naked-eye double — actually a six-star system" },
+      { label: "Deep sky", value: "M81, M82 galaxies; visible year-round from mid-northern latitudes" },
+    ],
+    prompts: [
+      "Five of the Dipper's stars are a real, physically-bound moving group; two are unrelated photobombers. Most human 'patterns' mix signal and coincidence exactly like this. Pick a trend you believe in and separate its moving group from its line-of-sight extras.",
+      "Research trail: the Ursa Major Moving Group is the nearest stellar kinematic group. How do astronomers decide a star belongs — proper motion, radial velocity, chemical fingerprint? Which test is strongest?",
+      "The Drinking Gourd encoded escape navigation into a star pattern and a song — knowledge infrastructure that couldn't be confiscated. Design a piece of knowledge for your domain that survives with zero technology: what compresses into a memorable pattern?",
+    ],
+    contentFile: "ursa-major.md",
+    tags: ["Ursa Major", "Big Dipper", "Polaris", "navigation", "Mizar", "Drinking Gourd", "moving group"],
+    related: ["orion", "star-wisdom", "sirius"],
+    sources: [
+      { label: "NASA: Finding Polaris", url: "https://science.nasa.gov/skywatching/" },
+      { label: "IAU constellations", url: "https://www.iau.org/public/themes/constellations/" },
+    ],
+    updated: "2026-07-13",
+  },
+  {
+    slug: "crux",
+    title: "Crux — the Southern Cross",
+    kind: "constellation",
+    tldr: "The smallest of the 88 constellations carries the most weight per star: it finds the south celestial pole, anchors Aboriginal sky knowledge, and flies on five national flags.",
+    facts: [
+      { label: "Rank", value: "Smallest of the 88 IAU constellations" },
+      { label: "Main stars", value: "Acrux, Mimosa, Gacrux, Imai" },
+      { label: "Navigation", value: "Long axis ×4.5 → south celestial pole (no southern pole star)" },
+      { label: "Dark nebula", value: "The Coalsack — visible as a void in the Milky Way" },
+      { label: "On flags", value: "Australia, New Zealand, Brazil, Papua New Guinea, Samoa" },
+    ],
+    prompts: [
+      "The southern sky has no pole star, so navigators derive south from Crux geometrically — a computed reference beats a missing landmark. Where in your systems are you waiting for a landmark that doesn't exist instead of computing one from what does?",
+      "Research trail: the Coalsack is knowledge encoded in darkness — Aboriginal Australian astronomy reads the dark nebulae (the Emu in the Sky) where Greek tradition reads bright stars. What does a tradition that maps absences see that a tradition mapping presences misses?",
+      "Story seed: five nations put this asterism on their flags — a star pattern as sovereign identity. Build the flag and founding myth of a spacefaring colony: which sky objects would they claim, and what would the choice say about them?",
+    ],
+    contentFile: "crux.md",
+    tags: ["Crux", "Southern Cross", "south celestial pole", "Coalsack", "Emu in the Sky", "navigation", "flags"],
+    related: ["ursa-major", "star-wisdom", "milky-way"],
+    sources: [
+      { label: "IAU constellations", url: "https://www.iau.org/public/themes/constellations/" },
+      { label: "ESO: Coalsack", url: "https://www.eso.org/public/images/eso1539a/" },
+    ],
+    updated: "2026-07-13",
+  },
+  {
+    slug: "cassiopeia",
+    title: "Cassiopeia",
+    kind: "constellation",
+    tldr: "The W in the northern sky — circumpolar, self-announcing, and home to Cassiopeia A, the brightest radio source in the sky beyond our solar system, plus the 1572 supernova that broke the idea of an unchanging heaven.",
+    facts: [
+      { label: "Shape", value: "Five stars forming a W (or M) opposite the Big Dipper" },
+      { label: "Visibility", value: "Circumpolar from mid-northern latitudes — never sets" },
+      { label: "Cassiopeia A", value: "Supernova remnant — brightest extrasolar radio source" },
+      { label: "Tycho's supernova", value: "SN 1572 — 'new star' that challenged celestial permanence" },
+      { label: "Location", value: "Sits in the Milky Way band — rich star fields" },
+    ],
+    prompts: [
+      "Tycho's 1572 supernova appeared in Cassiopeia and broke the doctrine that the heavens never change — one anomalous data point, honestly measured, ended a 1,500-year model. What measurement would falsify your current operating model, and are you instrumented to catch it?",
+      "Research trail: Cassiopeia A's light 'echoes' let astronomers study a supernova ~300 years after it happened, reflected off surrounding dust. Trace how light echoes work — what other past events does the universe keep replaying for us?",
+      "Story seed: the queen punished to circle the pole forever, never setting. Write a myth in which immortality-as-visibility is the punishment — for a person, an institution, or an AI that can never be turned off.",
+    ],
+    contentFile: "cassiopeia.md",
+    tags: ["Cassiopeia", "constellation", "Cassiopeia A", "Tycho supernova", "circumpolar", "radio astronomy"],
+    related: ["supernova-nucleosynthesis", "ursa-major", "star-wisdom"],
+    sources: [
+      { label: "NASA Chandra: Cassiopeia A", url: "https://www.nasa.gov/image-article/cassiopeia-supernova-remnant/" },
+      { label: "IAU constellations", url: "https://www.iau.org/public/themes/constellations/" },
+    ],
+    updated: "2026-07-13",
+  },
+
+  // ── Named stars ─────────────────────────────────────────────────
+  {
+    slug: "betelgeuse",
+    title: "Betelgeuse",
+    kind: "star",
+    tldr: "A red supergiant so large it would swallow the asteroid belt — a dying star whose 2019 'Great Dimming' triggered supernova speculation, and whose eventual explosion will be visible in daylight.",
+    facts: [
+      { label: "Type", value: "M-type red supergiant, semiregular variable" },
+      { label: "Distance", value: "~550 ly (genuinely uncertain: ~430–640 ly)" },
+      { label: "Size", value: "Placed at the Sun: engulfs Mercury→asteroid belt, roughly toward Jupiter" },
+      { label: "Mass", value: "~15–20 solar masses (estimate)" },
+      { label: "Great Dimming", value: "2019–2020 — caused by ejected dust, not a pre-supernova" },
+      { label: "Supernova timeline", value: "Likely within ~100,000 years — not imminent" },
+    ],
+    prompts: [
+      "Betelgeuse's distance is uncertain by ~40% — and every derived property (size, mass, fate) inherits that error bar. Find the 'distance measurement' in your own planning: the single upstream uncertainty most of your downstream numbers silently depend on.",
+      "Research trail: in 1920 Michelson and Pease measured Betelgeuse's angular diameter with a 6-meter interferometer — the first star ever resolved as more than a point. Trace the line from that experiment to today's VLTI imaging of its surface. What changed: physics, or engineering?",
+      "Story seed: when Betelgeuse goes, Earth gets months of a second light in the sky bright enough to read by at night — with zero danger. Write the week after it happens: the markets, the cults, the scientists who've waited their whole careers.",
+    ],
+    contentFile: "betelgeuse.md",
+    tags: ["Betelgeuse", "red supergiant", "Great Dimming", "supernova candidate", "Orion", "interferometry", "variable star"],
+    related: ["orion", "supernova-nucleosynthesis", "stellar-fusion"],
+    sources: [
+      { label: "NASA Hubble: Great Dimming", url: "https://science.nasa.gov/missions/hubble/hubble-finds-that-betelgeuses-mysterious-dimming-is-due-to-a-traumatic-outburst/" },
+      { label: "ESO: Betelgeuse imaging", url: "https://www.eso.org/public/news/eso2109/" },
+    ],
+    updated: "2026-07-13",
+  },
+  {
+    slug: "sirius",
+    title: "Sirius",
+    kind: "star",
+    tldr: "The brightest star in the night sky scheduled ancient Egypt's calendar — and its invisible companion, predicted from a wobble in 1844, became the first white dwarf ever found.",
+    facts: [
+      { label: "Apparent magnitude", value: "−1.46 — brightest night-sky star" },
+      { label: "Distance", value: "8.6 light-years" },
+      { label: "System", value: "Sirius A (A1V) + Sirius B (white dwarf)" },
+      { label: "Sirius B", value: "~1 solar mass compressed to roughly Earth's size" },
+      { label: "Prediction", value: "Bessel inferred B from A's wobble in 1844; seen 1862" },
+      { label: "Egypt", value: "Heliacal rising marked the new year + Nile flood" },
+    ],
+    prompts: [
+      "Bessel discovered Sirius B without seeing it — pure inference from the wobble it caused. That's the template for dark matter, exoplanets, and every anomaly-first discovery. What wobble in your metrics implies a massive unseen companion?",
+      "Research trail: Sirius B packs a solar mass into an Earth-sized sphere. Work through what electron degeneracy pressure is, why it stops the collapse, and why there's a mass ceiling (Chandrasekhar) beyond which even that fails.",
+      "Story seed: for ancient Egypt, one star's dawn rising was the calendar, the flood forecast, and the fiscal year — a star as civil infrastructure. Design a civilization whose entire institutional stack keys off one astronomical event. What breaks when precession slowly shifts it?",
+    ],
+    contentFile: "sirius.md",
+    tags: ["Sirius", "Dog Star", "white dwarf", "Sirius B", "Bessel", "heliacal rising", "Egyptian calendar"],
+    related: ["star-wisdom", "spectroscopy", "sol"],
+    sources: [
+      { label: "NASA Hubble: Sirius B", url: "https://science.nasa.gov/missions/hubble/hubble-sees-sirius-b/" },
+    ],
+    updated: "2026-07-13",
+  },
+  {
+    slug: "proxima-centauri",
+    title: "Proxima Centauri",
+    kind: "star",
+    tldr: "The nearest star to the Sun is invisible to the naked eye — a flare-prone red dwarf 4.25 light-years away with a rocky planet in its habitable zone, and a fuel tank that outlasts every other kind of star.",
+    facts: [
+      { label: "Distance", value: "4.246 light-years — nearest known star to the Sun" },
+      { label: "Type", value: "M5.5Ve red dwarf, ~12% of the Sun's mass" },
+      { label: "Brightness", value: "Invisible to the naked eye despite proximity" },
+      { label: "Planets", value: "Proxima b (≥1.07 M⊕, habitable zone, 2016) + Proxima d" },
+      { label: "Behavior", value: "Violent flare star — habitability contested" },
+      { label: "Lifespan", value: "Red dwarfs burn for trillions of years" },
+    ],
+    prompts: [
+      "Proxima b sits in the habitable zone of a star that regularly scours it with flares — 'in the zone' by one metric, hostile by another. Take something you evaluate with a single-metric zone (market fit, salary band, SLA) and add the flare dimension it's missing.",
+      "Research trail: at Voyager 1's speed, Proxima is tens of thousands of years away; Breakthrough Starshot proposes gram-scale lightsails at ~20% of c. Audit that proposal like an engineer — which subsystem (laser array, sail material, data return) is the real blocker?",
+      "Story seed: red dwarfs will still be burning when every Sun-like star is dark — the last light in the universe is red. Write from a civilization that migrated to a red dwarf for exactly this reason, trading a bright present for a near-eternal future.",
+    ],
+    contentFile: "proxima-centauri.md",
+    tags: ["Proxima Centauri", "red dwarf", "Proxima b", "Alpha Centauri", "flare star", "habitable zone", "interstellar travel"],
+    related: ["sol", "stellar-fusion", "voyager-1"],
+    sources: [
+      { label: "ESO: Proxima b discovery", url: "https://www.eso.org/public/news/eso1629/" },
+      { label: "NASA exoplanets: Proxima b", url: "https://science.nasa.gov/exoplanet-catalog/proxima-centauri-b/" },
+    ],
+    updated: "2026-07-13",
+  },
+
+  // ── Spacecraft — engineering at the edge ────────────────────────
+  {
+    slug: "voyager-1",
+    title: "Voyager 1",
+    kind: "spacecraft",
+    tldr: "Launched 1977 with 69 KB of memory, now the farthest human-made object — still returning interstellar data on a shrinking power budget, patched remotely across a 22-hour light delay in 2024.",
+    facts: [
+      { label: "Launched", value: "September 5, 1977" },
+      { label: "Distance", value: "~167 AU / ~25 billion km from the Sun (as of 2026, approx.)" },
+      { label: "Interstellar space", value: "Crossed the heliopause August 2012" },
+      { label: "Onboard memory", value: "~69 KB total" },
+      { label: "Power", value: "RTGs losing ~4 watts per year" },
+      { label: "One-way light time", value: "~23 hours" },
+    ],
+    prompts: [
+      "In 2024, engineers debugged a corrupted-memory failure on 46-year-old hardware they can never touch, over a 45-hour round trip, and won. Write the operating doctrine that makes that possible — then grade your own systems against it: could your team patch something it can't see, reboot, or replace?",
+      "Voyager's power budget shrinks ~4 watts a year, so the team retires one instrument at a time — planned graceful degradation over decades. Design the shutdown order for your own product or platform: what's the last capability you'd keep alive, and why?",
+      "Story seed: the Golden Record assumes a finder with no shared language, biology, or timescale. Curate the record for your own life or company under the same constraint — what survives translation to a mind you can't imagine?",
+    ],
+    contentFile: "voyager-1.md",
+    tags: ["Voyager 1", "interstellar space", "heliopause", "Golden Record", "Pale Blue Dot", "RTG", "graceful degradation", "long-lived systems"],
+    related: ["jupiter", "iss", "star-wisdom"],
+    sources: [
+      { label: "NASA JPL: Voyager", url: "https://science.nasa.gov/mission/voyager/" },
+      { label: "NASA: Voyager 1 status", url: "https://voyager.jpl.nasa.gov/mission/status/" },
+    ],
+    updated: "2026-07-13",
+  },
+  {
+    slug: "iss",
+    title: "International Space Station",
+    kind: "spacecraft",
+    tldr: "Continuously crewed since November 2000 — a football-field-sized laboratory at 28,000 km/h where five space agencies kept cooperating through every geopolitical crisis since 1998.",
+    facts: [
+      { label: "Continuously crewed since", value: "November 2, 2000" },
+      { label: "Orbit", value: "~400 km, ~28,000 km/h, 16 sunrises a day" },
+      { label: "Scale", value: "~420 tons, roughly a football field across" },
+      { label: "Partners", value: "NASA, Roscosmos, ESA, JAXA, CSA" },
+      { label: "Human cost of microgravity", value: "~1–1.5% bone density loss/month unprotected" },
+      { label: "Planned deorbit", value: "~2030–2031 (current plan), commercial stations to follow" },
+    ],
+    prompts: [
+      "The ISS partnership survived every terrestrial crisis since 1998 because the modules are physically interdependent — neither side can run the station alone. Where could you engineer interdependence-by-architecture into a partnership instead of relying on goodwill?",
+      "Research trail: two decades of ISS physiology data is the only long-baseline dataset on humans in microgravity. What are the three hardest unsolved problems it exposes for a Mars transit — and which countermeasures actually have evidence behind them?",
+      "An entire generation has never known a moment without humans off-planet — a streak maintained by thousands of people who mostly never met. Story seed: write the day the streak nearly broke, from the perspective of the flight controller who kept it alive.",
+    ],
+    contentFile: "iss.md",
+    tags: ["ISS", "space station", "microgravity", "international cooperation", "low Earth orbit", "human spaceflight"],
+    related: ["voyager-1", "gravity-and-orbits", "sol"],
+    sources: [
+      { label: "NASA: ISS", url: "https://www.nasa.gov/international-space-station/" },
+    ],
+    updated: "2026-07-13",
+  },
+
+  // ── Fusion + the meaning layer ──────────────────────────────────
+  {
+    slug: "fusion-on-earth",
+    title: "Fusion on Earth",
+    kind: "concept",
+    tldr: "Doing without gravity what the Sun does with it: three confinement strategies, one 2022 ignition milestone, 35 nations building ITER — and, as of 2026, still zero net electricity to any grid.",
+    facts: [
+      { label: "The problem", value: "Confining ~150-million-K plasma without gravity" },
+      { label: "Magnetic", value: "Tokamaks + stellarators — ITER, 35 nations, first plasma mid-2030s (2024 rebaseline)" },
+      { label: "Inertial", value: "NIF ignition Dec 5, 2022 — 3.15 MJ out vs 2.05 MJ laser-in" },
+      { label: "Honest caveat", value: "NIF wall-plug energy was ~100× the laser output" },
+      { label: "Private wave", value: "CFS SPARC (HTS magnets), Helion, TAE — no net electricity yet" },
+      { label: "Fuel", value: "Deuterium–tritium — not the Sun's proton-proton chain" },
+    ],
+    prompts: [
+      "Stars fuse at 15 million K because gravity provides free confinement; we need ~150 million K because magnets are worse at it. When you lack a force the reference design gets for free, you pay a 10× premium somewhere else. Find that substitution premium in a system you're building.",
+      "Research trail: 'net gain' has at least three definitions — target gain (NIF cleared it), engineering gain, and commercial gain. Build the honest ladder from Q_target > 1 to electrons on a grid, and locate every claimed 2026 milestone on it.",
+      "ITER holds 35 nations in a decades-long build through cost overruns and slipped timelines — arguably its hardest achievement isn't plasma physics but commitment engineering. What makes a 30-year multi-party project survivable? Extract the mechanisms.",
+    ],
+    contentFile: "fusion-on-earth.md",
+    tags: ["fusion power", "ITER", "NIF", "tokamak", "stellarator", "ignition", "deuterium-tritium", "energy"],
+    related: ["stellar-fusion", "sol", "star-wisdom"],
+    sources: [
+      { label: "DOE: NIF ignition", url: "https://www.energy.gov/articles/doe-national-laboratory-makes-history-achieving-fusion-ignition" },
+      { label: "ITER", url: "https://www.iter.org/" },
+    ],
+    updated: "2026-07-13",
+  },
+  {
+    slug: "star-wisdom",
+    title: "What Stars Teach",
+    kind: "concept",
+    tldr: "Stars were humanity's first clock, compass, calendar, and database — and the literal supply chain for every atom in you heavier than helium. The philosophy layer, kept honest by physics.",
+    facts: [
+      { label: "Your atoms", value: "Elements beyond H/He forged in stars, supernovae, mergers" },
+      { label: "First infrastructure", value: "Calendar (Sirius/Egypt), compass (Polaris, Crux), clock" },
+      { label: "Deep time", value: "Andromeda's light left 2.5 million years ago" },
+      { label: "Memory tech", value: "Constellations — knowledge compressed into sky patterns" },
+      { label: "The Overview Effect", value: "Documented cognitive shift reported by astronauts" },
+    ],
+    prompts: [
+      "Constellations are the original memory palace — oral cultures compressed navigation, agriculture, and law into star patterns that transmitted for millennia without writing. Take the knowledge your team loses every reorg and design its constellation: the minimal memorable structure that survives.",
+      "Looking up is looking back: every star you see is its past self, and the night sky is a time-layered archive, not a snapshot. What would change in your decision-making if you treated every metric dashboard the same way — as light that left its source some time ago?",
+      "'We are star stuff' is a supply-chain fact, not poetry: trace the iron in your blood from a core-collapse supernova to your hemoglobin. Then write the same provenance chain for something you built — every idea has its nucleosynthesis.",
+    ],
+    contentFile: "star-wisdom.md",
+    tags: ["philosophy", "star stuff", "navigation", "deep time", "overview effect", "memory palace", "meaning"],
+    related: ["supernova-nucleosynthesis", "spectroscopy", "orion"],
+    sources: [
+      { label: "NASA: Cosmic origins of elements", url: "https://science.nasa.gov/universe/stars/" },
+    ],
+    updated: "2026-07-13",
+  },
 ];
 
 export const COSMOS_CARDS = CARDS;
@@ -562,14 +865,16 @@ export const CARD_SLUGS = CARDS.map((c) => c.slug);
 
 /** Kinds in display order for the library index. */
 export const KIND_ORDER: CardKind[] = [
+  "constellation",
+  "star",
   "asteroid",
   "element",
-  "star",
   "planet",
   "moon",
   "galaxy",
   "law",
   "concept",
+  "spacecraft",
   "mission",
   "nebula",
 ];
@@ -583,7 +888,7 @@ export function cardsByKind(): { kind: CardKind; cards: CosmosCard[] }[] {
 
 /** Featured picks for the /cosmos hub. */
 export function featuredCards(): CosmosCard[] {
-  const picks = ["16-psyche", "spectroscopy", "jwst", "water-ice", "andromeda", "gold"];
+  const picks = ["voyager-1", "orion", "16-psyche", "star-wisdom", "jwst", "gold"];
   return picks.map((s) => CARD_BY_SLUG[s]).filter(Boolean);
 }
 

--- a/site/src/lib/cosmos/constellations.ts
+++ b/site/src/lib/cosmos/constellations.ts
@@ -1,0 +1,144 @@
+// Built on SIP — star chart data for /cosmos/constellations.
+// J2000 coordinates: ra in hours, dec in degrees, mag = apparent magnitude.
+// Positions are accurate to chart precision (~0.01h / 0.1°) — good for a
+// stylized sky map, not for pointing a telescope. The projection happens in
+// ConstellationMap.tsx.
+
+export type ChartStar = {
+  id: string;
+  name: string;
+  /** Right ascension, hours (J2000). */
+  ra: number;
+  /** Declination, degrees (J2000). */
+  dec: number;
+  /** Apparent visual magnitude (lower = brighter). */
+  mag: number;
+  /** One-line note shown on hover via <title>. */
+  note?: string;
+};
+
+export type Constellation = {
+  slug: string; // matches the cosmos card slug
+  name: string;
+  tagline: string;
+  stars: ChartStar[];
+  /** Stick-figure lines as pairs of star ids. */
+  lines: [string, string][];
+  /** The three reading layers. */
+  science: string;
+  myth: string;
+  navigation: string;
+};
+
+export const CONSTELLATIONS: Constellation[] = [
+  {
+    slug: "orion",
+    name: "Orion",
+    tagline: "The hunter on the celestial equator — visible from every inhabited place on Earth.",
+    stars: [
+      { id: "betelgeuse", name: "Betelgeuse", ra: 5.919, dec: 7.407, mag: 0.5, note: "M-type red supergiant, ~550 ly — see its own card" },
+      { id: "bellatrix", name: "Bellatrix", ra: 5.418, dec: 6.35, mag: 1.64, note: "B2 giant, ~245 ly — the nearest of Orion's bright stars" },
+      { id: "meissa", name: "Meissa", ra: 5.585, dec: 9.934, mag: 3.39, note: "The hunter's head — a hot O8 star ~1,100 ly away" },
+      { id: "alnitak", name: "Alnitak", ra: 5.679, dec: -1.943, mag: 1.77, note: "Belt east — O9.5 supergiant beside the Flame Nebula" },
+      { id: "alnilam", name: "Alnilam", ra: 5.604, dec: -1.202, mag: 1.69, note: "Belt center — B0 supergiant, roughly 1,300+ ly, farthest of the belt" },
+      { id: "mintaka", name: "Mintaka", ra: 5.533, dec: -0.299, mag: 2.23, note: "Belt west — sits almost exactly on the celestial equator" },
+      { id: "saiph", name: "Saiph", ra: 5.796, dec: -9.67, mag: 2.09, note: "B0.5 supergiant — as hot as Rigel, dimmer only in visible light" },
+      { id: "rigel", name: "Rigel", ra: 5.242, dec: -8.202, mag: 0.13, note: "Blue supergiant, ~860 ly — Orion's brightest star" },
+    ],
+    lines: [
+      ["meissa", "betelgeuse"],
+      ["meissa", "bellatrix"],
+      ["betelgeuse", "alnitak"],
+      ["bellatrix", "mintaka"],
+      ["alnitak", "alnilam"],
+      ["alnilam", "mintaka"],
+      ["alnitak", "saiph"],
+      ["mintaka", "rigel"],
+      ["saiph", "rigel"],
+    ],
+    science:
+      "The stars span ~245 to ~1,300+ light-years — the figure exists only from Earth's line of sight. Below the belt hangs M42, the nearest massive star-forming region.",
+    myth:
+      "Greek hunter, Egyptian Osiris, and a dozen other figures — nearly every culture drew someone on these seven stars.",
+    navigation:
+      "Mintaka rides the celestial equator: Orion's belt rises almost due east and sets almost due west, anywhere on Earth.",
+  },
+  {
+    slug: "ursa-major",
+    name: "Ursa Major — the Big Dipper",
+    tagline: "The sky's most useful machine: two stars that always point to north.",
+    stars: [
+      { id: "dubhe", name: "Dubhe", ra: 11.062, dec: 61.751, mag: 1.79, note: "Pointer star — not part of the moving group" },
+      { id: "merak", name: "Merak", ra: 11.031, dec: 56.383, mag: 2.37, note: "Pointer star — Merak→Dubhe extended ~5× lands on Polaris" },
+      { id: "phecda", name: "Phecda", ra: 11.897, dec: 53.695, mag: 2.44, note: "Bowl — Ursa Major Moving Group member" },
+      { id: "megrez", name: "Megrez", ra: 12.257, dec: 57.033, mag: 3.31, note: "Faintest of the seven — bowl meets handle" },
+      { id: "alioth", name: "Alioth", ra: 12.9, dec: 55.96, mag: 1.77, note: "Brightest of the seven — moving group member" },
+      { id: "mizar", name: "Mizar", ra: 13.399, dec: 54.925, mag: 2.27, note: "With Alcor: a naked-eye double that's really six stars" },
+      { id: "alkaid", name: "Alkaid", ra: 13.792, dec: 49.313, mag: 1.86, note: "Handle's end — like Dubhe, just passing through" },
+    ],
+    lines: [
+      ["dubhe", "merak"],
+      ["merak", "phecda"],
+      ["phecda", "megrez"],
+      ["megrez", "dubhe"],
+      ["megrez", "alioth"],
+      ["alioth", "mizar"],
+      ["mizar", "alkaid"],
+    ],
+    science:
+      "Five of the seven share real motion through the galaxy — the nearest stellar moving group. Dubhe and Alkaid are unrelated photobombers, so the Dipper is slowly deforming.",
+    myth:
+      "A bear across Greek, Indigenous North American, and Siberian traditions — and the Drinking Gourd whose handle pointed escapes north on the Underground Railroad.",
+    navigation:
+      "Merak→Dubhe extended about five times its length lands on Polaris — latitude and true north from one glance, no instrument required.",
+  },
+  {
+    slug: "crux",
+    name: "Crux — the Southern Cross",
+    tagline: "The smallest constellation finds the pole the southern sky doesn't mark.",
+    stars: [
+      { id: "acrux", name: "Acrux", ra: 12.443, dec: -63.099, mag: 0.77, note: "Foot of the cross — a multiple system of hot B stars" },
+      { id: "mimosa", name: "Mimosa", ra: 12.795, dec: -59.689, mag: 1.25, note: "East arm — B0.5 giant, ~280 ly" },
+      { id: "gacrux", name: "Gacrux", ra: 12.519, dec: -57.113, mag: 1.64, note: "Head — a red giant ~89 ly away, nearest M giant to the Sun" },
+      { id: "imai", name: "Imai", ra: 12.252, dec: -58.749, mag: 2.79, note: "West arm — B2 star" },
+      { id: "ginan", name: "Ginan", ra: 12.356, dec: -60.401, mag: 3.59, note: "The fifth star — its name comes from the Wardaman people" },
+    ],
+    lines: [
+      ["acrux", "gacrux"],
+      ["mimosa", "imai"],
+    ],
+    science:
+      "Beside the cross sits the Coalsack — a dark nebula visible as a hole in the Milky Way — and the Jewel Box open cluster.",
+    myth:
+      "In Aboriginal Australian sky knowledge the Coalsack forms the head of the Emu in the Sky — a constellation drawn in darkness, not light. Five nations carry Crux on their flags.",
+    navigation:
+      "No southern pole star exists: extend the Acrux–Gacrux axis ~4.5 times and you've computed the south celestial pole.",
+  },
+  {
+    slug: "cassiopeia",
+    name: "Cassiopeia",
+    tagline: "The W that never sets — and the sky's loudest radio source.",
+    stars: [
+      { id: "caph", name: "Caph", ra: 0.153, dec: 59.15, mag: 2.28, note: "F2 giant, ~54 ly" },
+      { id: "schedar", name: "Schedar", ra: 0.675, dec: 56.537, mag: 2.24, note: "K0 giant — the queen's heart" },
+      { id: "gamma-cas", name: "γ Cassiopeiae", ra: 0.945, dec: 60.717, mag: 2.47, note: "Eruptive variable — center of the W; navigation star 'Navi'" },
+      { id: "ruchbah", name: "Ruchbah", ra: 1.43, dec: 60.235, mag: 2.68, note: "A5 star, eclipsing variable" },
+      { id: "segin", name: "Segin", ra: 1.907, dec: 63.67, mag: 3.35, note: "B-class giant, ~410 ly" },
+    ],
+    lines: [
+      ["caph", "schedar"],
+      ["schedar", "gamma-cas"],
+      ["gamma-cas", "ruchbah"],
+      ["ruchbah", "segin"],
+    ],
+    science:
+      "Home to Cassiopeia A — the brightest radio source in the sky beyond the solar system — and to Tycho's 1572 supernova, the 'new star' that broke celestial permanence.",
+    myth:
+      "The vain queen of Aethiopia, condemned to circle the pole on her throne forever — visibility as punishment.",
+    navigation:
+      "Circumpolar from mid-northern latitudes and opposite the Big Dipper across Polaris: when the Dipper is low, the W is high.",
+  },
+];
+
+export const CONSTELLATION_BY_SLUG: Record<string, Constellation> =
+  Object.fromEntries(CONSTELLATIONS.map((c) => [c.slug, c]));


### PR DESCRIPTION
## What this ships

The next wave of Starlight Cosmos, extending the 2026-06-11 design spec — the encyclopedia grows, the first visual-exploration surface lands, and the platform vision is captured as a phased plan.

### New surface: `/cosmos/constellations`
- Deterministic SVG star maps for **Orion, Ursa Major (Big Dipper), Crux (Southern Cross), Cassiopeia** — projected from real J2000 RA/Dec coordinates, single scale so figures keep true sky proportions, zero client JS, seeded background starfield (no hydration mismatch).
- Every chart reads in three labeled layers: **Science / Myth / Navigation** — the physics and the mythology both present, never mixed.
- Wired into the `/cosmos` hub (fourth view tile: "Star Maps") and the sitemap.

### Encyclopedia: 19 → 30 cards
- **Two new card kinds:** `constellation`, `spacecraft` (registry now spans 12 kinds).
- New cards: Orion · Ursa Major · Crux · Cassiopeia · Betelgeuse · Sirius · Proxima Centauri · Voyager 1 · ISS · Fusion on Earth · What Stars Teach (the philosophy layer, kept honest by physics).
- Every new card carries **dual-track prompts**: a systems lens, a research trail, and a story seed — one substrate serving scientific exploration and fiction worldbuilding.
- Facts follow the Metrics Truth Rule: established figures only, estimates labeled (e.g. Betelgeuse's genuinely uncertain distance), fast-moving numbers dated "as of 2026".

### Plan doc
- `docs/superpowers/specs/2026-07-13-cosmos-platform-expansion.md` — phased, falsifiable roadmap for the larger vision: Cosmos MCP in `starlight-cosmos-engine`, embedded site agent, Expo/desktop apps, network visualization, and monetization options with a recommendation (templates now, subscription when the agent exists).

## Verification
- `npm run lint` — 0 errors (pre-existing warnings only, untouched files)
- `npm run build` — green; `/cosmos/constellations` prerendered, all 30 card pages SSG'd
- All 11 new content files match the established card format (no frontmatter, `##` sections, closing "Why it matters to a builder")

Built on SIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQB4GCtCMEZYwKZ1dzz9T9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQB4GCtCMEZYwKZ1dzz9T9)_