### PR TITLE
Reconcile ECOSYSTEM_ARCHITECTURE.md with verified metrics (v2.1) + 2026-07-28 absorption brief

### DIFF
--- a/ECOSYSTEM_ARCHITECTURE.md
+++ b/ECOSYSTEM_ARCHITECTURE.md
@@ -2,7 +2,9 @@
 
 **The Starlight Constellation: SIS as Substrate Hub for ~15 Repositories**
 
-Version 2.0 | 2026-06-10
+Version 2.1 | Structure verified 2026-06-10 · Counts reconciled with `metrics/current.json` 2026-07-28
+
+> **Metrics note:** Fast-moving counts (agents, skills, version) in this document are snapshots. The living, harness-enforced source of truth is [`metrics/current.json`](metrics/current.json) — the site build and agent harness fail closed on drift.
 
 ---
 
@@ -12,7 +14,7 @@ The FrankX ecosystem is no longer a three-repo stack. It is a constellation of r
 
 The original three-layer intuition still holds at the core — a universal framework (SIS), a platform-native implementation (ACOS), and a domain-specific creative universe (Arcanea) — but the satellite tier around that core has grown into its own ring of specialized repos, and several early members of the ecosystem have gone quiet. This document records the constellation as verified on 2026-06-10.
 
-**Starlight Intelligence System (SIS)** is the substrate layer. Two layers live in one repo: the SIP substrate (protocol, alliances, verticals, voices, attestation) and a reference operational build with **48 agents**, **71 auto-activating skills** across 14 domains, **6 persistent memory vaults**, 10 universal Intelligence Systems plus a Domain Sub-Stack tier, and platform adapters for 6 AI development tools. SIS is platform-agnostic: Markdown and JSON configuration, zero runtime dependencies. Any AI agent that reads files can consume SIS.
+**Starlight Intelligence System (SIS)** is the substrate layer. Two layers live in one repo: the SIP substrate (protocol, alliances, verticals, voices, attestation) and a reference operational build with **144 agents**, **84 auto-activating skills** across 16 domains (both harness-verified 2026-07-27, per `metrics/current.json`), **6 persistent memory vaults**, 10 universal Intelligence Systems plus a Domain Sub-Stack tier, and platform adapters for 6 AI development tools. SIS is platform-agnostic: Markdown and JSON configuration, zero runtime dependencies. Any AI agent that reads files can consume SIS.
 
 **Agentic Creator OS (ACOS)** is the implementation layer (public, v11). It consumes SIS intelligence and deploys it through Claude Code as a productivity operating system: **90+ skills**, **65+ commands**, **38 agents**, swarm topologies via claude-flow lineage, and the Agentic Jujutsu self-learning mechanism. Where SIS defines *what intelligence is*, ACOS defines *how intelligence works* in a specific tool.
 
@@ -33,7 +35,7 @@ The separation remains deliberate. SIS never contains Claude Code-specific confi
                             ACTIVE CORE TIER
             ┌──────────────────────────────────────────────┐
             │   SIS (substrate hub)                        │
-            │   SIP · 48 agents · 71 skills · 6 vaults     │
+            │   SIP · 144 agents · 84 skills · 6 vaults    │
             │      │                                       │
             │      ├── Generates context for ──> ACOS v11  │
             │      │     90+ skills · 65+ commands         │
@@ -56,7 +58,7 @@ Three tiers, verified 2026-06-10. "Pulse" is observed activity, not aspiration.
 
 | Repo | Visibility | Role | State (2026-06-10) |
 |------|-----------|------|---------------------|
-| **Starlight-Intelligence-System** | Public | Substrate hub — SIP, vaults, attestation, contracts | 48 agents, 71 skills, v8.2.0, daily-driven |
+| **Starlight-Intelligence-System** | Public | Substrate hub — SIP, vaults, attestation, contracts | 144 agents, 84 skills, v8.3.0 (harness-verified 2026-07-27), daily-driven |
 | **agentic-creator-os** | Public | Claude Code productivity OS, Built on SIP | v11: 90+ skills, 65+ commands, 38 agents |
 | **Arcanea** (arcanea-ai-app + arcanea) | Private app + public OSS | Creative universe layer | Most active in constellation: 356 commits/60d |
 
@@ -124,9 +126,9 @@ Transmissions on live channels are logged chronologically in channel files under
 
 The agent hierarchy spans the core tier, with each layer adding specialization while maintaining alignment to the SIS council structure.
 
-### 4.1 SIS Level: 48 Agents Around a Council Core
+### 4.1 SIS Level: 144 Agents Around a Council Core
 
-SIS now registers **48 agents** (`agents/AGENT_REGISTRY.md`): the 7-agent legacy council (Orchestrator, Prime, Architect, Navigator, Sentinel, Weaver, Sage), 7 Council Archetype seats, 3 front-door agents, 1 excavation agent, 5 universal-IS agents, 6 People Intelligence, 6 Sound Intelligence, 7 Music IS, and 5 SIS Extractors, plus the Starlight Genius excavation tier. The original council remains the coordination spine — flat, with emergent leadership; whichever agent's domain matches the current task leads.
+SIS registers **144 agents** as of 2026-07-27 (`agents/AGENT_REGISTRY.md` is the authoritative roster; the harness in `scripts/check-agent-harness.mjs` fail-closes on drift). The layers grew from the original 48-agent registry (snapshot 2026-06-10: 7-agent legacy council, 7 Council Archetype seats, 3 front-door agents, 1 excavation agent, 5 universal-IS agents, 6 People Intelligence, 6 Sound Intelligence, 7 Music IS, 5 SIS Extractors, plus the Starlight Genius excavation tier) by adding the Domain Vertical expansion — Space, Marine, Longevity, Legal, Crypto, Energy, Machine, Safety, and Partner adapter tiers. The original council remains the coordination spine — flat, with emergent leadership; whichever agent's domain matches the current task leads.
 
 | Council Agent | Domain | Cognitive Profile |
 |-------|--------|-------------------|
@@ -275,7 +277,7 @@ The Horizon Vault records what the builders of these systems hoped for, what the
 | **Platforms** | 6 adapters (Claude Code, Cursor, Cline, Codex, Gemini, Antigravity) | Claude Code (primary implementation target) | Web app (private) + public OSS, on-chain infrastructure |
 | **Visibility** | Public | Public | arcanea-ai-app private + arcanea public |
 | **Alignment** | Horizon Vault + starlight-horizon-dataset | Surfaces Horizon entries in decisions | Embodies values through Guardian philosophy |
-| **Pulse (2026-06-10)** | Daily-driven, v8.2.0 | v11 active | Most active: 356 commits/60d |
+| **Pulse (2026-06-10, versions reconciled 2026-07-28)** | Daily-driven, v8.3.0 | v11 active | Most active: 356 commits/60d |
 
 ---
 
@@ -325,7 +327,7 @@ These properties must hold across the constellation. If any invariant is violate
 
 ---
 
-*Starlight Intelligence System v8.2.0 | Agentic Creator OS v11 | Arcanea | Constellation verified 2026-06-10*
+*Starlight Intelligence System v8.3.0 | Agentic Creator OS v11 | Arcanea | Constellation structure verified 2026-06-10 · counts reconciled 2026-07-28 (`metrics/current.json`)*
 
 ---
 **Built on SIP** — Starlight Intelligence Protocol

--- a/docs/strategic/2026-07-28-absorption-brief.md
+++ b/docs/strategic/2026-07-28-absorption-brief.md
@@ -1,0 +1,61 @@
+# Absorption Brief — What SIS Should Take from the July 2026 Landscape
+
+**Date:** 2026-07-28 · **Method:** 3 parallel research agents (protocols/standards, agent frameworks, memory/evals/infra), all claims web-verified same-day with sources · **Audience:** Frank + Starlight Board · **Status:** proposal — substrate-touching items below go through `/starlight-board` before adoption.
+
+The question this answers: *"Don't we need more agents and skills and a meta layer — more latest stuff absorbed from other top-tier GitHubs?"*
+
+**Short answer: not more agents — more edges.** 144 agents and 84 skills is already above the credibility line the evals repo can defend. The gap between SIS and the July 2026 frontier is not roster size; it is (1) the wire protocols the frontier standardized this quarter, (2) three memory-schema patterns that are pure upgrades, and (3) distribution surfaces that put the existing roster where adopters already are. Every recommendation below composes — nothing replaces the substrate.
+
+---
+
+## 1. Protocol layer — the standards that locked in this quarter
+
+| Standard | State (verified 2026-07-28) | What SIS does |
+|---|---|---|
+| **MCP spec rev 2026-07-28** | Published **today**: stateless core (protocol session removed; identity/capabilities move to `_meta`), Extensions framework, Tasks, MCP Apps, `.well-known` server metadata, formal deprecation policy. v2 SDK betas (TS/Python/Go/C#). | **Highest priority.** Migrate `src/mcp-server.ts` + `starlight-mcp` from the 2024-11-05 protocol to the new revision. Statelessness means session semantics must move into application-layer memory keys — the vault layer already works this way, so the port is favorable. Publish `.well-known` metadata for both servers. |
+| **A2A v1.0** (Linux Foundation, 2026-04-09; 150+ orgs; shipped in Google/Microsoft/AWS platforms) | protobuf data model, JSON-RPC/gRPC/REST bindings, AgentCard discovery, extension mechanism. | Publish **A2A AgentCards for the Queens** (starlight-swarm) so external ADK/MAF/CrewAI agents can delegate into the swarm. Define a small **SIP extension** on the AgentCard carrying the attestation + sovereignty declaration — this is white space no one else occupies. |
+| **AGNTCY / OASF** (signed agent records) | Agent Directory Service with cryptographically signed agent records. | Export the 144-agent registry as signed OASF records in CI — machine-verifiable roster, generated from `agents/`, checked by the same fail-closed harness. |
+| **agents.md** (60k+ repos, LF Agentic AI Foundation) | De facto cross-harness convention. | Already aligned (AGENTS.md exists per-repo). Keep. |
+| **x402 Foundation + AP2 v0.2.0** | Payments protocols consolidating (Apr 2026). | payment-intelligence-system already models AP2 mandates fail-closed. Track v0.2.0 delta; no autonomous money movement — unchanged, non-waivable. |
+| **C2PA 2.3 / ISO/IEC 22144; EU AI Act Art. 50 applies 2026-08-02** | Content provenance goes regulatory **in 5 days**. | Extend `/sip-attest` to emit C2PA manifests for media artifacts. SIP's **text/code attestation** remains the differentiator — C2PA covers media; nobody owns text/code provenance. Claim it. |
+
+## 2. Framework layer — patterns worth stealing (no runtimes worth adopting)
+
+Verified state: OpenAI is **winding down AgentKit visual builder + Evals (discontinued 2026-11-30)** and steering everyone to code-first SDKs; Microsoft MAF 1.0 (Apr 2026) merged AutoGen+SK; Google ADK 2.0 GA'd at I/O with native OTel; LangGraph holds a no-breaking-changes line; CrewAI shipped pluggable memory backends. The market converged on exactly the bet SIS made: **markdown/code-first agent definitions, MCP + A2A interop, no visual-builder lock-in.** The builders are churning; the protocols are not.
+
+Absorb as patterns:
+- **CodeAct** (MAF, BUILD 2026): worker collapses a multi-step plan into one sandboxed program calling tools — claimed ~50% latency / >60% token cuts. Prototype as an execution mode for starlight-swarm workers **behind the existing fail-closed gate**.
+- **Checkpoint/resume** (LangGraph durable execution): map Queen-session checkpoints onto the vault/AgentDB tier so long swarm runs survive interruption. Semantics only; no dependency.
+- **Plugin packaging** (Claude Code ecosystem: ~36.6k plugins): package the 84 skills + agent roster as a Claude Code plugin-marketplace repo — distribution to where adopters already are, zero new code in the substrate.
+- **CrewAI memory-backend adapter**: thin shim exposing the SIS MCP memory server as a CrewAI backend. Low effort, real reach.
+
+## 3. Memory + evals layer — three pure-upgrade schema changes
+
+1. **Bi-temporal facts** (Zep/Graphiti pattern): add `valid_from` / `invalidated_at` to vault JSONL entries — facts get superseded, never overwritten. Composes perfectly with the existing `sis_invalidate` / `sis_contradict` tools; SQLite edge table beside FTS5, no Neo4j.
+2. **Memory-op taxonomy** (Mem0 v2.0 pattern): consolidation pass classifies each incoming entry ADD/UPDATE/DELETE against existing memory. Formalizes what vault consolidation already does by hand.
+3. **Retrieval-usage feedback** (AgentDB pattern): log which retrieved entries a session actually used (`used_in_session` signal), re-rank by it. SIS already names AgentDB as tier 3 — this wires the learning loop.
+
+Evals: adopt **promptfoo's declarative scorecard format** (pinned version — OpenAI acquired promptfoo Mar 2026, governance risk nonzero) as the interchange format in starlight-evals; run **LOCOMO** against Mem0/Zep published numbers so SIS retrieval has a public benchmark, not just self-reported scorecards. Emit **OTel `gen_ai.*` spans** from the MCP server pinned to a dated semconv snapshot (nothing tagged Stable as of 2026-07-17); optional self-hosted Langfuse for the trace UI. Mirror scorecards as a **Hugging Face dataset** (HF MCP server gained `hf_fs` + Sandboxes on 2026-07-26) — first concrete step of the Layer-4 preservation blueprint.
+
+## 4. Sequenced adoption plan
+
+| # | Move | Tier | Effort |
+|---|---|---|---|
+| 1 | MCP server migration to spec 2026-07-28 (v2 SDK) + `.well-known` metadata | Substrate → **Board first** | M |
+| 2 | Bi-temporal vault fields + memory-op consolidation pass | Substrate (schema) → **Board first** | S |
+| 3 | A2A AgentCards for Queens + SIP AgentCard extension | Substrate (cross-party) → **Board first** | S |
+| 4 | promptfoo-format scorecards + LOCOMO run in starlight-evals | Operational | S |
+| 5 | Claude Code plugin-marketplace packaging of skills/agents | Operational | S |
+| 6 | OASF signed registry export in CI | Operational | S |
+| 7 | C2PA emission in `/sip-attest` (before EU AI Act Art. 50, 2026-08-02) | Substrate → **Board first** | M |
+| 8 | CodeAct worker mode prototype (fail-closed gated) | Operational | M |
+| 9 | Retrieval-usage feedback column + re-rank | Operational | S |
+| 10 | OTel spans + optional Langfuse; HF dataset mirror of scorecards | Operational | S–M |
+
+**What we deliberately do NOT do:** adopt any framework runtime (MAF/ADK/LangGraph/CrewAI) as a dependency; chase agent-count growth; build on visual-builder surfaces (AgentKit's wind-down is the cautionary tale); anchor anything on-chain before two attested corpora exist (per the Layer-4 blueprint).
+
+---
+
+*Synthesized from three same-day research sweeps; full source lists live in the session journal. Companion doc: `docs/validation/2026-07-13-multiagent-ecosystem-validation.md` (the 5-layer blueprint this sequences into).*
+
+**Built on SIP** — Starlight Intelligence Protocol.

--- a/memory/vaults/operational-vault.md
+++ b/memory/vaults/operational-vault.md
@@ -689,3 +689,5 @@ Ops note: pushes to frankx.ai-vercel-website from this shallow checkout intermit
 **Unverifiable properties (do not publish).** An ecosystem sweep across 7 repos found **zero** evidence for `starlightintelligence.ai`, `starlight.you`, any university, or any retreat property. `starlight-intelligence.ai` exists only as a dormant, archive-queued *directory* superseded by `site/`. `starlightintelligence.academy` is attested live by the 2026-07-25 Vercel audit but has no description anywhere in any repo. No ecosystem section was shipped rather than fabricate one.
 
 **Built on SIP — Starlight Intelligence Protocol**
+
+**2026-07-28 addendum (validation-ops):** ECOSYSTEM_ARCHITECTURE.md reconciled to v2.1 — the last stale 48/71/v8.2.0 references updated to the harness-verified 144/84/v8.3.0 with a metrics-note pointing at `metrics/current.json` as the fail-closed source of truth. Closes the "three contradictory ecosystem maps" finding from the 2026-07-13 validation report. Verified: `node scripts/check-agent-harness.mjs` passes; zero stale-count matches remain.


### PR DESCRIPTION
Follow-up to the 2026-07-13 multi-agent validation (#36) — closes its last open documentation finding (**the three-way ecosystem-map contradiction**) and adds the **2026-07-28 absorption brief** requested in the current build cycle.

## Part 1 — Ecosystem map reconciliation

### What was still wrong

`ECOSYSTEM_ARCHITECTURE.md` ("Version 2.0, verified 2026-06-10") still claimed **48 agents / 71 skills / v8.2.0** in six places, while `metrics/current.json` and the fail-closed harness (`scripts/check-agent-harness.mjs`) prove **144 agents / 84 skills / v8.3.0** (last verified 2026-07-27). Per the repo's own Metrics Truth Rule, that's a hardcoded fast-moving number contradicting the living ledger.

### Changes

- Header bumped to **v2.1** with the structure-verified date (2026-06-10) split from the counts-reconciled date (2026-07-28), plus a metrics note naming `metrics/current.json` as the harness-enforced source of truth
- Overview paragraph, constellation ASCII diagram, core-tier table, §4.1 heading + composition paragraph, pulse row, and footer all updated to 144 / 84 / v8.3.0 with "harness-verified 2026-07-27" attribution
- The 2026-06-10 48-agent composition breakdown is preserved inside §4.1 as a dated snapshot (per Metrics Truth Rule: history is recorded, not deleted); the growth to 144 is attributed to the Domain Vertical expansion
- Operational vault addendum closing the loop on the validation finding

## Part 2 — Absorption brief (new: `docs/strategic/2026-07-28-absorption-brief.md`)

Synthesis of three same-day parallel research sweeps (protocols/standards, agent frameworks, memory/evals infra), answering "do we need more agents/skills/meta-layer?" with a sequenced 10-move adoption plan:

- **Protocols:** MCP spec rev **2026-07-28** (stateless core — direct impact on `src/mcp-server.ts`), A2A v1.0 AgentCards for Queens + a SIP AgentCard extension, OASF signed registry export, C2PA emission in `/sip-attest` ahead of EU AI Act Art. 50 (2026-08-02)
- **Frameworks:** absorb patterns only (MAF CodeAct, LangGraph checkpoint/resume, Claude Code plugin packaging, CrewAI memory-backend adapter) — no runtime dependencies; AgentKit's wind-down validates the markdown/code-first bet
- **Memory/evals:** bi-temporal vault fields (Graphiti pattern), Mem0-style memory-op taxonomy, AgentDB retrieval-feedback signal, promptfoo-format scorecards + LOCOMO benchmark, OTel `gen_ai.*` spans, HF dataset mirror of scorecards
- Substrate-tier items are explicitly flagged for `/starlight-board` before adoption — this PR proposes, it does not enact

## Verified

- `node scripts/check-agent-harness.mjs` → `passed (agents=144, skills=84, version=v8.3.0)`
- `grep -c "48 agents\|71 skills\|v8.2.0" ECOSYSTEM_ARCHITECTURE.md` → 0
- `npm run build` clean on current main + this diff

Note: the `starlight-intelligence-system` Vercel check fails on **all** commits including main production (pre-existing `ERR_PNPM_OUTDATED_LOCKFILE` on the duplicate root-directory project `prj_KWkVbpOpyrQUAU7Q4Bl333yB04UE`); the canonical `site` project deploys green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYLKNfybke8GJ7qq74BAD9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the ecosystem architecture documentation to version 2.1 with current inventory metrics, expanded domain coverage, verification dates, and clearer validation status.
  - Added a strategic brief outlining 2026 priorities for interoperability, memory, evaluation, observability, and distribution, including a phased adoption sequence.
  - Added an operational validation note confirming reconciled counts of 144 agents and 84 skills, version 8.3.0 alignment, and resolution of stale-count discrepancies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->