### PR TITLE
fix(site): restore the site build by rooting Turbopack at the repo

### DIFF
--- a/site/next.config.ts
+++ b/site/next.config.ts
@@ -1,5 +1,13 @@
 import type { NextConfig } from "next";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// The site imports the repo-level metrics ledger (`src/lib/metrics.ts` reads
+// ../../../metrics/current.json), so Turbopack's resolution root has to be the
+// repo, not the site directory. Derived from this file's own location rather
+// than from cwd: `path.resolve(".")` silently changed meaning depending on
+// whether the build was invoked from the repo root or from site/.
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 // Content Security Policy.
 //
@@ -35,7 +43,7 @@ const SECURITY_HEADERS = [
 
 const nextConfig: NextConfig = {
   turbopack: {
-    root: path.resolve("."),
+    root: REPO_ROOT,
   },
   // Strip the X-Powered-By: Next.js leak from response headers.
   poweredByHeader: false,


### PR DESCRIPTION
## The break

`npm run build:site` fails on `main` and has since #60 (2026-07-27):

```
./src/lib/metrics.ts:1:1
Module not found: Can't resolve '../../../metrics/current.json'
```

#60 added `site/src/lib/metrics.ts` so the site reads the repo-level metrics ledger instead of hardcoding counts — the right change. But `site/next.config.ts` pins Turbopack's resolution root to the **site** directory, so an import reaching up into `metrics/` escapes the root and cannot resolve.

`build:site` is part of `npm run verify`, the documented pre-push gate. That gate has been red for every change since 2026-07-27, which is a large part of why quality drift isn't being caught locally.

## The fix

Root Turbopack at the repo, derived from the config file's own location rather than from cwd:

```ts
const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
```

The previous `path.resolve(".")` was cwd-dependent — it resolved to a different directory depending on whether the build was invoked from the repo root (`npm run build:site`) or from inside `site/`. That ambiguity is why the breakage was easy to miss.

## Verification

| Invocation | Before | After |
|---|---|---|
| `npm run build:site` (repo root) | fails — module not found | exit 0 |
| `npm run build` (from `site/`) | fails — module not found | exit 0 |

## Why this is a draft until Vercel reports

Production currently deploys green from `main`, so Vercel resolves this import somehow that a local build does not. This PR changes build configuration for the live site, so I am not merging on local evidence alone — the `site` preview deployment on this PR is the check that matters. If the preview is green, the fix is safe in both environments and this can go ready.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RSdpyUzveSchNiLWPMczJW)_