### PR TITLE
ci: repin hardened Starlight design kernel

### DIFF
--- a/.github/workflows/starlight-design-contract.yml
+++ b/.github/workflows/starlight-design-contract.yml
@@ -8,4 +8,4 @@ permissions:
 
 jobs:
   design-contract:
-    uses: frankxai/starlight-design-intelligence/.github/workflows/design-contract.yml@0408bd8fb17a5890e1b743eb381abb4386f35a43
+    uses: frankxai/starlight-design-intelligence/.github/workflows/design-contract.yml@80830c60040967956580c761772469664c44dd55

--- a/.starlight/design-contract.json
+++ b/.starlight/design-contract.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "starlight.design_contract.v1",
   "repository": "frankxai/Starlight-Intelligence-System",
-  "kernel_commit_sha": "0408bd8fb17a5890e1b743eb381abb4386f35a43",
+  "kernel_commit_sha": "80830c60040967956580c761772469664c44dd55",
   "brand": {
     "id": "sis",
     "pack_sha256": "2c1d742c9ae823753b244da26816d740b80ca2ddd8428cd201790e2b827e3dea"


### PR DESCRIPTION
## Outcome

Repins SIS from the original immutable design kernel to the newly hardened Node 24 kernel.

## Exact repin

- previous kernel: `0408bd8fb17a5890e1b743eb381abb4386f35a43`
- hardened kernel: `80830c60040967956580c761772469664c44dd55`
- SIS brand digest remains `2c1d742c9ae823753b244da26816d740b80ca2ddd8428cd201790e2b827e3dea`
- surface registry remains `homepage / operations / availability+capability+provenance`
- local authorities remain `AGENTS.md`, `design.md`, and `taste.md`

The hardened kernel pins Node 24.14.0, official Node 24 action runtimes, patched AJV/YAML releases, and a moderate-severity dependency audit gate.

## Scope

Exactly two references change:

- `.github/workflows/starlight-design-contract.yml`
- `.starlight/design-contract.json`

No design authority, brand pack, product UI, production configuration, or release evidence changes.

## Verification

Exact proposed head: `f891b3d235d4479d8b63b6d0d34cd41d69e22803`

- current SIS main base: `05cefe256e2b44da1007d3e02beb9689c19954a5`
- one commit; two files; +2 / -2 — PASS
- pinned SIS brand pack and portfolio registry are byte-identical at the hardened kernel — PASS
- Starlight design contract workflow run #3 — PASS
- repository Harness check run #192 — PASS
- Vercel and CodeRabbit commit statuses — SUCCESS
- draft PR is mergeable and remains unmerged

**Built on SIP — Starlight Intelligence Protocol**
