### PR TITLE
fix(site): keep navigation and download heading intact

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -4,8 +4,9 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "node scripts/check-public-install-contract.mjs && next build",
+    "build": "node scripts/check-public-install-contract.mjs && node scripts/check-layout-contract.mjs && next build",
     "check:public-install-contract": "node scripts/check-public-install-contract.mjs",
+    "check:layout-contract": "node scripts/check-layout-contract.mjs",
     "start": "next start",
     "lint": "eslint"
   },

--- a/site/scripts/check-layout-contract.mjs
+++ b/site/scripts/check-layout-contract.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SITE_ROOT = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const header = readFileSync(
+  join(SITE_ROOT, "src/components/Header.tsx"),
+  "utf8",
+);
+const downloadPage = readFileSync(
+  join(SITE_ROOT, "src/app/download/page.tsx"),
+  "utf8",
+);
+const protocolPage = readFileSync(
+  join(SITE_ROOT, "src/app/protocol/page.tsx"),
+  "utf8",
+);
+
+const failures = [];
+
+if (
+  !header.includes("NAV_GROUPS.map((group, groupIndex)") ||
+  !header.includes(
+    "const alignPanelRight = groupIndex === NAV_GROUPS.length - 1;",
+  ) ||
+  !header.includes('alignPanelRight ? "right-0" : "left-0"')
+) {
+  failures.push(
+    "the final desktop navigation panel must align to its trigger's right edge",
+  );
+}
+
+if (
+  !downloadPage.includes(
+    '<span className="block">Start from</span>{" "}',
+  ) ||
+  !downloadPage.includes(
+    '<span className="block bg-gradient-to-r from-cyan-400 via-violet-400 to-fuchsia-400 bg-clip-text text-transparent">',
+  )
+) {
+  failures.push(
+    "the /download H1 must preserve its visual line break and a semantic space",
+  );
+}
+
+if (/Start from\s*<br\s*\/?>/.test(downloadPage)) {
+  failures.push(
+    "the /download H1 must not concatenate its two phrases around a br element",
+  );
+}
+
+if (!protocolPage.includes("overflow-x-auto")) {
+  failures.push(
+    "intentional table and pre horizontal scrollers must remain available",
+  );
+}
+
+if (failures.length > 0) {
+  console.error("Layout contract failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  "Layout contract passed: the final navigation panel stays in-viewport, semantic heading spacing is explicit, and nested scrollers remain.",
+);

--- a/site/src/app/download/page.tsx
+++ b/site/src/app/download/page.tsx
@@ -71,10 +71,8 @@ export default function DownloadPage() {
             Starlight Distribution
           </span>
           <h1 className="mt-6 max-w-3xl text-4xl font-bold leading-[1.05] tracking-tight text-white md:text-6xl">
-            Start from<br />
-            <span className="bg-gradient-to-r from-cyan-400 via-violet-400 to-fuchsia-400 bg-clip-text text-transparent">
-              verified source.
-            </span>
+            <span className="block">Start from</span>{" "}
+            <span className="block bg-gradient-to-r from-cyan-400 via-violet-400 to-fuchsia-400 bg-clip-text text-transparent">verified source.</span>
           </h1>
           <p className="mt-6 max-w-2xl text-[15px] leading-[1.8] text-slate-400">
             Build the current system from its public source. Download only the

--- a/site/src/components/Header.tsx
+++ b/site/src/components/Header.tsx
@@ -59,10 +59,11 @@ function HeaderContent({ pathname }: { pathname: string }) {
 
         {/* Desktop grouped nav */}
         <div className="hidden items-center gap-0.5 md:flex">
-          {NAV_GROUPS.map((group) => {
+          {NAV_GROUPS.map((group, groupIndex) => {
             const open = openMenu === group.label;
             const groupActive = group.items.some((it) => isActive(pathname, it.href));
             const panelId = `nav-panel-${group.label.toLowerCase()}`;
+            const alignPanelRight = groupIndex === NAV_GROUPS.length - 1;
             return (
               <div
                 key={group.label}
@@ -92,7 +93,9 @@ function HeaderContent({ pathname }: { pathname: string }) {
                     doesn't drop while crossing it. */}
                 <div
                   id={panelId}
-                  className={`absolute left-0 top-full z-50 w-72 pt-2 transition-micro ${
+                  className={`absolute top-full z-50 w-72 pt-2 transition-micro ${
+                    alignPanelRight ? "right-0" : "left-0"
+                  } ${
                     open ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0"
                   }`}
                 >


### PR DESCRIPTION
## Outcome

Repairs two production-facing integrity defects on the canonical Starlight site without changing its approved visual language:

- keeps the final desktop navigation panel inside the viewport
- restores the semantic `Start from verified source.` H1 while preserving the designed two-line treatment

## Implementation

- right-aligns only the final desktop dropdown to its trigger
- preserves intentional horizontal scrolling for tables and code blocks
- replaces the line-break concatenation with explicit block spans and a semantic space
- adds a fail-closed layout contract to the site build pipeline

## Verification

Independent verifier: **APPROVE**

- layout regression contract: **pass**
- public install contract: **pass** across 81 files
- production build: **75/75 static routes**
- ESLint: **0 errors** (5 unrelated existing image warnings)
- built dropdown alignment: **two left-aligned, one right-aligned**
- built `/download` H1: **Start from verified source.**
- `git diff --check`: **pass**
- published remote tree is byte-identical to the verified local tree: `add9ddcfd62a14afdb0542e2268f371d169d26d6`

## Rollback

Revert the squash commit created from head `5a8aaf4933033cf5aefb56606d9da7fc4a0eea06`. This PR changes no domain, secret, registry, or external publication state.