### PR TITLE
fix(site): preserve split-heading accessible names

### DIFF
--- a/site/scripts/check-layout-contract.mjs
+++ b/site/scripts/check-layout-contract.mjs
@@ -17,6 +17,10 @@ const protocolPage = readFileSync(
   join(SITE_ROOT, "src/app/protocol/page.tsx"),
   "utf8",
 );
+const homePage = readFileSync(
+  join(SITE_ROOT, "src/app/page.tsx"),
+  "utf8",
+);
 
 const failures = [];
 
@@ -51,6 +55,17 @@ if (/Start from\s*<br\s*\/?>/.test(downloadPage)) {
   );
 }
 
+if (
+  !homePage.includes(
+    'aria-label="Models learn from what we leave behind."',
+  ) ||
+  !homePage.includes('aria-label="Take the substrate. Keep the keys."')
+) {
+  failures.push(
+    "the homepage split-style headings must expose complete accessible names with semantic spaces",
+  );
+}
+
 if (!protocolPage.includes("overflow-x-auto")) {
   failures.push(
     "intentional table and pre horizontal scrollers must remain available",
@@ -64,5 +79,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  "Layout contract passed: the final navigation panel stays in-viewport, semantic heading spacing is explicit, and nested scrollers remain.",
+  "Layout contract passed: the final navigation panel stays in-viewport, split-style headings expose semantic spaces, and nested scrollers remain.",
 );

--- a/site/src/app/page.tsx
+++ b/site/src/app/page.tsx
@@ -524,7 +524,10 @@ export default async function HomePage() {
           <div className="flex justify-center">
             <StarlightMark size={34} />
           </div>
-          <h2 className="mt-7 text-center text-3xl font-semibold leading-tight md:text-5xl">
+          <h2
+            aria-label="Models learn from what we leave behind."
+            className="mt-7 text-center text-3xl font-semibold leading-tight md:text-5xl"
+          >
             Models learn from{" "}
             <span className="bg-gradient-to-r from-violet-300 to-cyan-300 bg-clip-text font-serif italic text-transparent">
               what we leave behind.
@@ -693,7 +696,10 @@ export default async function HomePage() {
         </div>
         <div className="relative mx-auto max-w-4xl text-center">
           <SectionKicker icon={BadgeCheck}>Start Here</SectionKicker>
-          <h2 className="mt-5 text-3xl font-semibold leading-tight md:text-5xl">
+          <h2
+            aria-label="Take the substrate. Keep the keys."
+            className="mt-5 text-3xl font-semibold leading-tight md:text-5xl"
+          >
             Take the substrate.{" "}
             <span className="bg-gradient-to-r from-violet-300 to-cyan-300 bg-clip-text font-serif italic text-transparent">
               Keep the keys.


### PR DESCRIPTION
## Summary

Fixes #73 by giving the two split-style homepage headings explicit, complete accessible names while preserving their existing visual markup and typography.

The layout contract now fails if either semantic name regresses.

## Exact scope

- `site/src/app/page.tsx`
  - `Models learn from what we leave behind.`
  - `Take the substrate. Keep the keys.`
- `site/scripts/check-layout-contract.mjs`
  - static regression assertions for both complete names

## Validation

- RED phase reproduced before implementation:
  - `node site/scripts/check-layout-contract.mjs` failed on the missing accessible-name contract
- GREEN phase:
  - layout contract passed
  - `npm --prefix site run lint` passed with zero errors; five existing `no-img-element` warnings remain outside this change
  - `CI=1 NEXT_TELEMETRY_DISABLED=1 npm --prefix site run build` passed
  - 87 static pages generated
  - emitted `site/.next/server/app/index.html` contains both exact `aria-label` values
  - `npm --prefix site audit --omit=dev --audit-level=critical` exited 0 with no critical findings
  - Anti-Slop verifier scored 85/100; its existing warning is the site's lack of a noise/grain overlay, unrelated to this non-visual accessibility patch

## Residual security follow-up

The production dependency audit reports four existing high-severity findings in the site dependency graph (`next`, `postcss`, `sharp`, and `nanoid`). They are not introduced by this two-file patch and should be remediated in a separate dependency PR rather than mixed into the accessibility fix.

## Risk and rollback

Low risk: accessibility-tree metadata and a static contract only; visible copy and styling are unchanged.

Rollback is a single revert of this commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen reader accessibility for Mission and Final CTA section headings.
  * Ensured split-style homepage headings provide complete, semantically spaced accessible names.
* **Bug Fixes**
  * Updated layout validation to check homepage heading accessibility requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->