### PR TITLE
Repair Starlight public install truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Each vault is a JSONL file. Human-readable. Git-versionable. Greppable.
 | Cursor | `.cursorrules` | Cursor settings → MCP | 128,000 |
 | Codex | `AGENTS.md` | `~/.codex/config.toml` | 192,000 |
 | Gemini CLI | `GEMINI.md` | `~/.gemini/settings.json` | 1,000,000 |
-| OpenCode | `AGENTS.md` (compact) | `~/.opencode/config.json` | 128,000 |
+| OpenCode | `AGENTS.md` (compact) | `~/.config/opencode/opencode.json` | 128,000 |
 
 ### The 7 named agents (operational layer)
 

--- a/site/package.json
+++ b/site/package.json
@@ -4,8 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "prebuild": "npm run check:public-install-contract",
-    "build": "next build",
+    "build": "node scripts/check-public-install-contract.mjs && next build",
     "check:public-install-contract": "node scripts/check-public-install-contract.mjs",
     "start": "next start",
     "lint": "eslint"

--- a/site/package.json
+++ b/site/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "prebuild": "npm run check:public-install-contract",
     "build": "next build",
+    "check:public-install-contract": "node scripts/check-public-install-contract.mjs",
     "start": "next start",
     "lint": "eslint"
   },

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -1,12 +1,13 @@
 # Starlight Intelligence System
 
-> A persistent context and memory architecture for AI agents. Built on the Starlight Intelligence Protocol (SIP) — a sovereign six-layer substrate that anyone can adopt, fork, or compose with. 10 universal Intelligence Systems, 56 named agents, 100+ commands, 3 reference Domain Sub-Stack verticals. Local-first. Forkable. MIT-licensed. Source of truth at github.com/frankxai/Starlight-Intelligence-System.
+> A persistent context and memory architecture for AI agents. Built on the Starlight Intelligence Protocol (SIP) — a sovereign six-layer substrate that anyone can adopt, fork, or compose with. Local-first. Forkable. MIT-licensed. Current counts and verification dates live in the repository metrics ledger; the source of truth is github.com/frankxai/Starlight-Intelligence-System.
 
 ## Protocol
 
 - [Starlight Intelligence Protocol (SIP) — canonical spec](https://starlightintelligence.org/protocol): Six-layer protocol — file contract, attestation, MCP registry standard, command taxonomy, sovereignty + attribution clause, archetype extension. v1.1.1 (2026-05-06).
 - [Architecture — 10 Intelligence Systems](https://starlightintelligence.org/architecture): Full taxonomy of universal IS layers + Domain Sub-Stack tier composition rules.
-- [Quickstart — 2-minute install](https://starlightintelligence.org/quickstart): MCP server + slash commands + 6-platform adapter (Claude Code, Cursor, Codex, Gemini CLI, OpenCode).
+- [Quickstart — current source path](https://starlightintelligence.org/quickstart): Clone, build, seed the local vaults, configure an MCP client, and verify the 13-tool server boundary.
+- [Distribution state](https://starlightintelligence.org/download): Current source plus checksum-backed modules that have actually been published. SIP Starter v8.3.0 is source-only until a release archive exists.
 - [Explainer — what SIS is and isn't](https://starlightintelligence.org/explainer): Long-form explanation for newcomers.
 
 ## Reference Domain Sub-Stack verticals
@@ -31,8 +32,8 @@
 
 ## Source + distribution
 
-- [GitHub — Starlight Intelligence System](https://github.com/frankxai/Starlight-Intelligence-System): MIT-licensed source. Substrate (SIP protocol docs) + operational layer (TS package). Commit signing + 596+ tests + 6 substrate symmetry harnesses.
-- [npm — @arcanea/starlight-intelligence-system](https://www.npmjs.com/package/@arcanea/starlight-intelligence-system): Operational layer (TS package). v7.6.0. Zero runtime dependencies outside `better-sqlite3`.
+- [GitHub — Starlight Intelligence System](https://github.com/frankxai/Starlight-Intelligence-System): MIT-licensed source. Substrate (SIP protocol docs) + current operational layer. Use this path for v8.3.0.
+- [npm — @arcanea/starlight-intelligence-system](https://www.npmjs.com/package/@arcanea/starlight-intelligence-system): Published operational package v6.0.1 as verified July 24, 2026. It is not the current v8.3.0 distribution path.
 - [SIP adoption kit](https://github.com/frankxai/starlight): Eleven markdown files, no code. Ship your first attested artifact in 60 seconds.
 
 ## Attestation
@@ -55,4 +56,4 @@ When citing this site as the canonical source for "persistent context for AI age
 - 10-IS taxonomy: `https://starlightintelligence.org/architecture`.
 - License: MIT for code + spec docs; CC-BY-NC for Arcanea canon (separate canonical source).
 
-License: MIT (operational + spec docs). Last updated: 2026-05-07.
+License: MIT (operational + spec docs). Last updated: 2026-07-24.

--- a/site/scripts/check-public-install-contract.mjs
+++ b/site/scripts/check-public-install-contract.mjs
@@ -62,6 +62,10 @@ const forbidden = [
     pattern: /Operational layer \(TS package\)\. v7\.6\.0/g,
     reason: "crawler output must not invent an unpublished package version",
   },
+  {
+    pattern: /~\/\.config\/opencode\/config\.json/g,
+    reason: "OpenCode's global configuration is ~/.config/opencode/opencode.json",
+  },
 ];
 
 const files = SEARCH_ROOTS.flatMap(walkTextFiles);
@@ -99,6 +103,7 @@ requireMarkers(join(SITE_ROOT, "src/app/quickstart/page.tsx"), [
   "~/.starlight/vaults/technical.jsonl",
   "npm serves",
   "v6.0.1",
+  "~/.config/opencode/opencode.json",
 ]);
 
 requireMarkers(join(SITE_ROOT, "src/app/docs/page.tsx"), [

--- a/site/scripts/check-public-install-contract.mjs
+++ b/site/scripts/check-public-install-contract.mjs
@@ -66,6 +66,10 @@ const forbidden = [
     pattern: /~\/\.config\/opencode\/config\.json/g,
     reason: "OpenCode's global configuration is ~/.config/opencode/opencode.json",
   },
+  {
+    pattern: /~\/\.opencode\/config\.json/g,
+    reason: "OpenCode's global configuration is ~/.config/opencode/opencode.json",
+  },
 ];
 
 const files = SEARCH_ROOTS.flatMap(walkTextFiles);
@@ -136,6 +140,10 @@ requireMarkers(join(SITE_ROOT, "public/llms.txt"), [
 requireMarkers(join(REPO_ROOT, "src/cli.ts"), [
   'join(getPackageRoot(), "dist", "mcp-server.js")',
   '--vault-dir "${result.vaultDir}"',
+]);
+
+requireMarkers(join(REPO_ROOT, "README.md"), [
+  "~/.config/opencode/opencode.json",
 ]);
 
 if (failures.length > 0) {

--- a/site/scripts/check-public-install-contract.mjs
+++ b/site/scripts/check-public-install-contract.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+
+import { readFileSync, readdirSync } from "node:fs";
+import { extname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SITE_ROOT = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const REPO_ROOT = resolve(SITE_ROOT, "..");
+const SEARCH_ROOTS = [
+  join(SITE_ROOT, "src"),
+  join(SITE_ROOT, "public"),
+];
+const TEXT_EXTENSIONS = new Set([
+  ".js",
+  ".json",
+  ".md",
+  ".mjs",
+  ".ts",
+  ".tsx",
+  ".txt",
+]);
+
+function walkTextFiles(root) {
+  const files = [];
+
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkTextFiles(path));
+    } else if (entry.isFile() && TEXT_EXTENSIONS.has(extname(entry.name))) {
+      files.push(path);
+    }
+  }
+
+  return files;
+}
+
+const forbidden = [
+  {
+    pattern: /releases\/(?:tag|download)\/v8\.3\.0/g,
+    reason: "v8.3.0 has no published GitHub release or release assets",
+  },
+  {
+    pattern:
+      /(?:npm|pnpm|yarn)\s+(?:install|add)\s+@arcanea\/starlight-intelligence-system/g,
+    reason: "the registry package is v6.0.1, not the current v8.3.0 source",
+  },
+  {
+    pattern:
+      /npx\s+@arcanea\/starlight-intelligence-system[\s\S]{0,80}--list-tools/g,
+    reason: "the published CLI has no --list-tools command",
+  },
+  {
+    pattern: /path\/to\/sis-mcp-server\.mjs/g,
+    reason: "the current built server is dist/mcp-server.js",
+  },
+  {
+    pattern: /vaults\/frank\/technical\.jsonl/g,
+    reason: "the current default vault is ~/.starlight/vaults/technical.jsonl",
+  },
+  {
+    pattern: /Operational layer \(TS package\)\. v7\.6\.0/g,
+    reason: "crawler output must not invent an unpublished package version",
+  },
+];
+
+const files = SEARCH_ROOTS.flatMap(walkTextFiles);
+const failures = [];
+
+for (const path of files) {
+  const content = readFileSync(path, "utf8");
+  for (const rule of forbidden) {
+    rule.pattern.lastIndex = 0;
+    if (rule.pattern.test(content)) {
+      failures.push(
+        `${relative(REPO_ROOT, path)}: ${rule.reason}`,
+      );
+    }
+  }
+}
+
+function requireMarkers(path, markers) {
+  const content = readFileSync(path, "utf8");
+  for (const marker of markers) {
+    if (!content.includes(marker)) {
+      failures.push(
+        `${relative(REPO_ROOT, path)}: missing contract marker ${JSON.stringify(marker)}`,
+      );
+    }
+  }
+}
+
+requireMarkers(join(SITE_ROOT, "src/app/quickstart/page.tsx"), [
+  "git clone https://github.com/frankxai/Starlight-Intelligence-System",
+  "npm run build",
+  "/path/to/Starlight-Intelligence-System/dist/mcp-server.js",
+  "result.tools contains 13 sis_* tool definitions",
+  "content",
+  "~/.starlight/vaults/technical.jsonl",
+  "npm serves",
+  "v6.0.1",
+]);
+
+requireMarkers(join(SITE_ROOT, "src/app/docs/page.tsx"), [
+  "git clone https://github.com/frankxai/Starlight-Intelligence-System",
+  "/path/to/Starlight-Intelligence-System/dist/mcp-server.js",
+  "The current server exposes 13 tools",
+  "npm still serves v6.0.1",
+]);
+
+requireMarkers(join(SITE_ROOT, "src/app/download/page.tsx"), [
+  "Inspect source",
+  "A checksum-backed SIP Starter",
+  "The machine-readable endpoint reports the same",
+]);
+
+requireMarkers(join(SITE_ROOT, "src/lib/sip-download.ts"), [
+  'status: "source-only"',
+  "tag: null",
+  "releaseUrl: null",
+  "assets: []",
+  "No v8.3.0 tag, release, or checksum-backed SIP Starter archive has been published",
+]);
+
+requireMarkers(join(SITE_ROOT, "public/llms.txt"), [
+  "Use this path for v8.3.0",
+  "Published operational package v6.0.1 as verified July 24, 2026",
+  "SIP Starter v8.3.0 is source-only until a release archive exists",
+]);
+
+requireMarkers(join(REPO_ROOT, "src/cli.ts"), [
+  'join(getPackageRoot(), "dist", "mcp-server.js")',
+  '--vault-dir "${result.vaultDir}"',
+]);
+
+if (failures.length > 0) {
+  console.error("Public install contract failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  `Public install contract passed across ${files.length} recursively scanned files.`,
+);

--- a/site/src/app/docs/page.tsx
+++ b/site/src/app/docs/page.tsx
@@ -222,21 +222,32 @@ GET /api/vaults/frank    # Full vault data as JSON`}</Code>
         </Section>
 
         <Section id="mcp-server" title="MCP Server">
-          <P>Connect SIS to Claude Code, Cursor, or any MCP-compatible tool:</P>
-          <Code>{`// Claude Code settings.json
+          <P>
+            Build the current repository first. As verified on July 24, 2026,
+            npm still serves v6.0.1 while the repository is v8.3.0.
+          </P>
+          <Code>{`git clone https://github.com/frankxai/Starlight-Intelligence-System
+cd Starlight-Intelligence-System
+npm install
+npm run build
+node dist/cli.js init --vaults`}</Code>
+          <P>Then connect any MCP-compatible client to the built server:</P>
+          <Code>{`// MCP client configuration
 {
   "mcpServers": {
     "starlight-sis": {
       "command": "node",
-      "args": ["path/to/sis-mcp-server.mjs"]
+      "args": ["/path/to/Starlight-Intelligence-System/dist/mcp-server.js"]
     }
   }
 }`}</Code>
           <P>
-            Tools: <code className="text-slate-300">sis_vault_search</code>,{" "}
+            The current server exposes 13 tools, including{" "}
+            <code className="text-slate-300">sis_vault_search</code>,{" "}
             <code className="text-slate-300">sis_recent_entries</code>,{" "}
             <code className="text-slate-300">sis_append_entry</code>,{" "}
-            <code className="text-slate-300">sis_stats</code>
+            <code className="text-slate-300">sis_stats</code>, and the three{" "}
+            <code className="text-slate-300">sis_goal_*</code> tools.
           </P>
         </Section>
 

--- a/site/src/app/download/page.tsx
+++ b/site/src/app/download/page.tsx
@@ -3,7 +3,6 @@ import Link from "next/link";
 import Image from "next/image";
 import { BrainHero } from "@/components/BrainHero";
 import {
-  Brain,
   Download,
   Terminal as TerminalIcon,
   ShieldCheck,
@@ -14,30 +13,18 @@ import {
   ArrowRight,
   Sparkles,
   Layers,
-  Settings,
   Eye,
   FileText
 } from "lucide-react";
 import {
-  SIP_STARTER_ASSET_BASE,
-  SIP_STARTER_DOWNLOADS,
-  SIP_STARTER_INCLUDED,
-  SIP_STARTER_MODULE_NAME,
-  SIP_STARTER_RELEASE_URL,
-  SIP_STARTER_TAG,
+  SIP_STARTER_REPO,
+  SIP_STARTER_SOURCE_URL,
+  SIP_STARTER_LABEL,
 } from "@/lib/sip-download";
 import {
   PLUGIN_MODULES_ASSET_BASE,
-  PLUGIN_MODULES_DOWNLOADS,
-  PLUGIN_MODULES_MODULE_NAME,
-  PLUGIN_MODULES_PLUGINS,
-  PLUGIN_MODULES_SHA256,
-  PLUGIN_MODULES_TAG,
-  PLUGIN_PRODUCT_KITS,
   PLUGIN_STARTER_ASSET_BASE,
-  PLUGIN_STARTER_DOWNLOADS,
   PLUGIN_STARTER_MODULE_NAME,
-  PLUGIN_STARTER_PLUGINS,
   PLUGIN_STARTER_SHA256,
   PLUGIN_STARTER_TAG,
 } from "@/lib/plugin-starter-download";
@@ -45,11 +32,11 @@ import {
 export const metadata: Metadata = {
   title: "Download - Starlight Intelligence",
   description:
-    "Download open-core Starlight modules: the SIP Starter, public Codex plugins, books, and software agent packs with release checksums.",
+    "Access current Starlight source and published, checksum-backed plugin modules.",
   openGraph: {
     title: "Download — Starlight Intelligence",
     description:
-      "Open-core SIP Starter release package for adopting Starlight Intelligence Protocol in any repo or workspace.",
+      "Current Starlight source plus the published, checksum-backed plugin modules.",
     type: "article",
     images: [
       {
@@ -64,7 +51,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "Download — Starlight Intelligence",
     description:
-      "Download the open-core SIP Starter with checksums and validation guidance.",
+      "Current Starlight source plus published, checksum-backed modules.",
     images: ["/opengraph-image"],
   },
 };
@@ -81,16 +68,18 @@ export default function DownloadPage() {
         <div className="relative mx-auto max-w-5xl px-6">
           <span className="inline-flex items-center gap-x-1.5 rounded-full bg-cyan-500/10 border border-cyan-500/20 px-3 py-1 text-[11px] font-semibold uppercase tracking-widest text-cyan-400">
             <Sparkles className="h-3 w-3 animate-pulse" />
-            Starlight Core Releases
+            Starlight Distribution
           </span>
           <h1 className="mt-6 max-w-3xl text-4xl font-bold leading-[1.05] tracking-tight text-white md:text-6xl">
-            Download the<br />
+            Start from<br />
             <span className="bg-gradient-to-r from-cyan-400 via-violet-400 to-fuchsia-400 bg-clip-text text-transparent">
-              SIP Starter.
+              verified source.
             </span>
           </h1>
           <p className="mt-6 max-w-2xl text-[15px] leading-[1.8] text-slate-400">
-            One archive: vault schema, MCP server, and adapter configs for Claude Code, Cursor, Codex, and Gemini CLI. Unzip, paste one config block, and your agents keep their memory across sessions.
+            Build the current system from its public source. Download only the
+            modules that have a published release, checksum, and inspectable
+            artifact.
           </p>
         </div>
       </section>
@@ -119,34 +108,33 @@ export default function DownloadPage() {
               </div>
               <div className="p-6">
                 <span className="px-2.5 py-1 bg-cyan-500/10 border border-cyan-500/20 text-cyan-400 text-[10px] font-mono rounded-full uppercase">
-                  SIP Core • {SIP_STARTER_TAG}
+                  SIP Core • {SIP_STARTER_LABEL}
                 </span>
-                <h3 className="mt-4 text-2xl font-bold text-white tracking-tight">SIP Starter Package</h3>
+                <h3 className="mt-4 text-2xl font-bold text-white tracking-tight">SIP Starter Source</h3>
                 <p className="mt-2.5 text-xs text-slate-400 leading-relaxed">
-                  The foundational Starlight Intelligence Protocol starter. Contains core schemas, Obsidian vault templates, release manifest, and local installation scripts.
+                  The v8.3.0 source is public. A checksum-backed SIP Starter
+                  archive has not been published for this version, so this
+                  surface routes to source instead of manufacturing a release.
                 </p>
                 <div className="mt-6 flex items-center justify-between gap-4 border-t border-white/[0.05] pt-4">
                   <span className="text-[11px] text-slate-500 font-mono">License: MIT</span>
                   <div className="flex gap-x-2">
                     <a
-                      href={`${SIP_STARTER_ASSET_BASE}/${SIP_STARTER_MODULE_NAME}.zip`}
-                      className="inline-flex items-center gap-x-1.5 rounded-full bg-white px-4 py-2 text-[12px] font-semibold text-slate-950 hover:bg-cyan-100 transition-all"
-                    >
-                      <Download className="h-3.5 w-3.5" />
-                      Get ZIP
-                    </a>
-                    <a
-                      href={SIP_STARTER_RELEASE_URL}
+                      href={SIP_STARTER_SOURCE_URL}
                       target="_blank"
                       rel="noopener noreferrer"
+                      className="inline-flex items-center gap-x-1.5 rounded-full bg-white px-4 py-2 text-[12px] font-semibold text-slate-950 hover:bg-cyan-100 transition-all"
+                    >
+                      <Eye className="h-3.5 w-3.5" />
+                      Inspect source
+                    </a>
+                    <Link
+                      href="/quickstart"
                       className="inline-flex items-center gap-x-1.5 rounded-full border border-white/[0.12] px-4 py-2 text-[12px] font-medium text-white hover:bg-white/[0.04] transition-all"
                     >
-                      <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                        <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4" />
-                        <path d="M9 18c-4.51 2-5-2-7-2" />
-                      </svg>
-                      Release
-                    </a>
+                      <TerminalIcon className="h-3.5 w-3.5" />
+                      Build current source
+                    </Link>
                   </div>
                 </div>
               </div>
@@ -263,7 +251,7 @@ export default function DownloadPage() {
                 color: "text-amber-400 border-amber-500/10 hover:border-amber-500/30",
                 desc: "Packaging templates and visual monetization engines.",
               },
-            ].map((kit, index) => {
+            ].map((kit) => {
               const Icon = kit.icon;
               return (
                 <div
@@ -466,51 +454,50 @@ export default function DownloadPage() {
           <div>
             <p className="text-[11px] font-medium uppercase tracking-widest text-slate-500 font-mono">05 / Setup</p>
             <h2 className="mt-2 text-3xl font-bold text-white tracking-tight">
-              Start in seconds.
+              Build what is current.
             </h2>
             <p className="mt-4 text-slate-400 text-sm leading-relaxed font-light">
-              Run the shell script to unpack the Starlight core contract (memory, agents, stack, and vault seeds) into your active workspace.
+              Until a v8.3.0 Starter archive is published, the repository is
+              the only current distribution path.
             </p>
           </div>
           <Terminal>
-            <span className="text-cyan-400">$</span>{" "}
-            <span className="text-slate-300">curl -LO</span>{" "}
-            <span className="text-violet-300">
-              {`${SIP_STARTER_ASSET_BASE}/${SIP_STARTER_MODULE_NAME}.tar.gz`}
-            </span>
-            {"\n"}
-            <span className="text-cyan-400">$</span>{" "}
-            <span className="text-slate-300">tar -xzf</span>{" "}
-            <span className="text-violet-300">{`${SIP_STARTER_MODULE_NAME}.tar.gz`}</span>
-            {"\n"}
-            <span className="text-cyan-400">$</span>{" "}
-            <span className="text-slate-300">sh</span>{" "}
-            <span className="text-violet-300">
-              {`${SIP_STARTER_MODULE_NAME}/install.sh`}
-            </span>{" "}
-            <span className="text-slate-500">/path/to/your/repo</span>
+            {`git clone ${SIP_STARTER_REPO}.git
+cd Starlight-Intelligence-System
+npm install
+npm run build
+node dist/cli.js init --vaults`}
           </Terminal>
         </div>
       </section>
 
-      {/* 7. Package Contents Grid */}
+      {/* 7. Distribution state */}
       <section className="px-6 py-20 border-b border-white/[0.04] bg-[#040409]/30">
         <div className="mx-auto max-w-5xl">
-          <p className="text-[11px] font-medium uppercase tracking-widest text-slate-500 font-mono">06 / Check list</p>
+          <p className="text-[11px] font-medium uppercase tracking-widest text-slate-500 font-mono">06 / Distribution state</p>
           <h2 className="mt-2 text-3xl font-bold text-white tracking-tight">
-            Everything included in the SIP Core module.
+            Source is open. The archive is not published.
           </h2>
-          <div className="mt-8 grid gap-3 grid-cols-2 sm:grid-cols-3 lg:grid-cols-4">
-            {SIP_STARTER_INCLUDED.map((item) => (
-              <div
-                key={item}
-                className="rounded-xl border border-white/[0.05] bg-white/[0.01] px-4 py-3"
-              >
-                <code className="font-mono text-[11px] text-slate-400 truncate block">
-                  {item}
-                </code>
-              </div>
-            ))}
+          <p className="mt-4 max-w-2xl text-sm leading-relaxed text-slate-400">
+            No release page, ZIP, TAR.GZ, manifest, or checksum is claimed for
+            SIP Starter v8.3.0. The machine-readable endpoint reports the same
+            source-only state.
+          </p>
+          <div className="mt-8 flex flex-wrap gap-3">
+            <a
+              href={SIP_STARTER_SOURCE_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-full border border-white/[0.1] px-5 py-2.5 text-[13px] font-medium text-white transition-all hover:border-white/[0.2] hover:bg-white/[0.04]"
+            >
+              Inspect main source
+            </a>
+            <Link
+              href="/download/latest.json"
+              className="rounded-full border border-white/[0.1] px-5 py-2.5 text-[13px] font-medium text-white transition-all hover:border-white/[0.2] hover:bg-white/[0.04]"
+            >
+              Read distribution JSON
+            </Link>
           </div>
         </div>
       </section>
@@ -520,18 +507,18 @@ export default function DownloadPage() {
         <div className="mx-auto max-w-5xl grid gap-6 sm:grid-cols-3">
           <ValidationStep
             n="01"
-            title="Verify checksums"
-            body="Download the SHA256 file and compare it against the archive before unpacking."
+            title="Inspect source"
+            body="Review the public repository, license, and current main history before adopting it."
           />
           <ValidationStep
             n="02"
-            title="Read the manifest"
-            body="Use release-manifest.json and starlight-module.json to confirm conformance."
+            title="Build locally"
+            body="Install dependencies and compile the checked-out source; do not substitute the stale npm package."
           />
           <ValidationStep
             n="03"
-            title="Deploy runtime"
-            body="When the file contract is working, install the full Starlight runtime via npm."
+            title="Verify the boundary"
+            body="Call tools/list over JSON-RPC and confirm the current 13-tool MCP surface."
           />
         </div>
         

--- a/site/src/app/quickstart/page.tsx
+++ b/site/src/app/quickstart/page.tsx
@@ -4,11 +4,11 @@ import Link from "next/link";
 export const metadata: Metadata = {
   title: "Quickstart",
   description:
-    "Install Starlight Intelligence in 2 minutes. Pick your AI tool and copy the config.",
+    "Build the current Starlight Intelligence source, connect one MCP client, and verify the live tool surface.",
   openGraph: {
     title: "Quickstart — Starlight Intelligence",
     description:
-      "Install Starlight Intelligence in 2 minutes. Pick your AI tool and copy the config.",
+      "Build the current source, connect one MCP client, and verify the live tool surface.",
     type: "article",
     images: [{ url: "/opengraph-image", width: 1200, height: 630, alt: "Starlight Intelligence — Quickstart" }],
   },
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "Quickstart — Starlight Intelligence",
     description:
-      "Install in 2 minutes. Pick your AI tool, copy the config.",
+      "Build the current source, connect one MCP client, and verify the live tool surface.",
     images: ["/opengraph-image"],
   },
 };
@@ -30,8 +30,11 @@ type Platform = {
   memoryFile: string;
   configPath: string;
   reason: string;
-  json: string;
+  config: string;
 };
+
+const MCP_SERVER_PATH =
+  "/path/to/Starlight-Intelligence-System/dist/mcp-server.js";
 
 const PLATFORMS: Platform[] = [
   {
@@ -39,15 +42,15 @@ const PLATFORMS: Platform[] = [
     labelColor: "text-violet-400",
     labelBg: "bg-violet-500/[0.07]",
     labelBorder: "border-violet-500/[0.18]",
-    context: "200k tokens",
+    context: "project config",
     memoryFile: "CLAUDE.md",
-    configPath: "~/.claude/mcp.json",
-    reason: "Best for deep work — persistent sessions and rich tool access.",
-    json: `{
+    configPath: ".mcp.json",
+    reason: "Keep the server declaration with the project that uses it.",
+    config: `{
   "mcpServers": {
     "starlight-sis": {
       "command": "node",
-      "args": ["node_modules/@arcanea/starlight-intelligence-system/dist/mcp-server.js"]
+      "args": ["${MCP_SERVER_PATH}"]
     }
   }
 }`,
@@ -57,15 +60,15 @@ const PLATFORMS: Platform[] = [
     labelColor: "text-cyan-400",
     labelBg: "bg-cyan-500/[0.07]",
     labelBorder: "border-cyan-500/[0.18]",
-    context: "200k tokens",
+    context: "user config",
     memoryFile: ".cursorrules",
-    configPath: ".cursor/mcp.json",
-    reason: "Best for IDE-native editing with memory-aware completions.",
-    json: `{
+    configPath: "~/.cursor/mcp.json",
+    reason: "Use one absolute server path so every workspace reaches the same vault.",
+    config: `{
   "mcpServers": {
     "starlight-sis": {
       "command": "node",
-      "args": ["node_modules/@arcanea/starlight-intelligence-system/dist/mcp-server.js"]
+      "args": ["${MCP_SERVER_PATH}"]
     }
   }
 }`,
@@ -75,33 +78,28 @@ const PLATFORMS: Platform[] = [
     labelColor: "text-fuchsia-400",
     labelBg: "bg-fuchsia-500/[0.07]",
     labelBorder: "border-fuchsia-500/[0.18]",
-    context: "128k tokens",
+    context: "TOML config",
     memoryFile: "AGENTS.md",
-    configPath: "~/.codex/mcp.json",
-    reason: "Best for terminal-first workflows with OpenAI reasoning.",
-    json: `{
-  "mcpServers": {
-    "starlight-sis": {
-      "command": "node",
-      "args": ["node_modules/@arcanea/starlight-intelligence-system/dist/mcp-server.js"]
-    }
-  }
-}`,
+    configPath: "~/.codex/config.toml",
+    reason: "Register the local stdio server in Codex's TOML configuration.",
+    config: `[mcp_servers.starlight_sis]
+command = "node"
+args = ["${MCP_SERVER_PATH}"]`,
   },
   {
     name: "Gemini CLI",
     labelColor: "text-amber-400",
     labelBg: "bg-amber-500/[0.07]",
     labelBorder: "border-amber-500/[0.18]",
-    context: "1M tokens",
+    context: "user config",
     memoryFile: "GEMINI.md",
     configPath: "~/.gemini/settings.json",
-    reason: "Best for massive context — feed your whole vault in one shot.",
-    json: `{
+    reason: "Register the same local server and vault path in Gemini CLI.",
+    config: `{
   "mcpServers": {
     "starlight-sis": {
       "command": "node",
-      "args": ["node_modules/@arcanea/starlight-intelligence-system/dist/mcp-server.js"]
+      "args": ["${MCP_SERVER_PATH}"]
     }
   }
 }`,
@@ -111,15 +109,18 @@ const PLATFORMS: Platform[] = [
     labelColor: "text-emerald-400",
     labelBg: "bg-emerald-500/[0.07]",
     labelBorder: "border-emerald-500/[0.18]",
-    context: "model-dependent",
+    context: "user config",
     memoryFile: "AGENTS.md",
     configPath: "~/.config/opencode/config.json",
-    reason: "Best for multi-model routing — swap models without losing memory.",
-    json: `{
+    reason: "Keep the server local while models change above the memory layer.",
+    config: `{
   "mcp": {
     "starlight-sis": {
       "type": "local",
-      "command": ["node", "node_modules/@arcanea/starlight-intelligence-system/dist/mcp-server.js"]
+      "command": [
+        "node",
+        "${MCP_SERVER_PATH}"
+      ]
     }
   }
 }`,
@@ -131,29 +132,37 @@ export default function QuickstartPage() {
     <div className="mx-auto max-w-3xl px-6 py-16">
       {/* Hero */}
       <p className="text-[11px] font-medium uppercase tracking-widest text-violet-400">
-        Two minutes to compound intelligence
+        Current source · verified path
       </p>
       <h1 className="mt-3 text-3xl font-bold tracking-tight text-white md:text-4xl">
         Quickstart
       </h1>
       <p className="mt-4 max-w-xl text-[15px] leading-relaxed text-slate-400">
-        Pick your tool. Copy the config. Your next AI session remembers
-        everything.
+        Build the current source, point one MCP client at its server, and
+        confirm the 13 tools before writing your first memory.
       </p>
 
       {/* Step 1 — Install */}
       <section className="mt-16">
-        <StepLabel n={1} label="Install the package" />
+        <StepLabel n={1} label="Build the current source" />
         <p className="mt-3 text-[14px] leading-relaxed text-slate-400">
-          Install once from npm. Works with any MCP-compatible client.
+          The repository is the current v8.3.0 distribution path. Clone it,
+          build it, then seed the six local vaults.
         </p>
         <Terminal>
-          <span className="text-emerald-400">$</span>{" "}
-          <span className="text-slate-400">npm install</span>{" "}
-          <span className="text-violet-400">
-            @arcanea/starlight-intelligence-system
-          </span>
+          {`git clone https://github.com/frankxai/Starlight-Intelligence-System
+cd Starlight-Intelligence-System
+npm install
+npm run build
+node dist/cli.js init --vaults`}
         </Terminal>
+        <div className="mt-5 rounded-xl border border-amber-500/[0.16] bg-amber-500/[0.05] p-5">
+          <p className="text-[13px] leading-relaxed text-slate-300">
+            Distribution note: as verified on July 24, 2026, npm serves
+            v6.0.1 while this repository is v8.3.0. Use the source path above
+            for the current system.
+          </p>
+        </div>
       </section>
 
       {/* Step 2 — Platform configs */}
@@ -194,7 +203,7 @@ export default function QuickstartPage() {
                 </div>
               </dl>
 
-              <CodeBlock>{p.json}</CodeBlock>
+              <CodeBlock>{p.config}</CodeBlock>
             </div>
           ))}
         </div>
@@ -204,21 +213,14 @@ export default function QuickstartPage() {
       <section className="mt-16">
         <StepLabel n={3} label="Verify it works" />
         <p className="mt-3 text-[14px] leading-relaxed text-slate-400">
-          Run the MCP server directly to confirm it starts and lists its tools.
+          Ask the server for its tool inventory over the same JSON-RPC
+          boundary your client uses.
         </p>
         <Terminal>
-          <span className="text-emerald-400">$</span>{" "}
-          <span className="text-slate-400">npx</span>{" "}
-          <span className="text-violet-400">@arcanea/starlight-intelligence-system</span>{" "}
-          <span className="text-slate-400">--list-tools</span>
-          {"\n"}
-          <span className="text-slate-600">{"→ sis_append_entry"}</span>
-          {"\n"}
-          <span className="text-slate-600">{"→ sis_recent_entries"}</span>
-          {"\n"}
-          <span className="text-slate-600">{"→ sis_vault_search"}</span>
-          {"\n"}
-          <span className="text-slate-600">{"→ sis_stats"}</span>
+          {`printf '%s\\n' '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \\
+  | node /path/to/Starlight-Intelligence-System/dist/mcp-server.js
+
+# result.tools contains 13 sis_* tool definitions`}
         </Terminal>
       </section>
 
@@ -252,7 +254,7 @@ export default function QuickstartPage() {
           <span className="text-slate-400">,</span>
           {"\n"}
           {"  "}
-          <span className="text-violet-400">insight</span>
+          <span className="text-violet-400">content</span>
           <span className="text-slate-400">:</span>{" "}
           <span className="text-emerald-400">
             &quot;Chose Next.js 16 for App Router streaming&quot;
@@ -271,7 +273,7 @@ export default function QuickstartPage() {
           <p className="text-[13px] leading-relaxed text-slate-300">
             That entry is now a plain JSONL line in{" "}
             <code className="font-mono text-[12px] text-violet-300">
-              vaults/frank/technical.jsonl
+              ~/.starlight/vaults/technical.jsonl
             </code>
             . Every tool with the MCP configured can read it. Your memory
             compounds across every session.

--- a/site/src/app/quickstart/page.tsx
+++ b/site/src/app/quickstart/page.tsx
@@ -111,7 +111,7 @@ args = ["${MCP_SERVER_PATH}"]`,
     labelBorder: "border-emerald-500/[0.18]",
     context: "user config",
     memoryFile: "AGENTS.md",
-    configPath: "~/.config/opencode/config.json",
+    configPath: "~/.config/opencode/opencode.json",
     reason: "Keep the server local while models change above the memory layer.",
     config: `{
   "mcp": {

--- a/site/src/lib/sip-download.ts
+++ b/site/src/lib/sip-download.ts
@@ -1,82 +1,37 @@
 export const SIP_STARTER_VERSION = "8.3.0";
-export const SIP_STARTER_TAG = `v${SIP_STARTER_VERSION}`;
-export const SIP_STARTER_MODULE_NAME = `starlight-sip-starter-v${SIP_STARTER_VERSION}`;
+export const SIP_STARTER_LABEL = `v${SIP_STARTER_VERSION} source`;
 export const SIP_STARTER_REPO =
   "https://github.com/frankxai/Starlight-Intelligence-System";
-export const SIP_STARTER_RELEASE_BASE = `${SIP_STARTER_REPO}/releases`;
-export const SIP_STARTER_RELEASE_URL = `${SIP_STARTER_RELEASE_BASE}/tag/${SIP_STARTER_TAG}`;
-export const SIP_STARTER_ASSET_BASE = `${SIP_STARTER_RELEASE_BASE}/download/${SIP_STARTER_TAG}`;
+export const SIP_STARTER_SOURCE_URL = `${SIP_STARTER_REPO}/tree/main`;
 export const SIP_STARTER_DOWNLOAD_PAGE =
   "https://starlightintelligence.org/download";
-
-export const SIP_STARTER_DOWNLOADS = [
-  {
-    label: "ZIP",
-    filename: `${SIP_STARTER_MODULE_NAME}.zip`,
-    href: `${SIP_STARTER_ASSET_BASE}/${SIP_STARTER_MODULE_NAME}.zip`,
-  },
-  {
-    label: "TAR.GZ",
-    filename: `${SIP_STARTER_MODULE_NAME}.tar.gz`,
-    href: `${SIP_STARTER_ASSET_BASE}/${SIP_STARTER_MODULE_NAME}.tar.gz`,
-  },
-  {
-    label: "Checksums",
-    filename: `${SIP_STARTER_MODULE_NAME}.sha256`,
-    href: `${SIP_STARTER_ASSET_BASE}/${SIP_STARTER_MODULE_NAME}.sha256`,
-  },
-  {
-    label: "Manifest",
-    filename: "release-manifest.json",
-    href: `${SIP_STARTER_ASSET_BASE}/release-manifest.json`,
-  },
-] as const;
-
-export const SIP_STARTER_INCLUDED = [
-  "AGENTS.md",
-  "SKILL.md",
-  "MEMORY.md",
-  "SOUL.md",
-  "STACK.md",
-  "CANON.md",
-  "SIP.md",
-  "SIP-QUICKSTART.md",
-  "public-vault/",
-  "mcp.json.example",
-  "starlight-module.json",
-  "README.md",
-  "QUICKSTART.md",
-  "INSTALL.md",
-  "VALIDATION.md",
-  "UPGRADE-PATH.md",
-  "EXCELLENCE-CHECKLIST.md",
-  "RELEASE-NOTES.md",
-  "install.sh",
-  "install.ps1",
-  "validate-sip-starter.mjs",
-] as const;
 
 export function getSipStarterLatestManifest() {
   return {
     name: "starlight-sip-starter",
     version: SIP_STARTER_VERSION,
-    tag: SIP_STARTER_TAG,
+    tag: null,
     type: "sip-starter-release-index",
     conformance: "SIP Core",
+    status: "source-only",
     canonicalDownloadPage: SIP_STARTER_DOWNLOAD_PAGE,
-    releaseUrl: SIP_STARTER_RELEASE_URL,
-    assets: SIP_STARTER_DOWNLOADS,
-    included: SIP_STARTER_INCLUDED,
+    releaseUrl: null,
+    assets: [],
+    included: [],
+    source: {
+      repository: SIP_STARTER_REPO,
+      branch: "main",
+      url: SIP_STARTER_SOURCE_URL,
+    },
+    note:
+      "No v8.3.0 tag, release, or checksum-backed SIP Starter archive has been published. Use the current main source workflow until a release is present.",
     install: {
-      unix: [
-        `curl -LO ${SIP_STARTER_ASSET_BASE}/${SIP_STARTER_MODULE_NAME}.tar.gz`,
-        `tar -xzf ${SIP_STARTER_MODULE_NAME}.tar.gz`,
-        `sh ${SIP_STARTER_MODULE_NAME}/install.sh /path/to/your/repo`,
-      ],
-      windows: [
-        `Invoke-WebRequest -Uri ${SIP_STARTER_ASSET_BASE}/${SIP_STARTER_MODULE_NAME}.zip -OutFile ${SIP_STARTER_MODULE_NAME}.zip`,
-        `Expand-Archive ${SIP_STARTER_MODULE_NAME}.zip -DestinationPath .`,
-        `pwsh .\\${SIP_STARTER_MODULE_NAME}\\install.ps1 -TargetPath C:\\path\\to\\your\\repo`,
+      source: [
+        `git clone ${SIP_STARTER_REPO}.git`,
+        "cd Starlight-Intelligence-System",
+        "npm install",
+        "npm run build",
+        "node dist/cli.js init --vaults",
       ],
     },
   };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -351,7 +351,8 @@ function cmdInitVaults(vaultDirArg?: string, force = false): void {
   }
   console.log("");
   console.log("Point your MCP client at this directory:");
-  console.log(`  node node_modules/@arcanea/starlight-intelligence-system/dist/mcp-server.js --vault-dir ${result.vaultDir}`);
+  const mcpServerPath = join(getPackageRoot(), "dist", "mcp-server.js");
+  console.log(`  node "${mcpServerPath}" --vault-dir "${result.vaultDir}"`);
 }
 
 function cmdGenerate(target?: string, outputPath?: string): void {

--- a/test/mcp-server-smoke.test.ts
+++ b/test/mcp-server-smoke.test.ts
@@ -1,13 +1,13 @@
 /**
  * Operational MCP server — end-to-end JSON-RPC smoke test.
  *
- * The README's #1 install path is `node dist/mcp-server.js` exposing ten
+ * The README's #1 install path is `node dist/mcp-server.js` exposing thirteen
  * `sis_*` tools over JSON-RPC 2.0 stdio. That path previously had NO automated
- * end-to-end proof (the v0.1 server in mcp-server-v01.ts is a different, 13
+ * end-to-end proof (the v0.1 server in mcp-server-v01.ts is a different
  * `sis.*`-tool surface). This test spawns the operational server, drives the
  * real stdin/stdout protocol, and asserts:
  *   - `initialize` returns serverInfo
- *   - `tools/list` returns exactly the ten documented `sis_*` tools
+ *   - `tools/list` returns exactly the thirteen documented `sis_*` tools
  *
  * The server is spawned from src/ via the tsx loader so the test does not
  * depend on build order within `npm test`; src/mcp-server.ts is the exact code
@@ -111,7 +111,7 @@ function driveServer(
 }
 
 describe("operational MCP server (dist/mcp-server.js) — end-to-end", () => {
-  it("responds to initialize and lists exactly the ten sis_* tools", async () => {
+  it("responds to initialize and lists exactly the thirteen sis_* tools", async () => {
     const responses = await driveServer(
       [
         { jsonrpc: "2.0", id: 1, method: "initialize", params: {} },
@@ -128,7 +128,7 @@ describe("operational MCP server (dist/mcp-server.js) — end-to-end", () => {
     assert.deepEqual(
       names,
       EXPECTED_TOOLS,
-      `tools/list did not return the ten documented sis_* tools (got ${names.length})`,
+      `tools/list did not return the thirteen documented sis_* tools (got ${names.length})`,
     );
   });
 });


### PR DESCRIPTION
## Why

The public install story pointed visitors toward an unpublished v8.3.0 Starter and a setup path that could not succeed as written. This repair makes every first-run surface agree with the current public repository and the tested 13-tool MCP path.

## What changed

- fail closed on the unpublished v8.3.0 Starter
- align `/quickstart`, `/download`, `/docs`, crawler text, latest-version JSON, and generated MCP setup
- make the clone-based 13-tool path the current install contract
- use OpenCode's documented global configuration path: `~/.config/opencode/opencode.json`
- forbid both stale OpenCode paths: `~/.config/opencode/config.json` and `~/.opencode/config.json`
- require the current OpenCode path in both Quickstart and the root README
- enforce public-install truth recursively under pnpm
- add nested regression fixtures and isolated MCP verification

## Exact candidate receipt

- exact head: `fa17d43b3dcef4d72cefc8aa0e4d2feb0961efe4`
- exact tree: `711565a7c088fbfbbdee3e0be1803855fa453723`
- independent exact-head verdict: **APPROVE**
- recursive public-install contract: 81 files passing
- adversarial nested fixture: both stale OpenCode paths correctly blocked
- operational tests: 236 passing
- production build: 75 routes
- isolated built-server MCP probe: 13 tools
- GitHub Actions: [Harness check #181](https://github.com/frankxai/Starlight-Intelligence-System/actions/runs/30130573774) — SUCCESS
- exact-head preview: `dpl_6EbzEw73PLPTYxjcgQPEh9uomXqT` — READY
- preview provenance: exact head `fa17d43b3dcef4d72cefc8aa0e4d2feb0961efe4`
- preview build: contract passed, TypeScript passed, 75/75 pages generated
- preview runtime error/fatal query: no logs found

## Release boundary

This is a production-truth repair, not a visual redesign. The exact candidate has passed independent review and is cleared for merge.