### PR TITLE
feat(verticals): register Starlight Gravity Engine as a sovereign vertical

### DIFF
--- a/VERTICALS.md
+++ b/VERTICALS.md
@@ -143,6 +143,20 @@ This is the **public registry**. Active alliances and private verticals (Family 
 - **Canon:** optional Hz / Arcanea composition for music-side workflows.
 - **Compounds:** Voice & Video IS playbook + creator pipeline outputs.
 
+### Starlight Gravity Engine
+- **Class:** sovereign vertical (operated, public)
+- **Domain:** Human-and-agentic "gravity" — turning meaningful encounters into shared intelligence, useful artifacts, fulfilled commitments, trusted relationships, valuable introductions, and rooms people want to return to. Mechanism: `Gravity = Direction × Signal × Contribution × Convening × Reliability`.
+- **Owner:** Frank Riemer / Starlight Holding BV.
+- **Status:** `active — v0.1 "Field Edition"` (working core + CLI; draft PR under review).
+- **Primary repo:** [`frankxai/starlight-gravity-engine`](https://github.com/frankxai/starlight-gravity-engine) (PUBLIC, MIT).
+- **Public surface:** `github.com/frankxai/starlight-gravity-engine` today; `frankx.ai/starlight/gravity` (product page) forthcoming.
+- **Canon:** **declines** — no canon layer at the protocol level; defines only its own operating rules in-repo (`CANON.md`). May compose Arcanea canon per-artifact under CC-BY-NC, never at the vertical level.
+- **Composition (built ON SIP, never inside it):** A standalone vertical built on SIP. It **composes with** — but never requires — SIS, Creator IS, and ACOS. It does **not** live inside SIS, does **not** duplicate SIS memory, and does **not** make SIS/ACOS mandatory for its fifteen-minute starter experience. This registry entry links to the standalone repo; the implementation is **not** copied into the substrate.
+- **SIP attestation:** every published artifact carries the `Built on SIP` block, pinned to `starlightintelligence.org/protocol v1.1.1`, emitted by the engine's `attest.ts` publish gate (which refuses to emit without an approved, publishable artifact).
+- **Substrate home (in-repo surface):** `verticals/gravity-engine/` — pointer only (links out; no implementation).
+- **SIP commands:** `/gravity-capture` · `/gravity-brief` · `/gravity-publish` · `/gravity-room` · `/gravity-follow-through` · `/gravity-review`.
+- **Compounds:** FrankX (protocol-adoption narrative + consulting surface) + the engine's own catalog and any future managed tier.
+
 ### Starlight Intelligence (the substrate)
 - **Class:** sovereign substrate (the substrate itself, not a vertical)
 - **Domain:** SIP protocol, SIS substrate, Alliance forging method, Starlight Console, canonical registry. Hosts the master **Starlight Orchestrator** layer at `core/orchestrator/` that routes the other nine universal IS.

--- a/verticals/gravity-engine/README.md
+++ b/verticals/gravity-engine/README.md
@@ -1,0 +1,51 @@
+# Starlight Gravity Engine — substrate pointer
+
+> **Pointer only.** The Gravity Engine is a standalone public vertical built on
+> SIP. Its implementation lives in its own repository and is **not** copied into
+> this substrate. This file exists so the vertical is discoverable from within
+> SIS and so its SIP posture is recorded here.
+
+- **Repo:** https://github.com/frankxai/starlight-gravity-engine (public, MIT)
+- **Registry entry:** see [`VERTICALS.md`](../../VERTICALS.md) → _Starlight Gravity Engine_
+- **Class:** sovereign vertical (operated, public)
+- **Canon:** declines (defines only its own operating rules in-repo)
+- **Composes with, never requires:** SIS · Creator IS · ACOS
+
+## What it is
+
+Human-and-agentic engineering for turning meaningful encounters into shared
+intelligence, useful artifacts, fulfilled commitments, trusted relationships,
+valuable introductions, and rooms people want to return to.
+
+```
+Gravity = Direction × Signal × Contribution × Convening × Reliability
+```
+
+Human engineering creates gravity; agentic engineering makes it compound. Agents
+increase memory, consistency, preparation, transformation, and cycle frequency —
+never judgment, presence, generosity, trust, relationship intent, or human
+identity. The division is enforced in the engine's code, not just documented.
+
+## Relationship to the substrate
+
+- **Built on SIP.** Every published artifact the engine emits carries the
+  `Built on SIP` attestation block, pinned to the substrate version. The publish
+  gate refuses to emit without an approved, publishable artifact.
+- **Local-first, zero-dependency.** The engine runs without SIS, Supabase, or any
+  cloud account. SIS/Connected adapters are optional composition, never a
+  requirement.
+- **No memory duplication.** The engine keeps its own local-first field; it does
+  not fork or mirror SIS memory infrastructure.
+
+---
+
+```
+Built on SIP — Starlight Intelligence Protocol
+- Substrate: starlightintelligence.org/protocol v1.1.1
+- Verticals: [starlight-gravity-engine]
+- Canon: [none]
+- Nodes: [Frank Riemer (Starlight Holding BV)]
+Generated: 2026-07-22
+```
+
+© 2026 Frank Riemer · MIT


### PR DESCRIPTION
## Register Starlight Gravity Engine as a sovereign vertical

Registers the [Starlight Gravity Engine](https://github.com/frankxai/starlight-gravity-engine) (public, MIT) in the SIP registry — **by reference, not by absorption**.

### What this adds
- **`VERTICALS.md`** — a new `### Starlight Gravity Engine` entry under *Sovereign verticals (operated)*: class, domain (`Gravity = Direction × Signal × Contribution × Convening × Reliability`), owner, status (v0.1 Field Edition), primary repo link, canon posture (**declines**), SIP attestation (pinned to `starlightintelligence.org/protocol v1.1.1`, emitted by the engine's publish gate), and its `/gravity-*` command surface.
- **`verticals/gravity-engine/README.md`** — a **pointer-only** in-repo surface that links out to the standalone repo and records the vertical's SIP posture, with a `Built on SIP` block.

### What this deliberately does NOT do (per the architecture)
- Does **not** copy the engine's implementation into the substrate.
- Does **not** duplicate SIS memory infrastructure.
- Does **not** make SIS or ACOS required for the engine's fifteen-minute starter — the vertical is standalone and local-first, composing with SIS by attestation only.

Draft, not for merge. Companion draft PR opens the engine itself at `frankxai/starlight-gravity-engine#1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
Consolidated into main by [PR #133](https://github.com/frankxai/Starlight-Intelligence-System/pull/133), commit `3f9f53eea13012319d5a6878ce6eef0a29b99123`, on 2026-09-06. This original PR is closed as superseded after exact-head source verification. Integration reconciliations, independent review, and scope limits are recorded in the linked PR and branch audit. Original source history remains in this PR.
