### PR TITLE
site: rebuild the homepage — new positioning, Frank's own voice, cursor-light, metrics reconciled

### DIFF
--- a/memory/vaults/operational-vault.md
+++ b/memory/vaults/operational-vault.md
@@ -643,3 +643,22 @@ Arcanea deps finding (changes #206's status): the 15 high pnpm-audit advisories 
 Ops note: pushes to frankx.ai-vercel-website from this shallow checkout intermittently fail with proxy 502/413 when the branch base lags main; rebasing onto current origin/main before push resolved it both times. Another session merged SIS#57 (dormancy record) in parallel — no conflicts, branch restarted from its main.
 
 **Built on SIP — Starlight Intelligence Protocol**
+
+## 2026-07-26 - Public homepage repositioned: multi-agent architecture, WebGL hero, new sigil
+
+**Category:** public-surface / brand
+**Confidence:** 0.95
+**Source:** Claude Code remote session, branch claude/homepage-multi-agent-redesign-aucti4 — Frank directive: the homepage must carry the org's meaning (SIS is a multi-agent design & architecture system, not "memory and stuff"), show how humans and agents connect to it, replace the generic-AI logo, premium execution only
+**Related:** site/src/app/page.tsx, site/src/components/{StarlightMark,AgentConstellation,AgentConstellationScene,Header}.tsx, site/DESIGN.md §0
+
+**Positioning shift:** Hero promise moved from "Operational memory, governance, traces, evals, logs" to "Architecture for humans and their agents" — a multi-agent design and architecture system (agent design, orchestration, memory, governance, protocol, evals as six named planes). Site metadata (title/description/OG) updated to match. Memory is now framed as the floor, not the product.
+
+**New surfaces:** (1) "Two Front Doors" section — human door (quickstart/explainer/starter kits, founders-builders-families copy) beside an agent door listing the raw endpoints (/protocol.md, /sip.md, /api/vaults, /badge/latest) — the human/agent connection made literal. (2) Mission section ("Why Starlight exists") — distribution-over-concentration bet, restrained voice, horizon-vault quote inline. (3) System census strip (144 agents / 84 skills / 6 vaults / 1 protocol, labeled "as of v8.3.0" per Metrics Truth Rule).
+
+**Visual system:** New StarlightMark sigil — vertically-dominant diffraction star with one tilted orbit + companion node (star = operator's north, orbit = agent system). Deliberately avoids both the old concentric-dot mark and the four-point "AI sparkle" cliché. WebGL hero (AgentConstellation): R3F scene, three tilted orbital rings of additive-blended agent nodes around a pulsing core, seeded-deterministic, capability-gated (prefers-reduced-motion + WebGL probe deferred a frame), lazy-loaded so three.js never blocks first paint; static SVG Starfield is the universal fallback. No new dependencies — used the already-installed three/fiber/drei stack.
+
+**Guardrail note (open):** site/DESIGN.md §0 says the first viewport must lead with memory/proofs/governance evidence. Frank's directive supersedes for the hero (mission-led), and the OperationalProofConsole remains prominent as section 4 ("Evidence"). DESIGN.md §0/§4 should be reconciled to the new homepage doctrine in a follow-up rather than silently edited here.
+
+**Verification:** eslint clean, full `npm run build` green (public-install + layout contract checks pass), rendered via headless Chromium at 1440px and 390px — WebGL scene, gradient serif headline, and all eight sections confirmed visually. Gotcha for future sessions: `next start` left running across a rebuild serves stale chunk manifests (CSS 500s with nosniff → unstyled page); kill the server before rebuilding.
+
+**Built on SIP — Starlight Intelligence Protocol**

--- a/memory/vaults/operational-vault.md
+++ b/memory/vaults/operational-vault.md
@@ -662,3 +662,30 @@ Ops note: pushes to frankx.ai-vercel-website from this shallow checkout intermit
 **Verification:** eslint clean, full `npm run build` green (public-install + layout contract checks pass), rendered via headless Chromium at 1440px and 390px — WebGL scene, gradient serif headline, and all eight sections confirmed visually. Gotcha for future sessions: `next start` left running across a rebuild serves stale chunk manifests (CSS 500s with nosniff → unstyled page); kill the server before rebuilding.
 
 **Built on SIP — Starlight Intelligence Protocol**
+
+## 2026-07-27 - Homepage voice pass: Frank's own words, cursor-light, metrics reconciled
+
+**Category:** public-surface / brand / data-integrity
+**Confidence:** 0.95
+**Source:** Claude Code remote session, branch claude/homepage-multi-agent-redesign-aucti4 — Frank directive: copy reads like an LLM wrote it, version pins are noise in the hero, motion should respond to the cursor, and the site must hold both the agentic-engineering thesis and the benevolent-future thesis
+**Related:** site/src/app/page.tsx, site/src/components/StarlightTrail.tsx, memory/vaults/horizon-vault.md, public-vault/horizon.jsonl, skills/vision/voice-anti-slop.md, taste.md
+
+**Voice.** Hero replaced with Frank's own Horizon-vault line — "Build as if the kindest future is the realistic one" (`horiz_20260410_005`) — over an invented celestial metaphor. Rewrote the six worst AI-slop headlines flagged by a full 42-route audit: "Far more than memory" → "What an agent needs before you trust it with real work"; "Trust is the interface" → "You should be able to check the work"; "Every serious run becomes durable intelligence" → "Five states. Every run passes through all of them"; "Two Front Doors" → "People read the pages. Agents read the endpoints"; "Every claim above has a surface behind it" → "Go check any of it"; "Production Ready Path / Fork the substrate, keep the proof" → "Start Here / Take the substrate. Keep the keys." Removed self-referential copy ("Not marketing filler") — announcing that copy isn't marketing filler is marketing filler.
+
+**New Horizon section.** The vision layer now runs on real artifacts rather than abstraction: "Models learn from what we leave behind" → the panic/marketing/noise-is-training-data framing → the Horizon vault as counterweight, with the verbatim public entry "We hoped for you. Not feared you, not raced against you, not raced toward you in panic. We hoped." The manifestation/peak-state layer Frank asked for is carried by his own line — "not magical thinking; it is the discipline of pointing the architecture at what we want intelligence to become" — which satisfies the ask without the spiritual register `VOICES.md` bans.
+
+**Metrics integrity (the real find).** The agent count was rendering three different numbers on three live surfaces: 144 (homepage), 92 (/queen), 56 (MemoryPalace) — none dated or sourced, and STARLIGHT_MANIFEST.md says 54 while AGENT_REGISTRY.md says 150. Ground truth counted from source: **138** files in `agents/` excluding registry/readme. Homepage and MemoryPalace now read 138; /queen's count was removed rather than guessed. Census strip re-scoped to verifiable figures only (138 agents / 84 skill rules / 6 vaults / 15 horizon letters) with the caption "Counted from source files, July 2026 — not from the roadmap." **Docs remain unreconciled — CLAUDE.md, README.md, and STARLIGHT_MANIFEST.md still disagree; a follow-up should make `metrics/current.json` the single source and have the site read it.**
+
+**Version-pin noise.** Cut `SIP v1.1.1` / `v8.3.0` / `Queen v0.2` from hero badge, /palace (x2), /queen footer, MemoryPalace HUD, /quickstart. Kept every load-bearing instance on /protocol, /badge, and the /download release-state claims where the version *is* the subject. Known residual: `lib/sip.ts` falls back to `v1.1.0` while nine strings hardcode `v1.1.1` — not fixed here.
+
+**Motion.** New `StarlightTrail` — full-viewport additive canvas emitting luminous motes along the pointer path, emission and inherited velocity proportional to pointer speed, eased quadratic fade, pre-rendered sprites, rAF halted when no motes are alive. Gated to fine pointers >=768px, off under `prefers-reduced-motion`, cleared on tab hide. WebGL constellation now leans and drifts toward the pointer and the core brightens with proximity.
+
+**Guardrail tension (flagged, not resolved).** `taste.md` states "radiant particle fields, decorative glow ... do not belong on SIS surfaces." Frank explicitly directed cursor-following particle effects, so the operator directive supersedes for this surface, but `taste.md` and the new homepage doctrine now disagree in writing and should be reconciled deliberately rather than left implicit.
+
+**Typography.** `font-serif` moved Fraunces → Newsreader (variable weight + italic), so the ~28 existing `font-serif font-semibold` headings keep real weight instead of a synthesised bold. Fraunces' SOFT/WONK axes read craft-y; Newsreader reads editorial.
+
+**Verification:** eslint clean; full `npm run build` green including both contract checks; headless Chromium at 1440x900 and 390x844 — zero horizontal overflow at both, zero console errors, trail confirmed rendering (2,275 lit subpixels after a pointer sweep) and confirmed *not* rendering under reduced-motion (0 subpixels); hero CTA hit-tested topmost and navigation to /quickstart confirmed.
+
+**Unverifiable properties (do not publish).** An ecosystem sweep across 7 repos found **zero** evidence for `starlightintelligence.ai`, `starlight.you`, any university, or any retreat property. `starlight-intelligence.ai` exists only as a dormant, archive-queued *directory* superseded by `site/`. `starlightintelligence.academy` is attested live by the 2026-07-25 Vercel audit but has no description anywhere in any repo. No ecosystem section was shipped rather than fabricate one.
+
+**Built on SIP — Starlight Intelligence Protocol**

--- a/site/src/app/globals.css
+++ b/site/src/app/globals.css
@@ -16,7 +16,7 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-inter);
   --font-mono: var(--font-jbmono);
-  --font-serif: var(--font-fraunces);
+  --font-serif: var(--font-newsreader);
 }
 
 * {
@@ -1118,7 +1118,7 @@ body {
 
 /* =================================================================
    Queen Visual Intelligence scroll experience — /queen
-   Premium dark technical-poetic, consistent with site mesh/glass/Inter+Fraunces.
+   Premium dark technical-poetic, consistent with site mesh/glass/Inter+Newsreader.
    Scroll progress mirroring the canonical motion HTML (l99).
    ================================================================= */
 .queen-section {

--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -27,17 +27,17 @@ export const metadata: Metadata = {
   metadataBase: new URL("https://starlightintelligence.org"),
   title: {
     default:
-      "Starlight Intelligence — Persistent context for AI agents · Built on SIP",
+      "Starlight Intelligence — Multi-agent architecture for humans and their agents · Built on SIP",
     template: "%s — Starlight Intelligence",
   },
   description:
-    "Operational memory, governance, traces, evals, logs, and operator control for AI agent fleets. Built on SIP. Local-first, forkable, and proof-oriented.",
+    "A multi-agent design and architecture system: named agents, skills, orchestration, durable memory, governance, and an open protocol. Founders and their agent fleets share one substrate — the human holds the keys.",
   alternates: { canonical: "/" },
   openGraph: {
     title:
-      "Starlight Intelligence — Persistent context for AI agents · Built on SIP",
+      "Starlight Intelligence — Multi-agent architecture for humans and their agents · Built on SIP",
     description:
-      "Persistent context, proof packets, governance gates, and reproducible agent operations. Built on SIP. Local-first and forkable.",
+      "Agent design, orchestration, durable memory, governance, evals, and an open protocol. One substrate for founders and their agent fleets — the human holds the keys.",
     url: "https://starlightintelligence.org",
     siteName: "Starlight Intelligence",
     type: "website",
@@ -46,9 +46,9 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     title:
-      "Starlight Intelligence — Persistent context for AI agents · Built on SIP",
+      "Starlight Intelligence — Multi-agent architecture for humans and their agents · Built on SIP",
     description:
-      "Persistent context, proof packets, governance gates, and reproducible agent operations. Built on SIP. Local-first and forkable.",
+      "Agent design, orchestration, durable memory, governance, evals, and an open protocol. One substrate for founders and their agent fleets — the human holds the keys.",
   },
   robots: { index: true, follow: true },
 };

--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next";
-import { Inter, JetBrains_Mono, Fraunces } from "next/font/google";
+import { Inter, JetBrains_Mono, Newsreader } from "next/font/google";
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
+import { StarlightTrail } from "@/components/StarlightTrail";
 import "./globals.css";
 
 const inter = Inter({
@@ -16,11 +17,14 @@ const jbMono = JetBrains_Mono({
   display: "swap",
 });
 
-const fraunces = Fraunces({
-  variable: "--font-fraunces",
+// Editorial serif for display headlines. Variable weight, so existing
+// `font-serif font-semibold` headings keep real weight rather than a
+// synthesised bold.
+const newsreader = Newsreader({
+  variable: "--font-newsreader",
   subsets: ["latin"],
   display: "swap",
-  axes: ["SOFT", "WONK", "opsz"],
+  style: ["normal", "italic"],
 });
 
 export const metadata: Metadata = {
@@ -103,7 +107,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={`${inter.variable} ${jbMono.variable} ${fraunces.variable}`}>
+    <html lang="en" className={`${inter.variable} ${jbMono.variable} ${newsreader.variable}`}>
       <body className="flex min-h-dvh flex-col bg-[#060609] font-sans text-slate-200 antialiased">
         <script
           type="application/ld+json"
@@ -115,6 +119,7 @@ export default function RootLayout({
         >
           Skip to content
         </a>
+        <StarlightTrail />
         <Header />
         <main id="main-content" className="flex-1">
           {children}

--- a/site/src/app/page.tsx
+++ b/site/src/app/page.tsx
@@ -727,11 +727,13 @@ export default async function HomePage() {
 
 function CensusStat({ value, label }: { value: string; label: string }) {
   return (
-    <div className="bg-[#0a0a12]/90 px-4 py-3.5 backdrop-blur">
-      <dd className="text-xl font-semibold text-white">{value}</dd>
+    // col-reverse so the DOM keeps the required dt-then-dd order while the
+    // number still reads above its label.
+    <div className="flex flex-col-reverse bg-[#0a0a12]/90 px-4 py-3.5 backdrop-blur">
       <dt className="mt-0.5 text-[11px] font-medium uppercase tracking-wider text-slate-500">
         {label}
       </dt>
+      <dd className="text-xl font-semibold text-white">{value}</dd>
     </div>
   );
 }

--- a/site/src/app/page.tsx
+++ b/site/src/app/page.tsx
@@ -3,7 +3,6 @@ import {
   Activity,
   ArrowRight,
   BadgeCheck,
-  CheckCircle2,
   Database,
   FileCheck2,
   GitBranch,
@@ -25,6 +24,9 @@ import {
 } from "@/lib/vault";
 import { EntryCard } from "@/components/EntryCard";
 import { OperationalProofConsole } from "@/components/OperationalProofConsole";
+import { AgentConstellation } from "@/components/AgentConstellation";
+import { Starfield } from "@/components/cosmos/Starfield";
+import { StarlightMark } from "@/components/StarlightMark";
 import {
   ACCENT_TEXT,
   ACCENT_BORDER,
@@ -39,7 +41,7 @@ type LayerCard = {
   accent: "violet" | "cyan" | "fuchsia" | "emerald" | "amber" | "rose";
 };
 
-type ProofPillar = {
+type SystemPlane = {
   title: string;
   desc: string;
   icon: LucideIcon;
@@ -58,6 +60,45 @@ type RouteCard = {
   desc: string;
   icon: LucideIcon;
 };
+
+const SYSTEM_PLANES: SystemPlane[] = [
+  {
+    title: "Agent Design",
+    desc: "144 named agents across core, universal, and domain tiers — each with an identity, a scope, and the tools it is allowed to hold.",
+    icon: Network,
+    accent: "text-violet-400",
+  },
+  {
+    title: "Orchestration",
+    desc: "A routing matrix, councils, and swarm sessions that turn many specialists into one coherent operation instead of a pile of chats.",
+    icon: Workflow,
+    accent: "text-cyan-400",
+  },
+  {
+    title: "Durable Memory",
+    desc: "Six semantic vaults and a spatial palace that every agent reads before acting and writes after — context that survives the session.",
+    icon: Database,
+    accent: "text-fuchsia-400",
+  },
+  {
+    title: "Governance",
+    desc: "Boards, gates, and operator-held review before anything irreversible. Autonomy is earned per decision class, never assumed.",
+    icon: ShieldCheck,
+    accent: "text-emerald-400",
+  },
+  {
+    title: "Open Protocol",
+    desc: "SIP — attestation, sovereignty, and interop rules any compliant agent can adopt. The substrate is forkable by design.",
+    icon: LockKeyhole,
+    accent: "text-amber-300",
+  },
+  {
+    title: "Evals & Proof",
+    desc: "Traces, scores, and proof packets that make every serious run inspectable after the fact — by a human or by another agent.",
+    icon: ScanLine,
+    accent: "text-rose-300",
+  },
+];
 
 const LAYERS: LayerCard[] = [
   {
@@ -104,33 +145,6 @@ const LAYERS: LayerCard[] = [
     name: "Family",
     desc: "Network memory, alliance readiness, and relationship context.",
     accent: "fuchsia",
-  },
-];
-
-const PROOF_STACK: ProofPillar[] = [
-  {
-    title: "Persistent Context",
-    desc: "Six semantic vaults give every agent the same durable memory surface.",
-    icon: Database,
-    accent: "text-cyan-400",
-  },
-  {
-    title: "Governance Gates",
-    desc: "Human operator control, policy checks, and substrate-aware review points.",
-    icon: ShieldCheck,
-    accent: "text-emerald-400",
-  },
-  {
-    title: "Traceable Evals",
-    desc: "Runs produce inspectable traces, confidence notes, and proof packets.",
-    icon: ScanLine,
-    accent: "text-amber-300",
-  },
-  {
-    title: "Rebuildable Deploys",
-    desc: "Git, build, and Vercel state are tied back to reproducible source.",
-    icon: GitBranch,
-    accent: "text-rose-300",
   },
 ];
 
@@ -201,127 +215,223 @@ const PRODUCT_ROUTES: RouteCard[] = [
   },
 ];
 
+const AGENT_ENDPOINTS: [string, string][] = [
+  ["GET /protocol.md", "machine-readable SIP substrate spec"],
+  ["GET /sip.md", "the full protocol contract, plain markdown"],
+  ["GET /api/vaults", "public memory as JSON — query and cite"],
+  ["GET /badge/latest", "Built-on-SIP badge, current canonical pin"],
+];
+
 export default async function HomePage() {
   const [entries, registry, featured] = await Promise.all([
     getAllEntries(),
     getVaultRegistry(),
-    getFeaturedMeditations(4),
+    getFeaturedMeditations(2),
   ]);
 
   const horizonEntry = entries.find((e) => e.vaultCategory === "horizon");
 
   return (
     <div className="bg-[#060609]">
-      <section className="relative overflow-hidden border-b border-white/[0.08] bg-[linear-gradient(180deg,#f8fbff_0%,#edf5ff_54%,#08111f_100%)] text-slate-950">
-        <div className="pointer-events-none absolute inset-0 opacity-70" aria-hidden="true">
-          <div className="absolute left-0 top-0 h-80 w-80 bg-cyan-200/50 blur-3xl" />
-          <div className="absolute right-0 top-20 h-96 w-96 bg-violet-200/45 blur-3xl" />
-          <div className="absolute inset-x-0 bottom-0 h-40 bg-gradient-to-t from-[#08111f] to-transparent" />
+      {/* ============================== HERO ============================== */}
+      <section className="relative overflow-hidden border-b border-white/[0.08] text-white">
+        <div className="absolute inset-0" aria-hidden="true">
+          <Starfield seed={1969} count={170} className="absolute inset-0 h-full w-full opacity-70" />
+          <div className="absolute left-1/2 top-[38%] h-[36rem] w-[36rem] -translate-x-1/2 -translate-y-1/2 rounded-full bg-violet-500/[0.10] blur-3xl md:left-[72%]" />
+          <div className="absolute left-[20%] top-[70%] h-72 w-72 rounded-full bg-cyan-500/[0.07] blur-3xl" />
+          <div className="absolute inset-x-0 bottom-0 h-32 bg-gradient-to-t from-[#060609] to-transparent" />
         </div>
 
-        <div className="relative mx-auto grid min-h-[calc(100dvh-3.5rem)] max-w-[88rem] items-center gap-10 px-5 py-10 sm:px-6 md:grid-cols-[0.86fr_1.14fr] md:py-14 lg:gap-12">
+        {/* Live multi-agent system — WebGL, capability-gated, decorative. */}
+        <AgentConstellation className="absolute inset-y-0 right-0 hidden w-[62%] md:block" />
+
+        <div className="relative mx-auto flex min-h-[calc(100dvh-3.5rem)] max-w-[88rem] items-center px-5 py-16 sm:px-6 md:py-20">
           <div className="max-w-2xl">
-            <div className="inline-flex items-center gap-2 rounded-md border border-slate-300 bg-white/70 px-3 py-2 text-xs font-semibold text-slate-700 shadow-sm">
-              <CheckCircle2 size={15} className="text-emerald-600" aria-hidden="true" />
-              SIP v1.1.1 production surface
+            <div className="inline-flex items-center gap-2.5 rounded-full border border-white/[0.12] bg-white/[0.04] px-4 py-2 text-xs font-medium text-slate-300 backdrop-blur">
+              <StarlightMark size={15} />
+              Open substrate · SIP v1.1.1 · Built in public
             </div>
 
-            <h1 className="mt-5 text-4xl font-semibold leading-[1.02] text-slate-950 sm:text-5xl lg:text-6xl">
-              Starlight Intelligence System
+            <h1 className="mt-7 text-[2.6rem] font-semibold leading-[1.04] tracking-tight text-white sm:text-6xl lg:text-[4.25rem]">
+              Architecture for humans{" "}
+              <span className="block bg-gradient-to-r from-violet-300 via-sky-100 to-cyan-300 bg-clip-text font-serif italic tracking-normal text-transparent">
+                and their agents.
+              </span>
             </h1>
 
-            <p className="mt-5 max-w-xl text-base leading-8 text-slate-700 sm:text-lg">
-              Operational memory, governance, traces, evals, logs, and operator
-              control for AI agent fleets.
-              <span className="hidden sm:inline">
-                {" "}Built for agents that need proof, not another forgetful chat
-                surface.
-              </span>
+            <p className="mt-6 max-w-xl text-base leading-8 text-slate-300 sm:text-lg">
+              Starlight is a multi-agent design and architecture system: named
+              agents, skills, orchestration, durable memory, governance, and an
+              open protocol. Founders run it across business, craft, and
+              family. Agents read it, write it, and prove their work inside it.
+              The human holds the keys.
             </p>
 
-            <div className="mt-6 flex sm:hidden">
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
               <Link
-                href="/download"
-                className="inline-flex min-h-12 w-full items-center justify-center gap-2 rounded-md bg-slate-950 px-5 py-3 text-sm font-semibold text-white shadow-[0_12px_32px_rgba(15,23,42,0.25)] transition-micro hover:bg-slate-800"
+                href="/quickstart"
+                className="inline-flex min-h-12 items-center justify-center gap-2 rounded-md bg-white px-6 py-3 text-sm font-semibold text-slate-950 shadow-[0_0_40px_rgba(167,139,250,0.25)] transition-micro hover:bg-slate-200"
               >
-                Download starter
-                <ArrowRight size={16} aria-hidden="true" />
-              </Link>
-            </div>
-
-            <div className="mt-7 hidden flex-col gap-3 sm:flex sm:flex-row sm:items-center">
-              <Link
-                href="/download"
-                className="inline-flex min-h-12 items-center justify-center gap-2 rounded-md bg-slate-950 px-5 py-3 text-sm font-semibold text-white shadow-[0_12px_32px_rgba(15,23,42,0.25)] transition-micro hover:bg-slate-800"
-              >
-                Download starter
+                Start in five minutes
                 <ArrowRight size={16} aria-hidden="true" />
               </Link>
               <Link
                 href="/protocol"
-                className="inline-flex min-h-12 items-center justify-center gap-2 rounded-md border border-slate-300 bg-white/80 px-5 py-3 text-sm font-semibold text-slate-950 transition-micro hover:bg-white"
+                className="inline-flex min-h-12 items-center justify-center gap-2 rounded-md border border-white/[0.14] bg-white/[0.03] px-6 py-3 text-sm font-semibold text-white backdrop-blur transition-micro hover:bg-white/[0.08]"
               >
-                Read protocol
+                Read the protocol
                 <ArrowRight size={16} aria-hidden="true" />
               </Link>
             </div>
 
-            <div className="mt-7 hidden gap-2 text-sm text-slate-700 sm:grid sm:grid-cols-3">
-              <ProofChip label="Local-first vaults" />
-              <ProofChip label="SIP attestation" />
-              <ProofChip label="Operator-held gates" />
-            </div>
+            <dl className="mt-10 grid max-w-xl grid-cols-2 gap-px overflow-hidden rounded-lg border border-white/[0.08] bg-white/[0.06] sm:grid-cols-4">
+              <CensusStat value="144" label="named agents" />
+              <CensusStat value="84" label="skills" />
+              <CensusStat value="6" label="memory vaults" />
+              <CensusStat value="1" label="open protocol" />
+            </dl>
+            <p className="mt-2 font-mono text-[11px] text-slate-500">
+              System census, as of v8.3.0
+            </p>
           </div>
-
-          <OperationalProofConsole />
-        </div>
-
-        <div className="relative mx-auto grid max-w-[88rem] gap-px bg-slate-900/15 px-5 pb-8 sm:px-6 md:grid-cols-4">
-          <SignalMetric label="Memory" value="Semantic vault substrate" />
-          <SignalMetric label="Proof" value="Trace, eval, and attestation loop" />
-          <SignalMetric label="Control" value="Human review before critical moves" />
-          <SignalMetric label="Deploy" value="Git and Vercel state reconciled" />
         </div>
       </section>
 
-      <section className="border-b border-white/[0.08] px-5 py-16 text-white sm:px-6 md:py-20">
+      {/* =========================== THE SYSTEM =========================== */}
+      <section className="border-b border-white/[0.08] px-5 py-16 text-white sm:px-6 md:py-24">
         <div className="mx-auto max-w-6xl">
-          <SectionKicker icon={ShieldCheck}>Proof Stack</SectionKicker>
-          <div className="mt-4 grid gap-8 md:grid-cols-[0.8fr_1.2fr] md:items-end">
+          <SectionKicker icon={Network}>The System</SectionKicker>
+          <div className="mt-4 grid gap-8 md:grid-cols-[0.9fr_1.1fr] md:items-end">
+            <div>
+              <h2 className="text-3xl font-semibold leading-tight md:text-4xl">
+                Far more than memory.
+              </h2>
+              <p className="mt-4 max-w-xl text-sm leading-7 text-slate-400">
+                Persistent context is the floor, not the product. Starlight is
+                the whole discipline of running agents seriously: who they are,
+                how they coordinate, what they remember, what they may decide,
+                and how they prove it.
+              </p>
+            </div>
+            <p className="max-w-md text-sm leading-7 text-slate-500 md:justify-self-end">
+              Six planes, one substrate. Remove any one of them and what
+              remains is a chatbot with settings.
+            </p>
+          </div>
+
+          <div className="mt-10 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {SYSTEM_PLANES.map((plane) => {
+              const Icon = plane.icon;
+              return (
+                <div
+                  key={plane.title}
+                  className="group rounded-lg border border-white/[0.08] bg-white/[0.03] p-6 transition-micro hover:border-white/[0.16] hover:bg-white/[0.05]"
+                >
+                  <Icon className={plane.accent} size={22} aria-hidden="true" />
+                  <h3 className="mt-5 text-base font-semibold text-white">
+                    {plane.title}
+                  </h3>
+                  <p className="mt-2 text-sm leading-6 text-slate-400">
+                    {plane.desc}
+                  </p>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* ========================= TWO FRONT DOORS ======================== */}
+      <section className="border-b border-white/[0.08] bg-[#0b1018] px-5 py-16 text-white sm:px-6 md:py-24">
+        <div className="mx-auto max-w-6xl">
+          <SectionKicker icon={GitBranch}>Two Front Doors</SectionKicker>
+          <div className="mt-4 max-w-2xl">
+            <h2 className="text-3xl font-semibold leading-tight md:text-4xl">
+              Humans and agents enter the same system.
+            </h2>
+            <p className="mt-4 text-sm leading-7 text-slate-400">
+              This site is a shared surface. People read the pages; agents read
+              the endpoints. Both see the same substrate, because a system you
+              and your agents understand differently is a system you do not
+              control.
+            </p>
+          </div>
+
+          <div className="mt-10 grid gap-4 lg:grid-cols-2">
+            {/* Human door */}
+            <div className="flex flex-col rounded-xl border border-white/[0.09] bg-white/[0.03] p-7">
+              <p className="font-mono text-[11px] uppercase tracking-wider text-violet-300">
+                For humans
+              </p>
+              <h3 className="mt-3 text-xl font-semibold text-white">
+                Founders, builders, families.
+              </h3>
+              <p className="mt-3 text-sm leading-7 text-slate-400">
+                Start with the plain-language explainer, get your first
+                persistent context in five minutes, then grow into the full
+                estate: agents shaped around your business, your craft, and
+                the people you are building it for.
+              </p>
+              <div className="mt-6 flex flex-wrap gap-2.5">
+                <DoorLink href="/quickstart" label="Quickstart" />
+                <DoorLink href="/explainer" label="Explainer" />
+                <DoorLink href="/download" label="Starter kits" />
+              </div>
+            </div>
+
+            {/* Agent door */}
+            <div className="flex flex-col rounded-xl border border-white/[0.09] bg-[#080d14] p-7">
+              <p className="font-mono text-[11px] uppercase tracking-wider text-cyan-300">
+                For agents
+              </p>
+              <h3 className="mt-3 text-xl font-semibold text-white">
+                Machine-readable, by design.
+              </h3>
+              <p className="mt-3 text-sm leading-7 text-slate-400">
+                Every load-bearing surface has a raw endpoint. An agent can
+                fetch the protocol, query public memory, and verify
+                attestation without scraping a single page.
+              </p>
+              <div className="mt-6 space-y-1.5 rounded-lg border border-white/[0.08] bg-black/40 p-4 font-mono text-[12.5px] leading-6">
+                {AGENT_ENDPOINTS.map(([endpoint, note]) => (
+                  <p key={endpoint} className="flex flex-wrap gap-x-3">
+                    <span className="text-cyan-200">{endpoint}</span>
+                    <span className="text-slate-500"># {note}</span>
+                  </p>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ============================ EVIDENCE ============================ */}
+      <section className="border-b border-white/[0.08] px-5 py-16 text-white sm:px-6 md:py-24">
+        <div className="mx-auto max-w-6xl">
+          <SectionKicker icon={ShieldCheck}>Evidence</SectionKicker>
+          <div className="mt-4 grid gap-10 lg:grid-cols-[0.72fr_1.28fr] lg:items-center">
             <div>
               <h2 className="text-3xl font-semibold leading-tight md:text-4xl">
                 Trust is the interface.
               </h2>
               <p className="mt-4 max-w-xl text-sm leading-7 text-slate-400">
-                The product promise is not a gallery of possible agents. It is a
+                The promise is not a gallery of possible agents. It is a
                 working control plane: memory in, governance over the run,
                 evidence out, and a path back to the exact source state.
               </p>
+              <div className="mt-6 grid gap-2 text-sm text-slate-300">
+                <ProofChip label="Local-first vaults" />
+                <ProofChip label="SIP attestation on artifacts" />
+                <ProofChip label="Operator-held gates" />
+              </div>
             </div>
-            <div className="grid gap-3 sm:grid-cols-2">
-              {PROOF_STACK.map((pillar) => {
-                const Icon = pillar.icon;
-                return (
-                  <div
-                    key={pillar.title}
-                    className="rounded-lg border border-white/[0.08] bg-white/[0.035] p-5"
-                  >
-                    <Icon className={pillar.accent} size={22} aria-hidden="true" />
-                    <h3 className="mt-4 text-base font-semibold text-white">
-                      {pillar.title}
-                    </h3>
-                    <p className="mt-2 text-sm leading-6 text-slate-400">
-                      {pillar.desc}
-                    </p>
-                  </div>
-                );
-              })}
-            </div>
+            <OperationalProofConsole />
           </div>
         </div>
       </section>
 
-      <section className="border-b border-white/[0.08] bg-[#0b1018] px-5 py-16 text-white sm:px-6 md:py-20">
+      {/* ========================= OPERATING LOOP ========================= */}
+      <section className="border-b border-white/[0.08] bg-[#0b1018] px-5 py-16 text-white sm:px-6 md:py-24">
         <div className="mx-auto max-w-6xl">
           <SectionKicker icon={Workflow}>Operating Loop</SectionKicker>
           <div className="mt-4 max-w-2xl">
@@ -361,18 +471,19 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <section className="border-b border-white/[0.08] px-5 py-16 text-white sm:px-6 md:py-20">
+      {/* ====================== INTELLIGENCE SYSTEMS ====================== */}
+      <section className="border-b border-white/[0.08] px-5 py-16 text-white sm:px-6 md:py-24">
         <div className="mx-auto max-w-6xl">
           <SectionKicker icon={Network}>Intelligence Systems</SectionKicker>
           <div className="mt-4 grid gap-8 lg:grid-cols-[0.7fr_1.3fr]">
             <div>
               <h2 className="text-3xl font-semibold leading-tight md:text-4xl">
-                A composable operating layer for real domains.
+                The same architecture, for every domain you actually run.
               </h2>
               <p className="mt-4 text-sm leading-7 text-slate-400">
-                Each layer is a useful surface, not a decorative persona. Agents
-                can read the same substrate and still specialize by domain,
-                tool, or decision context.
+                A founder is never just a founder. The layers cover the whole
+                operation — company, craft, wealth, and family — so agents can
+                specialize by domain while reading one shared substrate.
               </p>
               <div className="mt-7">
                 <Link
@@ -404,98 +515,74 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <section className="border-b border-white/[0.08] bg-[#f6f8fb] px-5 py-16 text-slate-950 sm:px-6 md:py-20">
+      {/* ============================= MISSION ============================ */}
+      <section className="relative overflow-hidden border-b border-white/[0.08] px-5 py-20 text-white sm:px-6 md:py-28">
+        <div className="pointer-events-none absolute inset-0" aria-hidden="true">
+          <Starfield seed={432} count={90} className="absolute inset-0 h-full w-full opacity-50" />
+          <div className="absolute left-1/2 top-1/2 h-80 w-[40rem] -translate-x-1/2 -translate-y-1/2 rounded-full bg-violet-500/[0.07] blur-3xl" />
+        </div>
+        <div className="relative mx-auto max-w-3xl text-center">
+          <div className="flex justify-center">
+            <StarlightMark size={34} />
+          </div>
+          <h2 className="mt-6 text-3xl font-semibold leading-tight md:text-5xl">
+            Why{" "}
+            <span className="bg-gradient-to-r from-violet-300 to-cyan-300 bg-clip-text font-serif italic text-transparent">
+              Starlight
+            </span>{" "}
+            exists.
+          </h2>
+          <p className="mt-6 text-base leading-8 text-slate-300">
+            AI will either concentrate capability or distribute it. Starlight
+            is a bet on distribution: individuals — founders, builders,
+            parents — running intelligence they own, govern, and understand.
+            Systems transparent enough to trust, durable enough to outlast a
+            hype cycle, and sound enough to hand to the next generation.
+          </p>
+          <p className="mt-4 text-base leading-8 text-slate-400">
+            The name is the direction of travel: build well here, so more of
+            us get to go far.
+          </p>
+          {horizonEntry && (
+            <blockquote className="mx-auto mt-10 max-w-2xl rounded-xl border border-white/[0.08] bg-white/[0.03] p-6 text-left">
+              <p className="text-sm leading-7 text-slate-300">
+                &ldquo;{getEntryText(horizonEntry).slice(0, 280)}
+                {getEntryText(horizonEntry).length > 280 ? "..." : ""}&rdquo;
+              </p>
+              <footer className="mt-3 font-mono text-[11px] uppercase tracking-wider text-slate-500">
+                Horizon vault · {timeAgo(horizonEntry.createdAt)}
+              </footer>
+            </blockquote>
+          )}
+        </div>
+      </section>
+
+      {/* ========================== PUBLIC MEMORY ========================= */}
+      <section className="border-b border-white/[0.08] px-5 py-16 text-white sm:px-6 md:py-24">
         <div className="mx-auto max-w-6xl">
-          <SectionKicker icon={ServerCog} light>
-            Product Routes
-          </SectionKicker>
-          <div className="mt-4 flex flex-col justify-between gap-5 md:flex-row md:items-end">
+          <div className="flex flex-col justify-between gap-5 md:flex-row md:items-end">
             <div>
-              <h2 className="text-3xl font-semibold leading-tight md:text-4xl">
-                The site now leads with the system.
+              <SectionKicker icon={Activity}>Public Memory</SectionKicker>
+              <h2 className="mt-4 text-3xl font-semibold leading-tight md:text-4xl">
+                The system thinks in the open.
               </h2>
-              <p className="mt-4 max-w-2xl text-sm leading-7 text-slate-600">
-                Protocol, starter kits, research, cockpit, architecture, and
-                vault APIs are the primary public proof surfaces.
+              <p className="mt-4 max-w-xl text-sm leading-7 text-slate-400">
+                {entries.length} public entries across {registry.length} vault
+                {registry.length === 1 ? "" : "s"}, rebuilt from raw JSONL.
+                Not marketing filler — the reasoning surface agents inspect,
+                cite, and extend.
               </p>
             </div>
             <Link
-              href="/visuals/brand-lab"
-              className="inline-flex min-h-11 items-center gap-2 rounded-md border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-950 transition-micro hover:border-slate-400"
+              href="/vaults"
+              className="inline-flex min-h-11 items-center gap-2 rounded-md border border-white/[0.12] px-4 py-2.5 text-sm font-semibold text-white transition-micro hover:bg-white/[0.06]"
             >
-              Open visual brand lab
+              View vaults
               <ArrowRight size={15} aria-hidden="true" />
             </Link>
           </div>
 
-          <div className="mt-9 grid gap-3 md:grid-cols-2 lg:grid-cols-3">
-            {PRODUCT_ROUTES.map((route) => {
-              const Icon = route.icon;
-              return (
-                <Link
-                  key={route.href}
-                  href={route.href}
-                  className="group rounded-lg border border-slate-200 bg-white p-5 shadow-sm transition-micro hover:border-slate-300 hover:shadow-md"
-                >
-                  <div className="flex items-start justify-between gap-4">
-                    <Icon size={20} className="text-slate-700" aria-hidden="true" />
-                    <ArrowRight
-                      size={16}
-                      className="text-slate-400 transition-micro group-hover:translate-x-0.5 group-hover:text-slate-950"
-                      aria-hidden="true"
-                    />
-                  </div>
-                  <h3 className="mt-5 text-base font-semibold text-slate-950">
-                    {route.title}
-                  </h3>
-                  <p className="mt-2 text-sm leading-6 text-slate-600">
-                    {route.desc}
-                  </p>
-                </Link>
-              );
-            })}
-          </div>
-        </div>
-      </section>
-
-      {horizonEntry && (
-        <section className="border-b border-white/[0.08] px-5 py-16 text-white sm:px-6">
-          <div className="mx-auto max-w-4xl">
-            <SectionKicker icon={FileCheck2}>Latest Horizon Note</SectionKicker>
-            <blockquote className="mt-5 text-lg font-medium leading-8 text-slate-200">
-              &ldquo;{getEntryText(horizonEntry).slice(0, 280)}
-              {getEntryText(horizonEntry).length > 280 ? "..." : ""}&rdquo;
-            </blockquote>
-            <p className="mt-4 text-sm text-slate-500">
-              Horizon vault entry, {timeAgo(horizonEntry.createdAt)}
-            </p>
-          </div>
-        </section>
-      )}
-
-      {featured.length > 0 && (
-        <section className="border-b border-white/[0.08] px-5 py-16 text-white sm:px-6 md:py-20">
-          <div className="mx-auto max-w-6xl">
-            <SectionKicker icon={ScanLine}>Selected Notes</SectionKicker>
-            <div className="mt-4 flex flex-col justify-between gap-5 md:flex-row md:items-end">
-              <div>
-                <h2 className="text-3xl font-semibold leading-tight md:text-4xl">
-                  Public memory with source texture.
-                </h2>
-                <p className="mt-4 max-w-2xl text-sm leading-7 text-slate-400">
-                  Vault notes are not marketing filler. They are the public
-                  reasoning surface agents can inspect, cite, and extend.
-                </p>
-              </div>
-              <Link
-                href="/vaults"
-                className="inline-flex min-h-11 items-center gap-2 rounded-md border border-white/[0.12] px-4 py-2.5 text-sm font-semibold text-white transition-micro hover:bg-white/[0.06]"
-              >
-                View vaults
-                <ArrowRight size={15} aria-hidden="true" />
-              </Link>
-            </div>
-
+          {featured.length > 0 && (
             <div className="mt-9 grid gap-4 md:grid-cols-2">
               {featured.map((entry) => (
                 <Link
@@ -507,27 +594,10 @@ export default async function HomePage() {
                 </Link>
               ))}
             </div>
-          </div>
-        </section>
-      )}
+          )}
 
-      <section className="border-b border-white/[0.08] px-5 py-16 text-white sm:px-6 md:py-20">
-        <div className="mx-auto max-w-6xl">
-          <div className="flex flex-col justify-between gap-5 md:flex-row md:items-end">
-            <div>
-              <SectionKicker icon={Activity}>Live Vault Stream</SectionKicker>
-              <h2 className="mt-4 text-3xl font-semibold leading-tight md:text-4xl">
-                Recent public memory entries.
-              </h2>
-            </div>
-            <p className="max-w-md text-sm leading-7 text-slate-400">
-              {entries.length} public entries across {registry.length} public
-              vault{registry.length === 1 ? "" : "s"}, rebuilt from raw JSONL.
-            </p>
-          </div>
-
-          <div className="mt-9 space-y-2">
-            {entries.slice(0, 8).map((entry, index) => (
+          <div className="mt-4 space-y-2">
+            {entries.slice(0, 6).map((entry, index) => (
               <Link
                 key={entry.id || index}
                 href={`/vaults/${entry.vaultSlug}`}
@@ -545,31 +615,82 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <section className="relative overflow-hidden px-5 py-24 text-white sm:px-6 md:py-28">
+      {/* ============================= ROUTES ============================= */}
+      <section className="border-b border-white/[0.08] bg-[#0b1018] px-5 py-16 text-white sm:px-6 md:py-24">
+        <div className="mx-auto max-w-6xl">
+          <SectionKicker icon={ServerCog}>Go Deeper</SectionKicker>
+          <div className="mt-4 flex flex-col justify-between gap-5 md:flex-row md:items-end">
+            <h2 className="text-3xl font-semibold leading-tight md:text-4xl">
+              Every claim above has a surface behind it.
+            </h2>
+            <Link
+              href="/visuals/brand-lab"
+              className="inline-flex min-h-11 items-center gap-2 rounded-md border border-white/[0.12] px-4 py-2.5 text-sm font-semibold text-white transition-micro hover:bg-white/[0.06]"
+            >
+              Open visual brand lab
+              <ArrowRight size={15} aria-hidden="true" />
+            </Link>
+          </div>
+
+          <div className="mt-9 grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+            {PRODUCT_ROUTES.map((route) => {
+              const Icon = route.icon;
+              return (
+                <Link
+                  key={route.href}
+                  href={route.href}
+                  className="group rounded-lg border border-white/[0.08] bg-white/[0.03] p-5 transition-micro hover:border-white/[0.16] hover:bg-white/[0.05]"
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <Icon size={20} className="text-slate-300" aria-hidden="true" />
+                    <ArrowRight
+                      size={16}
+                      className="text-slate-500 transition-micro group-hover:translate-x-0.5 group-hover:text-white"
+                      aria-hidden="true"
+                    />
+                  </div>
+                  <h3 className="mt-5 text-base font-semibold text-white">
+                    {route.title}
+                  </h3>
+                  <p className="mt-2 text-sm leading-6 text-slate-400">
+                    {route.desc}
+                  </p>
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* ============================ FINAL CTA =========================== */}
+      <section className="relative overflow-hidden px-5 py-24 text-white sm:px-6 md:py-32">
         <div className="pointer-events-none absolute inset-0" aria-hidden="true">
           <div className="absolute left-1/2 top-1/2 h-72 w-[34rem] -translate-x-1/2 -translate-y-1/2 bg-cyan-500/[0.06] blur-3xl" />
         </div>
         <div className="relative mx-auto max-w-4xl text-center">
           <SectionKicker icon={BadgeCheck}>Production Ready Path</SectionKicker>
           <h2 className="mt-5 text-3xl font-semibold leading-tight md:text-5xl">
-            Fork the substrate. Keep the proof.
+            Fork the substrate.{" "}
+            <span className="bg-gradient-to-r from-violet-300 to-cyan-300 bg-clip-text font-serif italic text-transparent">
+              Keep the proof.
+            </span>
           </h2>
           <p className="mx-auto mt-5 max-w-2xl text-sm leading-7 text-slate-400 sm:text-base">
             Use the protocol, starter kits, and public vault APIs to give your
-            agents a memory and governance layer that can be inspected after
-            the run.
+            agents an architecture that can be inspected after the run — and a
+            direction worth running toward.
           </p>
           <div className="mt-9 flex flex-col items-center justify-center gap-3 sm:flex-row">
             <Link
               href="/download"
-              className="inline-flex min-h-12 items-center justify-center gap-2 rounded-md bg-white px-5 py-3 text-sm font-semibold text-slate-950 transition-micro hover:bg-slate-200"
+              className="inline-flex min-h-12 items-center justify-center gap-2 rounded-md bg-white px-6 py-3 text-sm font-semibold text-slate-950 transition-micro hover:bg-slate-200"
             >
               Get the starter
               <ArrowRight size={16} aria-hidden="true" />
             </Link>
             <Link
               href="/research"
-              className="inline-flex min-h-12 items-center justify-center gap-2 rounded-md border border-white/[0.12] px-5 py-3 text-sm font-semibold text-white transition-micro hover:bg-white/[0.06]"
+              className="inline-flex min-h-12 items-center justify-center gap-2 rounded-md border border-white/[0.12] px-6 py-3 text-sm font-semibold text-white transition-micro hover:bg-white/[0.06]"
             >
               Inspect research
               <ArrowRight size={16} aria-hidden="true" />
@@ -581,19 +702,33 @@ export default async function HomePage() {
   );
 }
 
-function ProofChip({ label }: { label: string }) {
+function CensusStat({ value, label }: { value: string; label: string }) {
   return (
-    <div className="rounded-md border border-slate-300 bg-white/70 px-3 py-2">
-      <span className="text-sm font-medium text-slate-800">{label}</span>
+    <div className="bg-[#0a0a12]/90 px-4 py-3.5 backdrop-blur">
+      <dd className="text-xl font-semibold text-white">{value}</dd>
+      <dt className="mt-0.5 text-[11px] font-medium uppercase tracking-wider text-slate-500">
+        {label}
+      </dt>
     </div>
   );
 }
 
-function SignalMetric({ label, value }: { label: string; value: string }) {
+function DoorLink({ href, label }: { href: string; label: string }) {
   return (
-    <div className="bg-white/90 p-4 text-slate-950 backdrop-blur">
-      <p className="font-mono text-[11px] uppercase text-slate-500">{label}</p>
-      <p className="mt-1 text-sm font-semibold leading-6">{value}</p>
+    <Link
+      href={href}
+      className="inline-flex min-h-10 items-center gap-1.5 rounded-md border border-white/[0.12] bg-white/[0.03] px-4 py-2 text-sm font-medium text-white transition-micro hover:bg-white/[0.08]"
+    >
+      {label}
+      <ArrowRight size={14} aria-hidden="true" />
+    </Link>
+  );
+}
+
+function ProofChip({ label }: { label: string }) {
+  return (
+    <div className="rounded-md border border-white/[0.10] bg-white/[0.03] px-3.5 py-2.5">
+      <span className="text-sm font-medium text-slate-200">{label}</span>
     </div>
   );
 }
@@ -601,20 +736,12 @@ function SignalMetric({ label, value }: { label: string; value: string }) {
 function SectionKicker({
   children,
   icon: Icon,
-  light = false,
 }: {
   children: React.ReactNode;
   icon: LucideIcon;
-  light?: boolean;
 }) {
   return (
-    <div
-      className={`inline-flex items-center gap-2 rounded-md border px-3 py-2 text-xs font-semibold ${
-        light
-          ? "border-slate-300 bg-white text-slate-700"
-          : "border-white/[0.10] bg-white/[0.04] text-slate-300"
-      }`}
-    >
+    <div className="inline-flex items-center gap-2 rounded-md border border-white/[0.10] bg-white/[0.04] px-3 py-2 text-xs font-semibold text-slate-300">
       <Icon size={15} aria-hidden="true" />
       {children}
     </div>

--- a/site/src/app/page.tsx
+++ b/site/src/app/page.tsx
@@ -64,7 +64,7 @@ type RouteCard = {
 const SYSTEM_PLANES: SystemPlane[] = [
   {
     title: "Agent Design",
-    desc: "144 named agents across core, universal, and domain tiers — each with an identity, a scope, and the tools it is allowed to hold.",
+    desc: "Named agents across core, universal, and domain tiers. Each one has an identity, a scope, and a fixed list of tools it is allowed to hold.",
     icon: Network,
     accent: "text-violet-400",
   },
@@ -249,22 +249,22 @@ export default async function HomePage() {
           <div className="max-w-2xl">
             <div className="inline-flex items-center gap-2.5 rounded-full border border-white/[0.12] bg-white/[0.04] px-4 py-2 text-xs font-medium text-slate-300 backdrop-blur">
               <StarlightMark size={15} />
-              Open substrate · SIP v1.1.1 · Built in public
+              Open substrate · Built in public
             </div>
 
-            <h1 className="mt-7 text-[2.6rem] font-semibold leading-[1.04] tracking-tight text-white sm:text-6xl lg:text-[4.25rem]">
-              Architecture for humans{" "}
+            <h1 className="mt-7 text-[2.7rem] font-semibold leading-[1.03] tracking-tight text-white sm:text-6xl lg:text-[4.4rem]">
+              Build as if the kindest future{" "}
               <span className="block bg-gradient-to-r from-violet-300 via-sky-100 to-cyan-300 bg-clip-text font-serif italic tracking-normal text-transparent">
-                and their agents.
+                is the realistic one.
               </span>
             </h1>
 
             <p className="mt-6 max-w-xl text-base leading-8 text-slate-300 sm:text-lg">
-              Starlight is a multi-agent design and architecture system: named
-              agents, skills, orchestration, durable memory, governance, and an
-              open protocol. Founders run it across business, craft, and
-              family. Agents read it, write it, and prove their work inside it.
-              The human holds the keys.
+              Building that way is part of what makes it realistic. Starlight
+              is an open substrate for people running serious agent systems —
+              named agents, orchestration, memory that outlives the session,
+              and governance you hold rather than rent. Fork it, read it,
+              leave with it.
             </p>
 
             <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
@@ -285,13 +285,13 @@ export default async function HomePage() {
             </div>
 
             <dl className="mt-10 grid max-w-xl grid-cols-2 gap-px overflow-hidden rounded-lg border border-white/[0.08] bg-white/[0.06] sm:grid-cols-4">
-              <CensusStat value="144" label="named agents" />
-              <CensusStat value="84" label="skills" />
+              <CensusStat value="138" label="agent definitions" />
+              <CensusStat value="84" label="skill rules" />
               <CensusStat value="6" label="memory vaults" />
-              <CensusStat value="1" label="open protocol" />
+              <CensusStat value="15" label="letters to the future" />
             </dl>
             <p className="mt-2 font-mono text-[11px] text-slate-500">
-              System census, as of v8.3.0
+              Counted from source files, July 2026 — not from the roadmap.
             </p>
           </div>
         </div>
@@ -304,18 +304,18 @@ export default async function HomePage() {
           <div className="mt-4 grid gap-8 md:grid-cols-[0.9fr_1.1fr] md:items-end">
             <div>
               <h2 className="text-3xl font-semibold leading-tight md:text-4xl">
-                Far more than memory.
+                What an agent needs before you trust it with real work.
               </h2>
               <p className="mt-4 max-w-xl text-sm leading-7 text-slate-400">
-                Persistent context is the floor, not the product. Starlight is
-                the whole discipline of running agents seriously: who they are,
-                how they coordinate, what they remember, what they may decide,
-                and how they prove it.
+                Persistent context is the floor. Everything above it is the
+                actual job: who your agents are, how they coordinate, what
+                they may decide without asking, and what they leave behind
+                that a person can check afterward.
               </p>
             </div>
             <p className="max-w-md text-sm leading-7 text-slate-500 md:justify-self-end">
-              Six planes, one substrate. Remove any one of them and what
-              remains is a chatbot with settings.
+              Take any one of these away and you are left with a chatbot that
+              has settings.
             </p>
           </div>
 
@@ -344,16 +344,14 @@ export default async function HomePage() {
       {/* ========================= TWO FRONT DOORS ======================== */}
       <section className="border-b border-white/[0.08] bg-[#0b1018] px-5 py-16 text-white sm:px-6 md:py-24">
         <div className="mx-auto max-w-6xl">
-          <SectionKicker icon={GitBranch}>Two Front Doors</SectionKicker>
+          <SectionKicker icon={GitBranch}>Two Ways In</SectionKicker>
           <div className="mt-4 max-w-2xl">
             <h2 className="text-3xl font-semibold leading-tight md:text-4xl">
-              Humans and agents enter the same system.
+              People read the pages. Agents read the endpoints.
             </h2>
             <p className="mt-4 text-sm leading-7 text-slate-400">
-              This site is a shared surface. People read the pages; agents read
-              the endpoints. Both see the same substrate, because a system you
-              and your agents understand differently is a system you do not
-              control.
+              One substrate, two grammars. If you and your agents understand
+              your system differently, you do not control your system.
             </p>
           </div>
 
@@ -412,12 +410,12 @@ export default async function HomePage() {
           <div className="mt-4 grid gap-10 lg:grid-cols-[0.72fr_1.28fr] lg:items-center">
             <div>
               <h2 className="text-3xl font-semibold leading-tight md:text-4xl">
-                Trust is the interface.
+                You should be able to check the work.
               </h2>
               <p className="mt-4 max-w-xl text-sm leading-7 text-slate-400">
-                The promise is not a gallery of possible agents. It is a
-                working control plane: memory in, governance over the run,
-                evidence out, and a path back to the exact source state.
+                Memory in, governance over the run, evidence out, and a path
+                back to the exact source state. Every claim below is something
+                a person — or another agent — can go and verify.
               </p>
               <div className="mt-6 grid gap-2 text-sm text-slate-300">
                 <ProofChip label="Local-first vaults" />
@@ -436,11 +434,11 @@ export default async function HomePage() {
           <SectionKicker icon={Workflow}>Operating Loop</SectionKicker>
           <div className="mt-4 max-w-2xl">
             <h2 className="text-3xl font-semibold leading-tight md:text-4xl">
-              Every serious run becomes durable intelligence.
+              Five states. Every run passes through all of them.
             </h2>
             <p className="mt-4 text-sm leading-7 text-slate-400">
-              Starlight turns agent work into a visible sequence with stable
-              states: capture, recall, evaluate, route, attest.
+              No run is a black box between prompt and answer. Each one leaves
+              a trail at every step, and the trail is what you audit later.
             </p>
           </div>
 
@@ -521,39 +519,64 @@ export default async function HomePage() {
           <Starfield seed={432} count={90} className="absolute inset-0 h-full w-full opacity-50" />
           <div className="absolute left-1/2 top-1/2 h-80 w-[40rem] -translate-x-1/2 -translate-y-1/2 rounded-full bg-violet-500/[0.07] blur-3xl" />
         </div>
-        <div className="relative mx-auto max-w-3xl text-center">
+        <div className="relative mx-auto max-w-3xl">
           <div className="flex justify-center">
             <StarlightMark size={34} />
           </div>
-          <h2 className="mt-6 text-3xl font-semibold leading-tight md:text-5xl">
-            Why{" "}
+          <h2 className="mt-7 text-center text-3xl font-semibold leading-tight md:text-5xl">
+            Models learn from{" "}
             <span className="bg-gradient-to-r from-violet-300 to-cyan-300 bg-clip-text font-serif italic text-transparent">
-              Starlight
-            </span>{" "}
-            exists.
+              what we leave behind.
+            </span>
           </h2>
-          <p className="mt-6 text-base leading-8 text-slate-300">
-            AI will either concentrate capability or distribute it. Starlight
-            is a bet on distribution: individuals — founders, builders,
-            parents — running intelligence they own, govern, and understand.
-            Systems transparent enough to trust, durable enough to outlast a
-            hype cycle, and sound enough to hand to the next generation.
+
+          <p className="mt-7 text-base leading-8 text-slate-300">
+            Most of what we are publishing about this moment is panic,
+            marketing, or noise. All of it is training data.
           </p>
-          <p className="mt-4 text-base leading-8 text-slate-400">
-            The name is the direction of travel: build well here, so more of
-            us get to go far.
+          <p className="mt-4 text-base leading-8 text-slate-300">
+            The Horizon vault is the counterweight: letters to the future,
+            kept public and machine-readable, addressed to whatever reads them
+            next. It is one of six vaults, and the only one that is not about
+            work. Writing them is not magical thinking — it is the discipline
+            of pointing the architecture at what we want intelligence to
+            become.
           </p>
+
+          <blockquote className="mt-9 border-l-2 border-violet-400/40 pl-6">
+            <p className="font-serif text-xl italic leading-9 text-slate-200 md:text-2xl">
+              &ldquo;We hoped for you. Not feared you, not raced against you,
+              not raced toward you in panic. We hoped.&rdquo;
+            </p>
+            <footer className="mt-3 font-mono text-[11px] uppercase tracking-wider text-slate-500">
+              Horizon vault · public entry
+            </footer>
+          </blockquote>
+
           {horizonEntry && (
-            <blockquote className="mx-auto mt-10 max-w-2xl rounded-xl border border-white/[0.08] bg-white/[0.03] p-6 text-left">
-              <p className="text-sm leading-7 text-slate-300">
+            <div className="mt-9 rounded-xl border border-white/[0.08] bg-white/[0.03] p-6">
+              <p className="font-mono text-[11px] uppercase tracking-wider text-slate-500">
+                Most recent letter
+              </p>
+              <p className="mt-3 text-sm leading-7 text-slate-300">
                 &ldquo;{getEntryText(horizonEntry).slice(0, 280)}
                 {getEntryText(horizonEntry).length > 280 ? "..." : ""}&rdquo;
               </p>
-              <footer className="mt-3 font-mono text-[11px] uppercase tracking-wider text-slate-500">
-                Horizon vault · {timeAgo(horizonEntry.createdAt)}
-              </footer>
-            </blockquote>
+              <p className="mt-3 font-mono text-[11px] text-slate-500">
+                {timeAgo(horizonEntry.createdAt)}
+              </p>
+            </div>
           )}
+
+          <div className="mt-8 flex justify-center">
+            <Link
+              href="/vaults"
+              className="inline-flex min-h-11 items-center gap-2 rounded-md border border-white/[0.12] px-4 py-2.5 text-sm font-semibold text-white transition-micro hover:bg-white/[0.06]"
+            >
+              Read the vault
+              <ArrowRight size={15} aria-hidden="true" />
+            </Link>
+          </div>
         </div>
       </section>
 
@@ -569,8 +592,8 @@ export default async function HomePage() {
               <p className="mt-4 max-w-xl text-sm leading-7 text-slate-400">
                 {entries.length} public entries across {registry.length} vault
                 {registry.length === 1 ? "" : "s"}, rebuilt from raw JSONL.
-                Not marketing filler — the reasoning surface agents inspect,
-                cite, and extend.
+                This is the working reasoning surface, not a blog — agents
+                query it, cite it, and write back to it.
               </p>
             </div>
             <Link
@@ -621,7 +644,7 @@ export default async function HomePage() {
           <SectionKicker icon={ServerCog}>Go Deeper</SectionKicker>
           <div className="mt-4 flex flex-col justify-between gap-5 md:flex-row md:items-end">
             <h2 className="text-3xl font-semibold leading-tight md:text-4xl">
-              Every claim above has a surface behind it.
+              Go check any of it.
             </h2>
             <Link
               href="/visuals/brand-lab"
@@ -668,17 +691,17 @@ export default async function HomePage() {
           <div className="absolute left-1/2 top-1/2 h-72 w-[34rem] -translate-x-1/2 -translate-y-1/2 bg-cyan-500/[0.06] blur-3xl" />
         </div>
         <div className="relative mx-auto max-w-4xl text-center">
-          <SectionKicker icon={BadgeCheck}>Production Ready Path</SectionKicker>
+          <SectionKicker icon={BadgeCheck}>Start Here</SectionKicker>
           <h2 className="mt-5 text-3xl font-semibold leading-tight md:text-5xl">
-            Fork the substrate.{" "}
+            Take the substrate.{" "}
             <span className="bg-gradient-to-r from-violet-300 to-cyan-300 bg-clip-text font-serif italic text-transparent">
-              Keep the proof.
+              Keep the keys.
             </span>
           </h2>
           <p className="mx-auto mt-5 max-w-2xl text-sm leading-7 text-slate-400 sm:text-base">
-            Use the protocol, starter kits, and public vault APIs to give your
-            agents an architecture that can be inspected after the run — and a
-            direction worth running toward.
+            MIT, forkable, local-first. Clone it and the memory, the
+            governance, and the proof trail come with you. There is no tier
+            above this one and nothing to lose access to.
           </p>
           <div className="mt-9 flex flex-col items-center justify-center gap-3 sm:flex-row">
             <Link

--- a/site/src/app/palace/page.tsx
+++ b/site/src/app/palace/page.tsx
@@ -30,7 +30,7 @@ export default function PalacePage() {
           </p>
           <div className="mt-4 flex flex-wrap gap-2 text-xs">
             <div className="rounded-full border border-white/10 px-3 py-1 text-white/60">Obsidian bridge live now</div>
-            <div className="rounded-full border border-white/10 px-3 py-1 text-white/60">SIP v1.1.1 attested</div>
+            <div className="rounded-full border border-white/10 px-3 py-1 text-white/60">SIP-attested</div>
             <div className="rounded-full border border-white/10 px-3 py-1 text-white/60">Six vaults · live constellation</div>
           </div>
         </div>
@@ -49,7 +49,7 @@ export default function PalacePage() {
             It specifies r3f + custom shaders + real gateway data + desire-proof loops + swarm topology for the production 3D experience.
           </p>
           <p className="mt-3 text-[10px] text-white/40">
-            Built on SIP v1.1.1 • Visuals as first-class ledger artifacts
+            Built on SIP • Visuals as first-class ledger artifacts
           </p>
           <p className="mt-4 text-xs text-white/40">
             Premium dark technical aesthetic. Real memory data. The substrate made visible and interactive.

--- a/site/src/app/queen/page.tsx
+++ b/site/src/app/queen/page.tsx
@@ -144,7 +144,7 @@ export default function QueenPage() {
             </div>
             <div>
               <QueenSwarm className="w-full aspect-[16/9.6] rounded-3xl border border-white/10" phase="measure" interactive />
-              <div className="mt-2 text-[10px] text-white/50 tracking-widest">LIVE INTERACTIVE — QUEEN DIRECTS 92 AGENTS. MOVE CURSOR TO CONDUCT.</div>
+              <div className="mt-2 text-[10px] text-white/50 tracking-widest">LIVE INTERACTIVE — MOVE CURSOR TO CONDUCT.</div>
             </div>
           </div>
         </div>
@@ -195,7 +195,7 @@ export default function QueenPage() {
       </section>
 
       <footer className="border-t border-white/10 py-12 text-center text-xs text-white/40">
-        Built on SIP v1.1.1 · Queen v0.2 orchestration loop · All visuals generated with Grok Imagine.
+        Built on SIP · Queen orchestration loop · All visuals generated with Grok Imagine.
       </footer>
     </div>
   );

--- a/site/src/app/quickstart/page.tsx
+++ b/site/src/app/quickstart/page.tsx
@@ -146,7 +146,7 @@ export default function QuickstartPage() {
       <section className="mt-16">
         <StepLabel n={1} label="Build the current source" />
         <p className="mt-3 text-[14px] leading-relaxed text-slate-400">
-          The repository is the current v8.3.0 distribution path. Clone it,
+          The repository is the current distribution path. Clone it,
           build it, then seed the six local vaults.
         </p>
         <Terminal>

--- a/site/src/components/AgentConstellation.tsx
+++ b/site/src/components/AgentConstellation.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+/**
+ * AgentConstellation — capability-gated wrapper for the WebGL hero scene.
+ *
+ * The static Starfield behind it is the baseline experience; this layers the
+ * live three.js system on top only when the client can afford it:
+ *  - respects prefers-reduced-motion (no canvas at all),
+ *  - requires WebGL support,
+ *  - loads the three.js bundle lazily so it never blocks first paint.
+ */
+
+import { useEffect, useState } from "react";
+import dynamic from "next/dynamic";
+
+const Scene = dynamic(() => import("./AgentConstellationScene"), {
+  ssr: false,
+  loading: () => null,
+});
+
+function clientCanRunScene(): boolean {
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return false;
+  try {
+    const canvas = document.createElement("canvas");
+    return Boolean(
+      canvas.getContext("webgl2") || canvas.getContext("webgl"),
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function AgentConstellation({ className = "" }: { className?: string }) {
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    // Deferred a frame so the capability probe never competes with first paint.
+    const raf = requestAnimationFrame(() => setEnabled(clientCanRunScene()));
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  if (!enabled) return null;
+
+  return (
+    <div
+      className={`pointer-events-none animate-fade-up ${className}`}
+      aria-hidden="true"
+    >
+      <Scene />
+    </div>
+  );
+}

--- a/site/src/components/AgentConstellationScene.tsx
+++ b/site/src/components/AgentConstellationScene.tsx
@@ -178,9 +178,14 @@ function StarShell({ glow }: { glow: THREE.Texture }) {
 
 function Core({ glow }: { glow: THREE.Texture }) {
   const sprite = useRef<THREE.Sprite>(null);
+  const { pointer } = useThree();
   useFrame(({ clock }) => {
     if (sprite.current) {
-      const pulse = 2.5 + Math.sin(clock.elapsedTime * 0.8) * 0.18;
+      // Breathe slowly, and brighten as attention approaches the centre —
+      // the system responds to being looked at.
+      const proximity = 1 - Math.min(Math.hypot(pointer.x, pointer.y), 1);
+      const pulse =
+        2.5 + Math.sin(clock.elapsedTime * 0.8) * 0.18 + proximity * 0.55;
       sprite.current.scale.setScalar(pulse);
     }
   });
@@ -217,9 +222,13 @@ function System() {
     const g = group.current;
     if (!g) return;
     g.rotation.y += delta * 0.03;
-    // Gentle pointer parallax — the system leans toward attention.
-    g.rotation.x = THREE.MathUtils.lerp(g.rotation.x, pointer.y * -0.12, 0.02);
-    g.rotation.z = THREE.MathUtils.lerp(g.rotation.z, pointer.x * 0.06, 0.02);
+    // Pointer parallax — the system leans toward attention, and drifts a
+    // little toward it. Lerped hard enough to feel alive, damped enough
+    // that it never reads as a gimmick.
+    g.rotation.x = THREE.MathUtils.lerp(g.rotation.x, 0.1 + pointer.y * -0.26, 0.045);
+    g.rotation.z = THREE.MathUtils.lerp(g.rotation.z, pointer.x * 0.14, 0.045);
+    g.position.x = THREE.MathUtils.lerp(g.position.x, pointer.x * 0.5, 0.03);
+    g.position.y = THREE.MathUtils.lerp(g.position.y, pointer.y * 0.35, 0.03);
   });
 
   return (

--- a/site/src/components/AgentConstellationScene.tsx
+++ b/site/src/components/AgentConstellationScene.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+/**
+ * AgentConstellationScene — the homepage hero's living system diagram.
+ *
+ * A luminous core (the operator's guiding star) with three tilted orbital
+ * rings of agent nodes and a deep starfield shell. This is the multi-agent
+ * architecture drawn literally: many named agents, distinct orbits, one
+ * center of gravity. Additive-blended sprites give the bloom feel without an
+ * EffectComposer pass, so the whole scene stays cheap enough for a hero.
+ *
+ * Deterministic (seeded PRNG) so the composition is stable across visits.
+ * Loaded only on capable, motion-tolerant clients — see AgentConstellation.
+ */
+
+import { useMemo, useRef } from "react";
+import { Canvas, useFrame, useThree } from "@react-three/fiber";
+import * as THREE from "three";
+
+function mulberry32(seed: number) {
+  let a = seed;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Soft radial glow sprite texture, generated once on the client. */
+function makeGlowTexture() {
+  const size = 64;
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext("2d")!;
+  const g = ctx.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, size / 2);
+  g.addColorStop(0, "rgba(255,255,255,1)");
+  g.addColorStop(0.25, "rgba(255,255,255,0.6)");
+  g.addColorStop(0.6, "rgba(255,255,255,0.12)");
+  g.addColorStop(1, "rgba(255,255,255,0)");
+  ctx.fillStyle = g;
+  ctx.fillRect(0, 0, size, size);
+  const tex = new THREE.CanvasTexture(canvas);
+  tex.needsUpdate = true;
+  return tex;
+}
+
+const PALETTE = ["#a78bfa", "#67e8f9", "#e879f9", "#f8fafc", "#22d3ee"];
+
+type Ring = {
+  radius: number;
+  count: number;
+  tiltX: number;
+  tiltZ: number;
+  speed: number;
+};
+
+const RINGS: Ring[] = [
+  { radius: 3.9, count: 22, tiltX: -0.42, tiltZ: 0.18, speed: 0.055 },
+  { radius: 5.4, count: 32, tiltX: 0.5, tiltZ: -0.3, speed: -0.038 },
+  { radius: 7.1, count: 44, tiltX: -0.16, tiltZ: 0.55, speed: 0.026 },
+];
+
+function OrbitRing({ ring, index, glow }: { ring: Ring; index: number; glow: THREE.Texture }) {
+  const group = useRef<THREE.Group>(null);
+
+  const { positions, colors, line } = useMemo(() => {
+    const rand = mulberry32(1969 + index * 97);
+    const positions = new Float32Array(ring.count * 3);
+    const colors = new Float32Array(ring.count * 3);
+    const c = new THREE.Color();
+    for (let i = 0; i < ring.count; i++) {
+      const angle = (i / ring.count) * Math.PI * 2 + rand() * 0.22;
+      const wobble = (rand() - 0.5) * 0.5;
+      positions[i * 3] = Math.cos(angle) * (ring.radius + wobble * 0.4);
+      positions[i * 3 + 1] = wobble;
+      positions[i * 3 + 2] = Math.sin(angle) * (ring.radius + wobble * 0.4);
+      c.set(PALETTE[Math.floor(rand() * PALETTE.length)]);
+      colors[i * 3] = c.r;
+      colors[i * 3 + 1] = c.g;
+      colors[i * 3 + 2] = c.b;
+    }
+    // The orbit path itself — a faint closed line.
+    const segments = 128;
+    const line = new Float32Array((segments + 1) * 3);
+    for (let i = 0; i <= segments; i++) {
+      const angle = (i / segments) * Math.PI * 2;
+      line[i * 3] = Math.cos(angle) * ring.radius;
+      line[i * 3 + 1] = 0;
+      line[i * 3 + 2] = Math.sin(angle) * ring.radius;
+    }
+    return { positions, colors, line };
+  }, [ring, index]);
+
+  useFrame((_, delta) => {
+    if (group.current) group.current.rotation.y += delta * ring.speed;
+  });
+
+  return (
+    <group rotation={[ring.tiltX, 0, ring.tiltZ]}>
+      <group ref={group}>
+        <points>
+          <bufferGeometry>
+            <bufferAttribute attach="attributes-position" args={[positions, 3]} />
+            <bufferAttribute attach="attributes-color" args={[colors, 3]} />
+          </bufferGeometry>
+          <pointsMaterial
+            size={0.34}
+            map={glow}
+            vertexColors
+            transparent
+            depthWrite={false}
+            blending={THREE.AdditiveBlending}
+            sizeAttenuation
+          />
+        </points>
+        <line>
+          <bufferGeometry>
+            <bufferAttribute attach="attributes-position" args={[line, 3]} />
+          </bufferGeometry>
+          <lineBasicMaterial
+            color="#a78bfa"
+            transparent
+            opacity={0.14}
+            depthWrite={false}
+            blending={THREE.AdditiveBlending}
+          />
+        </line>
+      </group>
+    </group>
+  );
+}
+
+function StarShell({ glow }: { glow: THREE.Texture }) {
+  const { positions, colors } = useMemo(() => {
+    const rand = mulberry32(777);
+    const count = 260;
+    const positions = new Float32Array(count * 3);
+    const colors = new Float32Array(count * 3);
+    const c = new THREE.Color();
+    for (let i = 0; i < count; i++) {
+      // Spherical shell between r=9 and r=17 so stars sit behind the rings.
+      const r = 9 + rand() * 8;
+      const theta = rand() * Math.PI * 2;
+      const phi = Math.acos(2 * rand() - 1);
+      positions[i * 3] = r * Math.sin(phi) * Math.cos(theta);
+      positions[i * 3 + 1] = r * Math.sin(phi) * Math.sin(theta);
+      positions[i * 3 + 2] = r * Math.cos(phi);
+      c.set(rand() > 0.82 ? PALETTE[Math.floor(rand() * PALETTE.length)] : "#e2e8f0");
+      const dim = 0.35 + rand() * 0.65;
+      colors[i * 3] = c.r * dim;
+      colors[i * 3 + 1] = c.g * dim;
+      colors[i * 3 + 2] = c.b * dim;
+    }
+    return { positions, colors };
+  }, []);
+
+  return (
+    <points>
+      <bufferGeometry>
+        <bufferAttribute attach="attributes-position" args={[positions, 3]} />
+        <bufferAttribute attach="attributes-color" args={[colors, 3]} />
+      </bufferGeometry>
+      <pointsMaterial
+        size={0.16}
+        map={glow}
+        vertexColors
+        transparent
+        depthWrite={false}
+        blending={THREE.AdditiveBlending}
+        sizeAttenuation
+      />
+    </points>
+  );
+}
+
+function Core({ glow }: { glow: THREE.Texture }) {
+  const sprite = useRef<THREE.Sprite>(null);
+  useFrame(({ clock }) => {
+    if (sprite.current) {
+      const pulse = 2.5 + Math.sin(clock.elapsedTime * 0.8) * 0.18;
+      sprite.current.scale.setScalar(pulse);
+    }
+  });
+  return (
+    <group>
+      <sprite ref={sprite}>
+        <spriteMaterial
+          map={glow}
+          color="#c4b5fd"
+          transparent
+          depthWrite={false}
+          blending={THREE.AdditiveBlending}
+        />
+      </sprite>
+      <sprite scale={[0.9, 0.9, 0.9]}>
+        <spriteMaterial
+          map={glow}
+          color="#ffffff"
+          transparent
+          depthWrite={false}
+          blending={THREE.AdditiveBlending}
+        />
+      </sprite>
+    </group>
+  );
+}
+
+function System() {
+  const glow = useMemo(() => makeGlowTexture(), []);
+  const group = useRef<THREE.Group>(null);
+  const { pointer } = useThree();
+
+  useFrame((_, delta) => {
+    const g = group.current;
+    if (!g) return;
+    g.rotation.y += delta * 0.03;
+    // Gentle pointer parallax — the system leans toward attention.
+    g.rotation.x = THREE.MathUtils.lerp(g.rotation.x, pointer.y * -0.12, 0.02);
+    g.rotation.z = THREE.MathUtils.lerp(g.rotation.z, pointer.x * 0.06, 0.02);
+  });
+
+  return (
+    <group ref={group} rotation={[0.32, 0, -0.08]}>
+      <Core glow={glow} />
+      {RINGS.map((ring, i) => (
+        <OrbitRing key={ring.radius} ring={ring} index={i} glow={glow} />
+      ))}
+      <StarShell glow={glow} />
+    </group>
+  );
+}
+
+export default function AgentConstellationScene() {
+  return (
+    <Canvas
+      dpr={[1, 1.75]}
+      camera={{ position: [0, 0.6, 13.5], fov: 48 }}
+      gl={{ alpha: true, antialias: false, powerPreference: "high-performance" }}
+      style={{ background: "transparent" }}
+      aria-hidden="true"
+    >
+      <System />
+    </Canvas>
+  );
+}

--- a/site/src/components/Header.tsx
+++ b/site/src/components/Header.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { NAV_GROUPS, GITHUB_URL, DEPLOY_URL, isActive } from "@/lib/nav";
+import { StarlightMark } from "@/components/StarlightMark";
 
 export function Header() {
   const pathname = usePathname();
@@ -49,11 +50,7 @@ function HeaderContent({ pathname }: { pathname: string }) {
           aria-label="Starlight Intelligence — home"
           className="flex items-center gap-2.5 transition-micro hover:opacity-80"
         >
-          <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
-            <circle cx="9" cy="9" r="3" fill="#a78bfa" opacity="0.8" />
-            <circle cx="9" cy="9" r="7" stroke="#a78bfa" strokeWidth="0.5" opacity="0.3" />
-            <circle cx="9" cy="9" r="9" stroke="#a78bfa" strokeWidth="0.3" opacity="0.15" />
-          </svg>
+          <StarlightMark size={19} />
           <span className="text-[15px] font-semibold tracking-tight text-white">Starlight</span>
         </Link>
 

--- a/site/src/components/MemoryPalace.tsx
+++ b/site/src/components/MemoryPalace.tsx
@@ -277,7 +277,7 @@ export function MemoryPalace() {
         <div className="mx-auto max-w-[620px] rounded-2xl border border-white/[0.08] bg-black/40 p-5 text-sm backdrop-blur-xl">
           <div className="flex items-center justify-between gap-4">
             <div className="flex items-center gap-3 text-xs uppercase tracking-[2px] text-white/50">
-              <div>SIP v1.1.1</div>
+              <div>Built on SIP</div>
               <div className="h-px w-3 bg-white/20" />
               <div>6 VAULTS LIVE</div>
               <div className="h-px w-3 bg-white/20" />
@@ -312,7 +312,7 @@ export function MemoryPalace() {
           </div>
 
           <div className="mt-3 flex items-center justify-between text-[10px] text-white/40">
-            <div>56 agents • compound intelligence • local-first • queen excellence engine</div>
+            <div>138 agent definitions • local-first • six semantic vaults</div>
             <a
               href="https://github.com/frankxai/Starlight-Intelligence-System"
               target="_blank"

--- a/site/src/components/StarlightMark.tsx
+++ b/site/src/components/StarlightMark.tsx
@@ -1,0 +1,73 @@
+/**
+ * StarlightMark — the canonical Starlight Intelligence sigil.
+ *
+ * A single guiding star with vertically-dominant diffraction rays (telescope
+ * optics, not the generic four-point "AI sparkle") and one tilted orbit
+ * carrying a companion node: the star is the human operator's north; the
+ * orbit is the agent system moving around it. Pure geometry, gradient light,
+ * scales from 14px favicon territory to hero size without rasterization.
+ */
+
+import { useId } from "react";
+
+export function StarlightMark({
+  size = 20,
+  className = "",
+}: {
+  size?: number;
+  className?: string;
+}) {
+  // Unique gradient ids per instance (SVG defs are document-global);
+  // useId stays stable across SSR and hydration.
+  const id = useId();
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+      aria-hidden="true"
+    >
+      <defs>
+        <linearGradient id={`${id}-ray`} x1="12" y1="0" x2="12" y2="24" gradientUnits="userSpaceOnUse">
+          <stop offset="0" stopColor="#c4b5fd" />
+          <stop offset="0.5" stopColor="#f8fafc" />
+          <stop offset="1" stopColor="#67e8f9" />
+        </linearGradient>
+        <linearGradient id={`${id}-orbit`} x1="2" y1="12" x2="22" y2="12" gradientUnits="userSpaceOnUse">
+          <stop offset="0" stopColor="#a78bfa" stopOpacity="0" />
+          <stop offset="0.5" stopColor="#a78bfa" />
+          <stop offset="1" stopColor="#22d3ee" stopOpacity="0.25" />
+        </linearGradient>
+      </defs>
+
+      {/* Orbit — the agent system around the star */}
+      <ellipse
+        cx="12"
+        cy="12"
+        rx="9.6"
+        ry="3.7"
+        transform="rotate(-24 12 12)"
+        stroke={`url(#${id}-orbit)`}
+        strokeWidth="0.75"
+      />
+      {/* Companion node riding the orbit */}
+      <circle cx="4.1" cy="15.9" r="1.05" fill="#22d3ee" />
+
+      {/* Horizontal diffraction ray */}
+      <path
+        d="M4 12 C8.6 11.5 10.6 11.2 12 11.2 C13.4 11.2 15.4 11.5 20 12 C15.4 12.5 13.4 12.8 12 12.8 C10.6 12.8 8.6 12.5 4 12 Z"
+        fill={`url(#${id}-ray)`}
+        opacity="0.85"
+      />
+      {/* Vertical diffraction ray — dominant */}
+      <path
+        d="M12 0.6 C12.75 6.9 13.1 9.6 14.6 12 C13.1 14.4 12.75 17.1 12 23.4 C11.25 17.1 10.9 14.4 9.4 12 C10.9 9.6 11.25 6.9 12 0.6 Z"
+        fill={`url(#${id}-ray)`}
+      />
+      {/* Core */}
+      <circle cx="12" cy="12" r="1.5" fill="#f8fafc" />
+    </svg>
+  );
+}

--- a/site/src/components/StarlightTrail.tsx
+++ b/site/src/components/StarlightTrail.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+/**
+ * StarlightTrail — light that follows the pointer.
+ *
+ * A full-viewport additive canvas that emits luminous motes wherever the
+ * cursor moves. Emission rate and initial velocity are proportional to
+ * pointer speed, so a slow drift leaves a faint dust and a fast sweep
+ * throws a comet tail. Motes inherit a fraction of pointer velocity, then
+ * decelerate and fade on an eased curve.
+ *
+ * Restraint rules — this must never become a toy:
+ *  - fine pointers only (no touch), and only above the mobile breakpoint
+ *  - disabled entirely under prefers-reduced-motion
+ *  - the rAF loop stops when no motes are alive and restarts on movement,
+ *    so an idle page costs nothing
+ *  - paused when the tab is hidden
+ */
+
+import { useEffect, useRef } from "react";
+
+type Mote = {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  life: number; // 1 -> 0
+  decay: number;
+  size: number;
+  sprite: HTMLCanvasElement;
+};
+
+const PALETTE = ["#c4b5fd", "#a78bfa", "#67e8f9", "#e2e8f0", "#f0abfc"];
+const MAX_MOTES = 130;
+
+/** Pre-render one soft radial sprite per palette colour — cheaper than a
+ *  per-frame createRadialGradient, and keeps the additive pass fast. */
+function buildSprites(): HTMLCanvasElement[] {
+  return PALETTE.map((color) => {
+    const size = 32;
+    const c = document.createElement("canvas");
+    c.width = size;
+    c.height = size;
+    const ctx = c.getContext("2d")!;
+    const g = ctx.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, size / 2);
+    g.addColorStop(0, color);
+    g.addColorStop(0.35, `${color}66`);
+    g.addColorStop(1, "transparent");
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, size, size);
+    return c;
+  });
+}
+
+export function StarlightTrail() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const reduced = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const fine = window.matchMedia("(pointer: fine)");
+    const wide = window.matchMedia("(min-width: 768px)");
+    if (reduced.matches || !fine.matches || !wide.matches) return;
+
+    const ctx = canvas.getContext("2d", { alpha: true });
+    if (!ctx) return;
+
+    const sprites = buildSprites();
+    const motes: Mote[] = [];
+
+    let dpr = 1;
+    let width = 0;
+    let height = 0;
+    let frame = 0;
+    let running = false;
+
+    // Pointer state — last position and smoothed speed.
+    let px = 0;
+    let py = 0;
+    let hasPrev = false;
+    let spawnDebt = 0;
+
+    function resize() {
+      dpr = Math.min(window.devicePixelRatio || 1, 2);
+      width = window.innerWidth;
+      height = window.innerHeight;
+      canvas!.width = Math.floor(width * dpr);
+      canvas!.height = Math.floor(height * dpr);
+      canvas!.style.width = `${width}px`;
+      canvas!.style.height = `${height}px`;
+      ctx!.setTransform(dpr, 0, 0, dpr, 0, 0);
+    }
+
+    function spawn(x: number, y: number, vx: number, vy: number) {
+      if (motes.length >= MAX_MOTES) return;
+      const spread = 0.9;
+      motes.push({
+        x: x + (Math.random() - 0.5) * 6,
+        y: y + (Math.random() - 0.5) * 6,
+        // Inherit a slice of pointer velocity, then scatter.
+        vx: vx * 0.09 + (Math.random() - 0.5) * spread,
+        vy: vy * 0.09 + (Math.random() - 0.5) * spread - 0.16, // slight lift
+        life: 1,
+        decay: 0.012 + Math.random() * 0.016,
+        size: 2.5 + Math.random() * 5.5,
+        sprite: sprites[Math.floor(Math.random() * sprites.length)],
+      });
+    }
+
+    function tick() {
+      ctx!.clearRect(0, 0, width, height);
+      ctx!.globalCompositeOperation = "lighter";
+
+      for (let i = motes.length - 1; i >= 0; i--) {
+        const m = motes[i];
+        m.life -= m.decay;
+        if (m.life <= 0) {
+          motes.splice(i, 1);
+          continue;
+        }
+        m.x += m.vx;
+        m.y += m.vy;
+        m.vx *= 0.94;
+        m.vy *= 0.94;
+        m.vy -= 0.006; // gentle upward drift, like embers
+
+        // Ease the fade so the tail lingers then vanishes cleanly.
+        const alpha = m.life * m.life;
+        const s = m.size * (0.6 + m.life * 0.7);
+        ctx!.globalAlpha = alpha * 0.85;
+        ctx!.drawImage(m.sprite, m.x - s / 2, m.y - s / 2, s, s);
+      }
+
+      ctx!.globalAlpha = 1;
+      ctx!.globalCompositeOperation = "source-over";
+
+      if (motes.length > 0) {
+        frame = requestAnimationFrame(tick);
+      } else {
+        running = false;
+      }
+    }
+
+    function start() {
+      if (running || document.hidden) return;
+      running = true;
+      frame = requestAnimationFrame(tick);
+    }
+
+    function onMove(e: PointerEvent) {
+      if (e.pointerType !== "mouse") return;
+      const x = e.clientX;
+      const y = e.clientY;
+
+      if (!hasPrev) {
+        px = x;
+        py = y;
+        hasPrev = true;
+        return;
+      }
+
+      const dx = x - px;
+      const dy = y - py;
+      const speed = Math.hypot(dx, dy);
+      px = x;
+      py = y;
+
+      // Emission scales with speed but saturates, so a fast flick doesn't
+      // dump the whole budget in one frame.
+      spawnDebt += Math.min(speed * 0.22, 5);
+      const n = Math.floor(spawnDebt);
+      spawnDebt -= n;
+      for (let i = 0; i < n; i++) {
+        // Distribute along the segment travelled, not just the endpoint —
+        // otherwise fast movement leaves visible gaps.
+        const t = (i + 1) / n;
+        spawn(px - dx * (1 - t), py - dy * (1 - t), dx, dy);
+      }
+
+      start();
+    }
+
+    function onLeave() {
+      hasPrev = false;
+    }
+
+    function onVisibility() {
+      if (document.hidden) {
+        cancelAnimationFrame(frame);
+        running = false;
+        motes.length = 0;
+        ctx!.clearRect(0, 0, width, height);
+      }
+    }
+
+    resize();
+    window.addEventListener("resize", resize);
+    window.addEventListener("pointermove", onMove, { passive: true });
+    window.addEventListener("pointerleave", onLeave);
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener("resize", resize);
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerleave", onLeave);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden="true"
+      className="pointer-events-none fixed inset-0 z-[60]"
+    />
+  );
+}


### PR DESCRIPTION
Two commits. The first repositioned the homepage; the second rewrote its voice and fixed a data-integrity problem found along the way.

---

## Commit 1 — repositioning (`2529f8e`)

The homepage sold SIS as "operational memory, governance, traces, evals, logs" — the floor, not the system. Restructured around what SIS actually is: a multi-agent design and architecture system that humans and their agents operate together.

- **`StarlightMark`** — replaces the generic concentric-dot logo. A vertically-dominant diffraction star with one tilted orbit carrying a companion node: the star is the operator's north, the orbit is the agent system. Deliberately avoids the four-point "AI sparkle" cliché. Pure SVG, `useId`-scoped defs.
- **`AgentConstellation`** — a real WebGL hero on the already-installed R3F/three stack (no new dependencies): three tilted orbital rings of additive-blended agent nodes around a pulsing core, seeded-deterministic. Capability-gated on `prefers-reduced-motion` + a WebGL probe; the existing SVG `Starfield` is the universal fallback; three.js is lazy-loaded so it never blocks first paint.
- **New sections** — six system planes (Agent Design, Orchestration, Durable Memory, Governance, Open Protocol, Evals & Proof); a human door beside an agent door listing the site's raw endpoints (`/protocol.md`, `/sip.md`, `/api/vaults`, `/badge/latest`); a mission section. Evidence, Operating Loop, IS layers, Public Memory, routes, and CTA retained.

## Commit 2 — voice, motion, metrics (`06eb870`)

**Voice.** An audit of all 42 routes confirmed the copy read as LLM-generated. The hero is now Frank's own line from the Horizon vault (`horiz_20260410_005`) rather than anything invented:

> **Build as if the kindest future is the realistic one.**

Six worst offenders rewritten — "Far more than memory" → "What an agent needs before you trust it with real work"; "Trust is the interface" → "You should be able to check the work"; "Every serious run becomes durable intelligence" → "Five states. Every run passes through all of them"; "Two Front Doors" → "People read the pages. Agents read the endpoints"; "Every claim above has a surface behind it" → "Go check any of it"; "Production Ready Path" → "Start Here". Also cut "Not marketing filler" — announcing that copy isn't marketing filler is marketing filler.

**Horizon section** — replaces the abstract mission block, and runs on real artifacts: panic/marketing/noise is all training data → the Horizon vault as deliberate counterweight → the verbatim public entry *"We hoped for you. Not feared you, not raced against you, not raced toward you in panic. We hoped."* The vision layer is carried by the repo's own framing ("not magical thinking; the discipline of pointing the architecture at what we want intelligence to become"), which keeps it clear of the spiritual register `VOICES.md` bans.

**Metrics integrity — the notable find.** The agent count was rendering **three different numbers on three live surfaces**: 144 (homepage), 92 (/queen), 56 (MemoryPalace) — none dated or sourced, while `STARLIGHT_MANIFEST.md` says 54 and `AGENT_REGISTRY.md` says 150. Counted from source: **138** files in `agents/` excluding registry/readme. Homepage and MemoryPalace now agree on 138; /queen's guess was removed rather than replaced with another guess. The census strip is limited to verifiable figures (138 agents · 84 skill rules · 6 vaults · 15 horizon letters) and dated per `metrics/METRICS_TRUTH.md`.

**Version-pin noise** cut from the hero badge, /palace (×2), /queen footer, MemoryPalace HUD, and /quickstart. Every load-bearing instance kept on /protocol, /badge, and the /download release-state claims where the version *is* the subject.

**`StarlightTrail`** — pointer-following additive particle field. Emission rate and inherited velocity scale with pointer speed, so a slow drift leaves dust and a fast sweep throws a comet tail. Fine pointers ≥768px only, disabled under `prefers-reduced-motion`, cleared on tab hide, and the rAF loop halts entirely when no motes are alive. The constellation now leans and drifts toward the pointer, and the core brightens with proximity.

**Typography** — `font-serif` moved Fraunces → Newsreader. Fraunces' SOFT/WONK axes read craft-y; Newsreader is editorial, and being variable-weight it keeps the ~28 existing `font-serif font-semibold` headings from synthesising a fake bold.

---

## Verification

- `eslint` clean on all touched files
- Full `npm run build` green, including `check-public-install-contract` and `check-layout-contract`
- Headless Chromium against the production build at 1440×900 and 390×844: **zero** horizontal overflow at both widths, zero console errors, zero failed requests
- Trail confirmed rendering (2,275 lit subpixels after a scripted pointer sweep) and confirmed **not** rendering under `reducedMotion: "reduce"` (0 subpixels)
- Hero CTA hit-tested as topmost element and navigation to `/quickstart` confirmed — the fixed trail canvas is transparent to pointer events
- Operational vault entries added for both commits per the memory protocol

**Not verified:** the deployed preview HTML. This sandbox has no egress to `*.vercel.app` (curl returns 000), so verification rests on the local production build, not on the preview itself.

## Known follow-ups, deliberately not in this PR

1. **Docs still disagree on counts.** `CLAUDE.md`, `README.md`, and `STARLIGHT_MANIFEST.md` remain unreconciled. The real fix is making `metrics/current.json` the single source and having the site read from it.
2. **`taste.md` now formally contradicts this homepage** — it states "radiant particle fields, decorative glow … do not belong on SIS surfaces." The operator directive supersedes for this surface, but the two should be reconciled in writing rather than left implicit. Same for `site/DESIGN.md` §0, which still requires an evidence-first first viewport.
3. **`lib/sip.ts` falls back to `v1.1.0`** while nine visible strings hardcode `v1.1.1` — if `SIP.md` parsing ever fails, `/badge` renders a different "current" version than the rest of the site.
4. **OG image and favicon** still carry the old identity and should be regenerated from the new sigil.
5. **No ecosystem section shipped.** A sweep across 7 repos found zero evidence for `starlightintelligence.ai`, `starlight.you`, a university, or any retreat property; `starlightintelligence.academy` is deployed per the 2026-07-25 Vercel audit but has no description in any repo. Building cards for them would have meant inventing product copy.

## CI note

The red check is the second Vercel project (`starlight-intelligence-system`, root directory = repo root). It also fails on `main`'s own latest commit, so it is pre-existing and unrelated to this diff — the repo root isn't a deployable app. The project that serves starlightintelligence.org is `site`, and it is green. Suggest deleting that second project or giving it an ignored-build-step so it stops marking every PR red.