### PR TITLE
Site excellence pass: honest evidence console, mobile overflow fixes, type-scale consistency

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -88,4 +88,8 @@ git merge upstream/main
 
 Review the diff and let Vercel create a preview before merging changes into the production branch.
 
+## Design authority
+
+`taste.md` (repo root) governs judgment; `site/DESIGN.md` governs the visual system. Read both before UI work.
+
 **Built on SIP — Starlight Intelligence Protocol v1.1.1**

--- a/site/src/app/docs/page.tsx
+++ b/site/src/app/docs/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 export default function DocsPage() {
   return (
     <div className="mx-auto max-w-3xl px-6 py-16">
-      <h1 className="text-2xl font-bold text-white">Documentation</h1>
+      <h1 className="text-3xl font-semibold leading-tight text-white md:text-4xl">Documentation</h1>
       <p className="mt-2 text-[14px] text-slate-500">
         Everything you need to deploy, configure, and connect.
       </p>

--- a/site/src/app/globals.css
+++ b/site/src/app/globals.css
@@ -225,7 +225,7 @@ body {
   position: absolute;
   right: 8.5%;
   bottom: 9%;
-  width: 14rem;
+  width: min(14rem, 42vw);
   border: 1px solid rgba(255, 255, 255, 0.1);
   background: rgba(3, 7, 18, 0.64);
   box-shadow: 0 18px 42px rgba(0, 0, 0, 0.22);

--- a/site/src/app/page.tsx
+++ b/site/src/app/page.tsx
@@ -443,7 +443,7 @@ export default async function HomePage() {
             </p>
           </div>
 
-          <div className="mt-10 grid gap-3 lg:grid-cols-5">
+          <div className="mt-10 grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
             {OPERATING_STEPS.map((step, index) => {
               const Icon = step.icon;
               return (

--- a/site/src/app/queen/page.tsx
+++ b/site/src/app/queen/page.tsx
@@ -22,11 +22,11 @@ export default function QueenPage() {
             <div className="inline-flex items-center gap-2 rounded-full border border-cyan-400/20 bg-cyan-400/5 px-4 py-1 text-xs tracking-[3px] text-cyan-400 mb-6">
               STARLIGHT ORCHESTRATOR • v0.2
             </div>
-            <h1 className="font-serif text-[72px] md:text-[92px] leading-[0.9] tracking-[-4.5px] text-white mb-6">
+            <h1 className="font-serif text-5xl sm:text-6xl md:text-[92px] leading-[0.95] md:leading-[0.9] tracking-tight md:tracking-[-4.5px] text-white mb-6">
               The Starlight<br />Queen &amp; Her Swarms
             </h1>
-            <p className="max-w-2xl text-2xl text-zinc-400 tracking-tight mb-10">
-              The orchestrator at the center of the substrate — routing work across every agent,<br />running parallel review swarms, and keeping a ledger of what actually shipped.
+            <p className="max-w-2xl text-lg sm:text-xl md:text-2xl text-zinc-400 tracking-tight mb-10">
+              The orchestrator at the center of the substrate — routing work across every agent,<span className="hidden md:inline"><br /></span> running parallel review swarms, and keeping a ledger of what actually shipped.
             </p>
             <div className="flex flex-wrap items-center gap-4">
               <a href="#the-loop" className="inline-flex items-center gap-3 rounded-2xl bg-white px-9 py-4 text-lg font-medium tracking-tight text-[#0a0a0f] hover:bg-zinc-200 active:scale-[0.985] transition">
@@ -42,7 +42,7 @@ export default function QueenPage() {
 
         {/* Hero visual — wired premium generated L99 asset */}
         <div className="absolute inset-y-0 right-0 w-full md:w-[58%] opacity-90">
-          <img src="/assets/visuals/08-readme-hero.jpg" alt="One substrate — every CLI shares attested memory" className="h-full w-full object-cover" />
+          <img src="/assets/visuals/08-readme-hero.jpg" alt="One substrate — every CLI shares attested memory" className="h-full w-full object-cover" width={1920} height={1080} loading="eager" />
           <div className="absolute inset-0 bg-gradient-to-r from-[#0a0a0f] via-[#0a0a0f]/85 to-[#0a0a0f]/40" />
           <div className="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-[#0a0a0f]" />
         </div>
@@ -64,7 +64,7 @@ export default function QueenPage() {
           <div className="mb-10 flex items-end justify-between">
             <div>
               <div className="text-xs tracking-[3px] text-cyan-400">THE CONTINUOUS CYCLE</div>
-              <h2 className="mt-2 font-serif text-6xl tracking-[-2.2px]">The Queen Loop</h2>
+              <h2 className="mt-2 font-serif text-4xl sm:text-5xl md:text-6xl tracking-tight md:tracking-[-2.2px]">The Queen Loop</h2>
             </div>
             <div className="hidden text-right text-sm text-zinc-400 md:block max-w-[280px]">
               ROUTE → MEASURE → LEARN → RATIFY → LEDGER<br />
@@ -137,13 +137,13 @@ export default function QueenPage() {
       <section className="border-t border-white/10 py-16">
         <div className="mx-auto max-w-6xl px-8">
           <div className="grid gap-10 md:grid-cols-2">
-            <div>
+            <div className="min-w-0">
               <div className="text-xs tracking-[3px] text-amber-400">DISTRIBUTED INTELLIGENCE</div>
-              <h2 className="mt-2 font-serif text-5xl tracking-[-1.8px]">Her Swarms</h2>
+              <h2 className="mt-2 font-serif text-4xl sm:text-5xl tracking-tight md:tracking-[-1.8px]">Her Swarms</h2>
               <p className="mt-5 text-xl text-zinc-400">The Queen never works alone. Subagent swarms (Grok-native parallelism) execute MEASURE and LEARN concurrently while the Visual Composition Layer turns every tick into a permanent, attested artifact.</p>
             </div>
-            <div>
-              <QueenSwarm className="w-full aspect-[16/9.6] rounded-3xl border border-white/10" phase="measure" interactive />
+            <div className="min-w-0">
+              <QueenSwarm className="w-full max-w-full aspect-[16/9.6] rounded-3xl border border-white/10" phase="measure" interactive />
               <div className="mt-2 text-[10px] text-white/50 tracking-widest">LIVE INTERACTIVE — MOVE CURSOR TO CONDUCT.</div>
             </div>
           </div>

--- a/site/src/app/sitemap.ts
+++ b/site/src/app/sitemap.ts
@@ -31,6 +31,7 @@ const STATIC_ROUTES = [
   "/asteroids",
   "/queen",
   "/palace",
+  "/yolo",
 ] as const;
 
 const VERTICAL_SLUGS = [

--- a/site/src/app/vaults/page.tsx
+++ b/site/src/app/vaults/page.tsx
@@ -26,7 +26,7 @@ export default async function VaultsPage() {
 
   return (
     <div className="mx-auto max-w-5xl px-6 py-16">
-      <h1 className="text-2xl font-bold text-white">Public Vaults</h1>
+      <h1 className="text-3xl font-semibold leading-tight text-white md:text-4xl">Public Vaults</h1>
       <p className="mt-2 text-[14px] text-slate-500">
         Memory gardens from builders and thinkers. Each vault is a collection
         of insights readable by humans and agents.

--- a/site/src/components/OperationalProofConsole.tsx
+++ b/site/src/components/OperationalProofConsole.tsx
@@ -13,6 +13,7 @@ import {
   Terminal,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
+import { CURRENT_METRICS, METRICS_AS_OF } from "@/lib/metrics";
 
 type ProofLane = {
   label: string;
@@ -25,8 +26,8 @@ type ProofLane = {
 const PROOF_LANES: ProofLane[] = [
   {
     label: "Memory",
-    value: "6 vaults",
-    state: "context locked",
+    value: `${CURRENT_METRICS.vaults} vaults`,
+    state: "source-counted",
     icon: Database,
     tone: "text-blue-600",
   },
@@ -39,7 +40,7 @@ const PROOF_LANES: ProofLane[] = [
   },
   {
     label: "Evals",
-    value: "0.97 score",
+    value: "scored runs",
     state: "evidence kept",
     icon: Activity,
     tone: "text-amber-600",
@@ -53,20 +54,20 @@ const PROOF_LANES: ProofLane[] = [
   },
   {
     label: "Release",
-    value: "READY",
-    state: "rebuildable",
+    value: "rebuildable",
+    state: "manifest linked",
     icon: FileCheck2,
     tone: "text-rose-600",
   },
 ];
 
 const TRACE_EVENTS = [
-  ["00:00", "intent captured", "source: operator"],
-  ["00:12", "memory recall", "semantic + temporal"],
-  ["00:27", "trace linked", "run graph captured"],
-  ["00:43", "eval scored", "policy and provenance"],
-  ["01:04", "gate cleared", "human review held"],
-  ["01:28", "deployment ready", "manifest + source linked"],
+  ["01", "intent captured", "source: operator"],
+  ["02", "memory recall", "semantic + temporal"],
+  ["03", "trace linked", "run graph captured"],
+  ["04", "eval scored", "policy and provenance"],
+  ["05", "gate cleared", "human review held"],
+  ["06", "deployment ready", "manifest + source linked"],
 ];
 
 const FLOW_NODES = [
@@ -134,7 +135,7 @@ export function OperationalProofConsole() {
     <motion.figure
       ref={rootRef}
       role="img"
-      aria-label="Starlight release room console showing memory recall, trace, evaluation, governance gate, and deployment readiness."
+      aria-label="Schematic of the Starlight release loop: memory recall, trace, evaluation, governance gate, then deployment readiness. Illustrative sequence, not a live run."
       className="relative overflow-hidden rounded-lg border border-slate-200 bg-white text-slate-950 shadow-[0_28px_90px_rgba(15,23,42,0.18)]"
       initial={reducedMotion ? false : { opacity: 0, y: 18, scale: 0.985 }}
       animate={{ opacity: 1, y: 0, scale: 1 }}
@@ -152,13 +153,13 @@ export function OperationalProofConsole() {
                 SIS release room
               </p>
               <p className="text-sm font-semibold text-white">
-                Verified release run
+                The release loop
               </p>
             </div>
           </div>
           <div className="inline-flex items-center gap-2 rounded-md bg-emerald-400/12 px-3 py-1.5 text-xs font-semibold text-emerald-100">
             <BadgeCheck size={14} aria-hidden="true" />
-            Governance clear
+            Operator-held gate
           </div>
         </div>
       </div>
@@ -170,9 +171,9 @@ export function OperationalProofConsole() {
               <p className="font-mono text-[11px] uppercase text-slate-500">
                 Release route
               </p>
-              <h2 className="mt-1 text-xl font-semibold text-slate-950">
+              <p className="mt-1 text-xl font-semibold text-slate-950">
                 Memory becomes a release packet.
-              </h2>
+              </p>
             </div>
             <span className="rounded-md border border-slate-200 px-2.5 py-1 font-mono text-[11px] text-slate-600">
               main
@@ -281,7 +282,7 @@ export function OperationalProofConsole() {
               Release ledger
             </p>
             <span className="rounded-md bg-cyan-300/12 px-2.5 py-1 font-mono text-[11px] text-cyan-100">
-              release confidence 0.97
+              ledger verified {METRICS_AS_OF}
             </span>
           </div>
 
@@ -324,7 +325,8 @@ export function OperationalProofConsole() {
               />
             </div>
             <p className="mt-3 text-xs leading-relaxed text-slate-400">
-              State sequence: recall, trace, score, gate, then release.
+              Illustrative sequence: recall, trace, score, gate, then release.
+              Counts read from the source-verified ledger.
             </p>
           </div>
         </div>

--- a/site/src/components/QueenSwarm.tsx
+++ b/site/src/components/QueenSwarm.tsx
@@ -56,8 +56,8 @@ export function QueenSwarm({ className = "", phase = "conduct", interactive = tr
 
     const resize = () => {
       const rect = container.getBoundingClientRect();
-      width = Math.max(560, Math.floor(rect.width));
-      height = Math.max(420, Math.floor(rect.height));
+      width = Math.max(1, Math.floor(rect.width));
+      height = Math.max(1, Math.floor(rect.height));
       canvas.width = width * window.devicePixelRatio;
       canvas.height = height * window.devicePixelRatio;
       canvas.style.width = `${width}px`;


### PR DESCRIPTION
Production-site quality pass on `site/`, run through the five-phase release gate (capture → decide → build → audit → prove). Direction: **evidence-first refinement within the existing taste.md/DESIGN.md system** — chosen over a visual re-skin (violates restraint) and over adding testimonial sections (no citable social-proof data exists; inventing it would violate the Metrics Truth Rule).

## The headline fix — the Evidence section now tells the truth

The homepage says *"You should be able to check the work"* next to `OperationalProofConsole`, which hardcoded **invented evidence**: a fake `0.97 score`, `release confidence 0.97`, fabricated trace timestamps, and a "Verified release run" framing. That directly violated `taste.md` ("visual confidence is never a substitute for cited evidence") and `site/DESIGN.md` §0 (no invented-evidence surfaces). Now:

- Vault count reads from `src/lib/metrics.ts` (the fail-closed ledger) instead of a hardcoded string
- Fake score/confidence figures removed; the badge shows `ledger verified {METRICS_AS_OF}`
- The figure is explicitly labeled an **illustrative sequence** in both aria-label and caption
- Stray `h2` inside the `figure` demoted to `p` (was competing with the section heading)

## Mobile + consistency fixes (measured, not guessed)

- **`/queen` had 457px of horizontal overflow at 375px** (Playwright-measured): fixed 72px hero type with hard `<br>`, plus the `QueenSwarm` canvas forcing a 560px minimum width inside a grid track. Responsive type scale + `min-w-0` grid children + canvas floor removed → **0px overflow at 375/768/1440** after.
- Homepage 5-step operating loop gains a `sm:grid-cols-2` tablet step (was a long 1-column run below `lg`).
- `/docs` and `/vaults` H1s raised from bare `text-2xl` to the system display scale.
- `.command-readout` fixed 14rem width clamped to `min(14rem, 42vw)`.
- `sitemap.ts` gains `/yolo`; `site/README.md` replaces create-next-app boilerplate with the actual build contracts.

## Gate receipt

```
Direction:  evidence-first refinement (beat: re-skin, invented social proof)
Changed:    9 files under site/
Audit:      taste.md invented-evidence violation fixed; heading semantics fixed;
            layout/metrics/install/deploy contracts untouched and passing
Motion:     no motion added; existing reduced-motion paths preserved
Vitals:     /queen hero img gains width/height + eager loading (was bare )
Visual:     before/after at 375/768/1440 on / and /queen (session artifacts);
            /queen@375 horizontal overflow 457px -> 0px
Open:       motion durations in globals.css still exceed taste.md budget
            (300/500ms vs 180-260/300-420) — global change, left deliberate;
            /queen page still runs its own zinc-based palette
```

**2026-08-25 — rebased onto current `main` (383c635, includes #103/#104's Vercel-deploy-product work) per Queen /si triage instruction.** `site/README.md` conflict resolved by keeping main's newer deploy-flow doc and folding this PR's "Design authority" pointer (taste.md/DESIGN.md) into it. `npm run build` re-verified green — all four fail-closed contracts (metrics, public-install, layout, deploy) pass, `next build` generates all 84 pages clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYLKNfybke8GJ7qq74BAD9

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYLKNfybke8GJ7qq74BAD9)_