### PR TITLE
Block new repository media debt

### DIFF
--- a/.github/workflows/media-guard.yml
+++ b/.github/workflows/media-guard.yml
@@ -1,8 +1,9 @@
 name: Media Guard
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main, staging]
+    types: [opened, synchronize, reopened, ready_for_review, edited, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -13,10 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - name: Check out trusted base policy
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           fetch-depth: 0
+          path: trusted-base
           persist-credentials: false
+          ref: ${{ github.event.pull_request.base.sha }}
 
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
@@ -25,8 +29,44 @@ jobs:
           # packageManager metadata and requires pnpm before this no-install job.
           package-manager-cache: false
 
-      - name: Media guard regression contract
-        run: node --test scripts/tests/media-guard.test.mjs
+      - name: Stage trusted policy outside the PR workspace
+        run: |
+          install -d "$RUNNER_TEMP/media-guard/scripts/tests"
+          install -m 0644 trusted-base/scripts/media-guard.mjs "$RUNNER_TEMP/media-guard/scripts/media-guard.mjs"
+          install -m 0644 trusted-base/scripts/tests/media-guard.contract.mjs "$RUNNER_TEMP/media-guard/scripts/tests/media-guard.contract.mjs"
 
-      - name: Reject repository media debt
-        run: node scripts/media-guard.mjs --base ${{ github.event.pull_request.base.sha }}
+      - name: Verify trusted policy regression contract
+        run: node --test "$RUNNER_TEMP/media-guard/scripts/tests/media-guard.contract.mjs"
+
+      - name: Check out untrusted PR tree without executing it
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          fetch-depth: 0
+          path: pr-head
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Verify immutable comparison commits
+        working-directory: pr-head
+        env:
+          EXPECTED_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
+          git -c protocol.file.allow=always fetch --no-tags ../trusted-base "$EXPECTED_BASE_SHA"
+          git cat-file -e "${EXPECTED_BASE_SHA}^{commit}"
+
+      - name: Reject repository media debt with trusted policy
+        working-directory: pr-head
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          # Break glass: a maintainer must apply this label to an owner/member/
+          # collaborator PR. Label changes rerun the trusted base workflow.
+          POLICY_UPDATE_APPROVED: ${{ contains(github.event.pull_request.labels.*.name, 'media-policy-change-approved') && (github.event.pull_request.author_association == 'OWNER' || github.event.pull_request.author_association == 'MEMBER' || github.event.pull_request.author_association == 'COLLABORATOR') }}
+        run: |
+          policy_arguments=(--protect-policy)
+          if [[ "$POLICY_UPDATE_APPROVED" == "true" ]]; then
+            policy_arguments=()
+          fi
+          node "$RUNNER_TEMP/media-guard/scripts/media-guard.mjs" "${policy_arguments[@]}" --base "$BASE_SHA"

--- a/.github/workflows/media-guard.yml
+++ b/.github/workflows/media-guard.yml
@@ -61,9 +61,9 @@ jobs:
         working-directory: pr-head
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          # Break glass: a maintainer must apply this label to an owner/member/
-          # collaborator PR. Label changes rerun the trusted base workflow.
-          POLICY_UPDATE_APPROVED: ${{ contains(github.event.pull_request.labels.*.name, 'media-policy-change-approved') && (github.event.pull_request.author_association == 'OWNER' || github.event.pull_request.author_association == 'MEMBER' || github.event.pull_request.author_association == 'COLLABORATOR') }}
+          # Break glass is exact-head: a maintainer must remove/reapply this
+          # label after each push to an owner/member/collaborator policy PR.
+          POLICY_UPDATE_APPROVED: ${{ github.event.action == 'labeled' && github.event.label.name == 'media-policy-change-approved' && (github.event.pull_request.author_association == 'OWNER' || github.event.pull_request.author_association == 'MEMBER' || github.event.pull_request.author_association == 'COLLABORATOR') }}
         run: |
           policy_arguments=(--protect-policy)
           if [[ "$POLICY_UPDATE_APPROVED" == "true" ]]; then

--- a/.github/workflows/media-guard.yml
+++ b/.github/workflows/media-guard.yml
@@ -1,0 +1,30 @@
+name: Media Guard
+
+on:
+  pull_request:
+    branches: [main, staging]
+
+permissions:
+  contents: read
+
+jobs:
+  media-guard:
+    name: Media Guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: '22'
+          package-manager-cache: false
+
+      - name: Media guard regression contract
+        run: node --test scripts/tests/media-guard.test.mjs
+
+      - name: Reject repository media debt
+        run: node scripts/media-guard.mjs --base origin/${{ github.base_ref }}

--- a/.github/workflows/media-guard.yml
+++ b/.github/workflows/media-guard.yml
@@ -21,10 +21,9 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: '22'
-          package-manager-cache: false
 
       - name: Media guard regression contract
         run: node --test scripts/tests/media-guard.test.mjs
 
       - name: Reject repository media debt
-        run: node scripts/media-guard.mjs --base origin/${{ github.base_ref }}
+        run: node scripts/media-guard.mjs --base ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/media-guard.yml
+++ b/.github/workflows/media-guard.yml
@@ -21,6 +21,9 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: '22'
+          # setup-node v5 otherwise auto-enables package-manager caching from
+          # packageManager metadata and requires pnpm before this no-install job.
+          package-manager-cache: false
 
       - name: Media guard regression contract
         run: node --test scripts/tests/media-guard.test.mjs

--- a/memory/vaults/operational-vault.md
+++ b/memory/vaults/operational-vault.md
@@ -749,6 +749,9 @@ Coordination note: website + SIS film/foundry lanes are actively stewarded by si
 ## 2026-08-10 — Portfolio media governance guard
 
 **Source:** Codex portfolio storage audit and Wave 1 execution  
+**Category:** portfolio-ops / media-governance  
+**Confidence:** 1.0  
+**Related:** `frankxai/agentic-ops#8`, `frankxai/agentic-ops#9`, `frankxai/Starlight-Intelligence-System#77`  
 **Class:** operational; no SIP substrate contract changed
 
 **Decision:** New repository media debt is now fail-closed at pull-request time. Browser-ready images/fonts stay in Git only below strict size ceilings; large audio, video, PDFs, originals, and compressed/source archives must use the portfolio object-store path. The guard checks renamed destinations, symlinks, compound archives, unclassified media, and workflow-command escaping, with an executable twenty-four-scenario regression contract covering trusted-base execution, controlled and nested roots, Git type changes, symlink/gitlink/LFS rejection, bounded sidecars, and per-file/per-PR byte budgets.

--- a/memory/vaults/operational-vault.md
+++ b/memory/vaults/operational-vault.md
@@ -751,7 +751,7 @@ Coordination note: website + SIS film/foundry lanes are actively stewarded by si
 **Source:** Codex portfolio storage audit and Wave 1 execution  
 **Class:** operational; no SIP substrate contract changed
 
-**Decision:** New repository media debt is now fail-closed at pull-request time. Browser-ready images/fonts stay in Git only below strict size ceilings; large audio, video, PDFs, originals, and compressed/source archives must use the portfolio object-store path. The guard checks renamed destinations, symlinks, compound archives, unclassified media, and workflow-command escaping, with an executable eight-scenario regression contract.
+**Decision:** New repository media debt is now fail-closed at pull-request time. Browser-ready images/fonts stay in Git only below strict size ceilings; large audio, video, PDFs, originals, and compressed/source archives must use the portfolio object-store path. The guard checks renamed destinations, symlinks, compound archives, unclassified media, and workflow-command escaping, with an executable nine-scenario regression contract.
 
 **State:** This PR adds only the enforcement boundary. Existing bytes and public URLs remain untouched. The shared R2 control-plane proposal is under review in `frankxai/agentic-ops#8`; no bucket, domain, Worker, asset, or production route has been mutated from this repository.
 

--- a/memory/vaults/operational-vault.md
+++ b/memory/vaults/operational-vault.md
@@ -751,7 +751,7 @@ Coordination note: website + SIS film/foundry lanes are actively stewarded by si
 **Source:** Codex portfolio storage audit and Wave 1 execution  
 **Class:** operational; no SIP substrate contract changed
 
-**Decision:** New repository media debt is now fail-closed at pull-request time. Browser-ready images/fonts stay in Git only below strict size ceilings; large audio, video, PDFs, originals, and compressed/source archives must use the portfolio object-store path. The guard checks renamed destinations, symlinks, compound archives, unclassified media, and workflow-command escaping, with an executable fourteen-scenario regression contract covering controlled roots and an explicit safe-sidecar allowlist.
+**Decision:** New repository media debt is now fail-closed at pull-request time. Browser-ready images/fonts stay in Git only below strict size ceilings; large audio, video, PDFs, originals, and compressed/source archives must use the portfolio object-store path. The guard checks renamed destinations, symlinks, compound archives, unclassified media, and workflow-command escaping, with an executable twenty-four-scenario regression contract covering trusted-base execution, controlled and nested roots, Git type changes, symlink/gitlink/LFS rejection, bounded sidecars, and per-file/per-PR byte budgets.
 
 **State:** This PR adds only the enforcement boundary. Existing bytes and public URLs remain untouched. The shared R2 control plane merged in `frankxai/agentic-ops#8`; provisioning remains credential-gated, so no bucket, domain, Worker, asset, or production route has been mutated from this repository.
 

--- a/memory/vaults/operational-vault.md
+++ b/memory/vaults/operational-vault.md
@@ -744,6 +744,23 @@ Coordination note: website + SIS film/foundry lanes are actively stewarded by si
 
 **Built on SIP — Starlight Intelligence Protocol**
 
+---
+
+## 2026-08-10 — Portfolio media governance guard
+
+**Source:** Codex portfolio storage audit and Wave 1 execution  
+**Class:** operational; no SIP substrate contract changed
+
+**Decision:** New repository media debt is now fail-closed at pull-request time. Browser-ready images/fonts stay in Git only below strict size ceilings; large audio, video, PDFs, originals, and compressed/source archives must use the portfolio object-store path. The guard checks renamed destinations, symlinks, compound archives, unclassified media, and workflow-command escaping, with an executable six-scenario regression contract.
+
+**State:** This PR adds only the enforcement boundary. Existing bytes and public URLs remain untouched. The shared R2 control-plane proposal is under review in `frankxai/agentic-ops#8`; no bucket, domain, Worker, asset, or production route has been mutated from this repository.
+
+**Next:** After the control plane is approved and staging is provisioned, inventory the site from the exact default-branch tree, upload content-addressed copies, verify remote metadata plus sampled hashes, and cut over references in a separate reversible PR. Preserve originals through the production observation window.
+
+**Built on SIP** — Starlight Intelligence Protocol
+
+---
+
 ## 2026-08-14 - Automation-layer audit: silence reads as health; first dead-man's switch shipped
 
 **Category:** portfolio-ops

--- a/memory/vaults/operational-vault.md
+++ b/memory/vaults/operational-vault.md
@@ -751,9 +751,9 @@ Coordination note: website + SIS film/foundry lanes are actively stewarded by si
 **Source:** Codex portfolio storage audit and Wave 1 execution  
 **Class:** operational; no SIP substrate contract changed
 
-**Decision:** New repository media debt is now fail-closed at pull-request time. Browser-ready images/fonts stay in Git only below strict size ceilings; large audio, video, PDFs, originals, and compressed/source archives must use the portfolio object-store path. The guard checks renamed destinations, symlinks, compound archives, unclassified media, and workflow-command escaping, with an executable nine-scenario regression contract.
+**Decision:** New repository media debt is now fail-closed at pull-request time. Browser-ready images/fonts stay in Git only below strict size ceilings; large audio, video, PDFs, originals, and compressed/source archives must use the portfolio object-store path. The guard checks renamed destinations, symlinks, compound archives, unclassified media, and workflow-command escaping, with an executable fourteen-scenario regression contract covering controlled roots and an explicit safe-sidecar allowlist.
 
-**State:** This PR adds only the enforcement boundary. Existing bytes and public URLs remain untouched. The shared R2 control-plane proposal is under review in `frankxai/agentic-ops#8`; no bucket, domain, Worker, asset, or production route has been mutated from this repository.
+**State:** This PR adds only the enforcement boundary. Existing bytes and public URLs remain untouched. The shared R2 control plane merged in `frankxai/agentic-ops#8`; provisioning remains credential-gated, so no bucket, domain, Worker, asset, or production route has been mutated from this repository.
 
 **Next:** After the control plane is approved and staging is provisioned, inventory the site from the exact default-branch tree, upload content-addressed copies, verify remote metadata plus sampled hashes, and cut over references in a separate reversible PR. Preserve originals through the production observation window.
 

--- a/memory/vaults/operational-vault.md
+++ b/memory/vaults/operational-vault.md
@@ -751,7 +751,7 @@ Coordination note: website + SIS film/foundry lanes are actively stewarded by si
 **Source:** Codex portfolio storage audit and Wave 1 execution  
 **Class:** operational; no SIP substrate contract changed
 
-**Decision:** New repository media debt is now fail-closed at pull-request time. Browser-ready images/fonts stay in Git only below strict size ceilings; large audio, video, PDFs, originals, and compressed/source archives must use the portfolio object-store path. The guard checks renamed destinations, symlinks, compound archives, unclassified media, and workflow-command escaping, with an executable six-scenario regression contract.
+**Decision:** New repository media debt is now fail-closed at pull-request time. Browser-ready images/fonts stay in Git only below strict size ceilings; large audio, video, PDFs, originals, and compressed/source archives must use the portfolio object-store path. The guard checks renamed destinations, symlinks, compound archives, unclassified media, and workflow-command escaping, with an executable eight-scenario regression contract.
 
 **State:** This PR adds only the enforcement boundary. Existing bytes and public URLs remain untouched. The shared R2 control-plane proposal is under review in `frankxai/agentic-ops#8`; no bucket, domain, Worker, asset, or production route has been mutated from this repository.
 

--- a/scripts/media-guard.mjs
+++ b/scripts/media-guard.mjs
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process"
-import { existsSync, lstatSync } from "node:fs"
+import { lstatSync } from "node:fs"
 import { extname } from "node:path"
 
 const MIB = 1024 * 1024
@@ -52,7 +52,7 @@ const prohibitedSuffixes = [
   ".zip",
 ]
 
-const controlledMediaPath = /(?:^|\/)(?:audio|downloads?|fonts?|images?|media|video)(?:\/|$)/i
+const controlledMediaPath = /(?:^|\/)(?:audios?|downloads?|fonts?|images?|media|videos?)(?:\/|$)/i
 const allowedMediaSidecars = new Set([".css", ".csv", ".json", ".lrc", ".md", ".srt", ".txt", ".vtt", ".xml"])
 
 function parseBaseArgument() {
@@ -102,6 +102,17 @@ function escapeWorkflowCommandProperty(value) {
     .replace(/,/g, "%2C")
 }
 
+function escapeWorkflowCommandMessage(value) {
+  return value
+    .replace(/%/g, "%25")
+    .replace(/\r/g, "%0D")
+    .replace(/\n/g, "%0A")
+}
+
+function formatLogValue(value) {
+  return JSON.stringify(value)
+}
+
 function prohibitedSuffix(file) {
   const lower = file.toLowerCase()
   return prohibitedSuffixes.find((suffix) => lower.endsWith(suffix)) || null
@@ -111,8 +122,6 @@ const files = changedFiles()
 const violations = []
 
 for (const file of files) {
-  if (!existsSync(file)) continue
-
   const extension = extname(file).toLowerCase()
   const stats = lstatSync(file)
   const size = stats.size
@@ -158,9 +167,11 @@ for (const file of files) {
 if (violations.length > 0) {
   console.error("Media policy violations:\n")
   for (const violation of violations) {
-    console.error(`- ${violation.file} (${formatMiB(violation.size)}): ${violation.reason}`)
     console.error(
-      `::error file=${escapeWorkflowCommandProperty(violation.file)}::${violation.reason}; file size ${formatMiB(violation.size)}`,
+      `- ${formatLogValue(violation.file)} (${formatMiB(violation.size)}): ${formatLogValue(violation.reason)}`,
+    )
+    console.error(
+      `::error file=${escapeWorkflowCommandProperty(violation.file)}::${escapeWorkflowCommandMessage(violation.reason)}; file size ${formatMiB(violation.size)}`,
     )
   }
   console.error(

--- a/scripts/media-guard.mjs
+++ b/scripts/media-guard.mjs
@@ -1,8 +1,13 @@
 import { execFileSync } from "node:child_process"
-import { lstatSync } from "node:fs"
+import { lstatSync, readFileSync } from "node:fs"
 import { extname } from "node:path"
 
 const MIB = 1024 * 1024
+const KIB = 1024
+const MAX_SIDECAR_BYTES = 512 * KIB
+const MAX_GENERIC_FILE_BYTES = 2 * MIB
+const MAX_GOVERNED_CHANGE_BYTES = 5 * MIB
+const MAX_TOTAL_CHANGE_BYTES = 20 * MIB
 
 const limits = new Map([
   [".avif", 1 * MIB],
@@ -52,8 +57,13 @@ const prohibitedSuffixes = [
   ".zip",
 ]
 
-const controlledMediaRoot = /^(?:public|generated_audio|generated_imgs)(?:\/|$)|^content\/music\/source(?:\/|$)/i
+const controlledMediaRoot = /(?:^|\/)(?:public|generated_audio|generated_imgs)(?:\/|$)|(?:^|\/)content\/music\/source(?:\/|$)/i
 const controlledMediaPath = /(?:^|\/)(?:audios?|downloads?|fonts?|images?|media|videos?)(?:\/|$)/i
+const protectedPolicyFiles = new Set([
+  ".github/workflows/media-guard.yml",
+  "scripts/media-guard.mjs",
+  "scripts/tests/media-guard.contract.mjs",
+])
 const allowedMediaSidecars = new Set([
   ".css",
   ".csv",
@@ -81,6 +91,10 @@ function parseBaseArgument() {
   return value
 }
 
+function protectPolicyFiles() {
+  return process.argv.includes("--protect-policy")
+}
+
 function hasRef(ref) {
   try {
     execFileSync("git", ["rev-parse", "--verify", ref], { stdio: "ignore" })
@@ -98,13 +112,23 @@ function changedFiles() {
   const base = requestedBase || (githubBase && hasRef(githubBase) ? githubBase : null) || (hasRef("HEAD^") ? "HEAD^" : null)
 
   const args = base
-    ? ["diff", "--no-renames", "--name-only", "--diff-filter=AM", "-z", `${base}...HEAD`]
-    : ["diff-tree", "--root", "--no-renames", "--no-commit-id", "--name-only", "-r", "-z", "HEAD"]
+    ? ["diff", "--no-renames", "--name-status", "--diff-filter=ADMT", "-z", `${base}...HEAD`]
+    : ["diff-tree", "--root", "--no-renames", "--no-commit-id", "--name-status", "-r", "-z", "HEAD"]
 
-  return execFileSync("git", args)
+  const fields = execFileSync("git", args)
     .toString("utf8")
     .split("\0")
     .filter(Boolean)
+
+  if (fields.length % 2 !== 0) {
+    throw new Error("Unexpected Git name-status output")
+  }
+
+  const entries = []
+  for (let index = 0; index < fields.length; index += 2) {
+    entries.push({ status: fields[index], file: fields[index + 1] })
+  }
+  return entries
 }
 
 function formatMiB(bytes) {
@@ -140,24 +164,85 @@ function isControlledMediaFile(file) {
   return controlledMediaRoot.test(file) || controlledMediaPath.test(file)
 }
 
-const files = changedFiles()
+function isGitLfsPointer(file, size) {
+  if (size > 1_024) return false
+  const lines = readFileSync(file, "utf8").split(/\r?\n/u)
+  return (
+    lines[0] === "version https://git-lfs.github.com/spec/v1" &&
+    lines.some((line) => /^oid sha256:[0-9a-f]{64}$/u.test(line)) &&
+    lines.some((line) => /^size [0-9]+$/u.test(line))
+  )
+}
+
+const entries = changedFiles()
 const violations = []
+let governedChangeBytes = 0
+let totalChangeBytes = 0
+let firstGovernedFile = null
+let firstChangedFile = null
 
-for (const file of files) {
-  const extension = extname(file).toLowerCase()
-  const stats = lstatSync(file)
-  const size = stats.size
-
-  if (stats.isSymbolicLink() && isControlledMediaFile(file)) {
+for (const { status, file } of entries) {
+  if (protectPolicyFiles() && protectedPolicyFiles.has(file)) {
     violations.push({
       file,
-      reason: "media paths must not be symbolic links",
+      reason: "media-guard trust roots require an administrator-authorized policy update",
+      size: 0,
+    })
+  }
+
+  if (status === "D") continue
+
+  const extension = extname(file).toLowerCase()
+  let stats
+  try {
+    stats = lstatSync(file)
+  } catch {
+    violations.push({
+      file,
+      reason: "changed path is unavailable for inspection",
+      size: 0,
+    })
+    continue
+  }
+  const size = stats.size
+  totalChangeBytes += size
+  firstChangedFile ||= file
+
+  const blockedSuffix = prohibitedSuffix(file)
+  const limit = limits.get(extension)
+  const controlled = isControlledMediaFile(file)
+  if (controlled || limit || blockedSuffix) {
+    governedChangeBytes += size
+    firstGovernedFile ||= file
+  }
+
+  if (stats.isSymbolicLink()) {
+    violations.push({
+      file,
+      reason: "repository additions and type changes must not be symbolic links",
       size,
     })
     continue
   }
 
-  const blockedSuffix = prohibitedSuffix(file)
+  if (!stats.isFile()) {
+    violations.push({
+      file,
+      reason: "repository additions and type changes must be regular files",
+      size,
+    })
+    continue
+  }
+
+  if (isGitLfsPointer(file, size)) {
+    violations.push({
+      file,
+      reason: "Git LFS pointers are not permitted; use the portfolio object store",
+      size,
+    })
+    continue
+  }
+
   if (blockedSuffix) {
     violations.push({
       file,
@@ -167,7 +252,6 @@ for (const file of files) {
     continue
   }
 
-  const limit = limits.get(extension)
   if (limit && size > limit) {
     violations.push({
       file,
@@ -177,13 +261,47 @@ for (const file of files) {
     continue
   }
 
-  if (isControlledMediaFile(file) && !limit && !allowedMediaSidecars.has(extension)) {
+  if (controlled && !limit && !allowedMediaSidecars.has(extension)) {
     violations.push({
       file,
       reason: `${extension || "extensionless"} is not a classified web-media format`,
       size,
     })
+    continue
   }
+
+  if (controlled && allowedMediaSidecars.has(extension) && size > MAX_SIDECAR_BYTES) {
+    violations.push({
+      file,
+      reason: `${extension} sidecar exceeds the ${formatMiB(MAX_SIDECAR_BYTES)} Git limit`,
+      size,
+    })
+    continue
+  }
+
+  if (size > MAX_GENERIC_FILE_BYTES) {
+    violations.push({
+      file,
+      reason: `unclassified file exceeds the ${formatMiB(MAX_GENERIC_FILE_BYTES)} Git limit`,
+      size,
+    })
+  }
+}
+
+if (governedChangeBytes > MAX_GOVERNED_CHANGE_BYTES && firstGovernedFile) {
+  violations.push({
+    file: firstGovernedFile,
+    reason: `governed media changes exceed the ${formatMiB(MAX_GOVERNED_CHANGE_BYTES)} pull-request budget`,
+    size: governedChangeBytes,
+  })
+}
+
+if (totalChangeBytes > MAX_TOTAL_CHANGE_BYTES && firstChangedFile) {
+  violations.push({
+    file: firstChangedFile,
+    reason: `changed files exceed the ${formatMiB(MAX_TOTAL_CHANGE_BYTES)} pull-request budget`,
+    size: totalChangeBytes,
+  })
 }
 
 if (violations.length > 0) {
@@ -202,4 +320,4 @@ if (violations.length > 0) {
   process.exit(1)
 }
 
-console.log(`Media guard passed for ${files.length} changed file(s).`)
+console.log(`Media guard passed for ${entries.length} changed path(s).`)

--- a/scripts/media-guard.mjs
+++ b/scripts/media-guard.mjs
@@ -1,0 +1,172 @@
+import { execFileSync } from "node:child_process"
+import { existsSync, lstatSync } from "node:fs"
+import { extname } from "node:path"
+
+const MIB = 1024 * 1024
+
+const limits = new Map([
+  [".avif", 1 * MIB],
+  [".gif", 1 * MIB],
+  [".ico", 512 * 1024],
+  [".jpeg", 1 * MIB],
+  [".jpg", 1 * MIB],
+  [".png", 1 * MIB],
+  [".svg", 512 * 1024],
+  [".webp", 1 * MIB],
+  [".m4a", 2 * MIB],
+  [".mp3", 2 * MIB],
+  [".ogg", 2 * MIB],
+  [".mp4", 2 * MIB],
+  [".webm", 2 * MIB],
+  [".pdf", 2 * MIB],
+  [".eot", 512 * 1024],
+  [".otf", 512 * 1024],
+  [".ttf", 512 * 1024],
+  [".woff", 512 * 1024],
+  [".woff2", 512 * 1024],
+])
+
+const prohibitedSuffixes = [
+  ".tar.bz2",
+  ".tar.gz",
+  ".tar.xz",
+  ".7z",
+  ".ai",
+  ".avi",
+  ".bmp",
+  ".bz2",
+  ".flac",
+  ".gz",
+  ".heic",
+  ".heif",
+  ".mkv",
+  ".mov",
+  ".psd",
+  ".rar",
+  ".tar",
+  ".tgz",
+  ".tif",
+  ".tiff",
+  ".wav",
+  ".xz",
+  ".zip",
+]
+
+const controlledMediaPath = /(?:^|\/)(?:audio|downloads?|fonts?|images?|media|video)(?:\/|$)/i
+const allowedMediaSidecars = new Set([".css", ".csv", ".json", ".lrc", ".md", ".srt", ".txt", ".vtt", ".xml"])
+
+function parseBaseArgument() {
+  const index = process.argv.indexOf("--base")
+  if (index === -1) return null
+  const value = process.argv[index + 1]
+  if (!value) throw new Error("--base requires a Git ref")
+  return value
+}
+
+function hasRef(ref) {
+  try {
+    execFileSync("git", ["rev-parse", "--verify", ref], { stdio: "ignore" })
+    return true
+  } catch {
+    return false
+  }
+}
+
+function changedFiles() {
+  const requestedBase = parseBaseArgument()
+  const githubBase = process.env.GITHUB_BASE_REF
+    ? `origin/${process.env.GITHUB_BASE_REF}`
+    : null
+  const base = requestedBase || githubBase || (hasRef("HEAD^") ? "HEAD^" : null)
+
+  const args = base
+    ? ["diff", "--no-renames", "--name-only", "--diff-filter=AM", "-z", `${base}...HEAD`]
+    : ["diff-tree", "--root", "--no-renames", "--no-commit-id", "--name-only", "-r", "-z", "HEAD"]
+
+  return execFileSync("git", args)
+    .toString("utf8")
+    .split("\0")
+    .filter(Boolean)
+}
+
+function formatMiB(bytes) {
+  return `${(bytes / MIB).toFixed(2)} MiB`
+}
+
+function escapeWorkflowCommandProperty(value) {
+  return value
+    .replace(/%/g, "%25")
+    .replace(/\r/g, "%0D")
+    .replace(/\n/g, "%0A")
+    .replace(/:/g, "%3A")
+    .replace(/,/g, "%2C")
+}
+
+function prohibitedSuffix(file) {
+  const lower = file.toLowerCase()
+  return prohibitedSuffixes.find((suffix) => lower.endsWith(suffix)) || null
+}
+
+const files = changedFiles()
+const violations = []
+
+for (const file of files) {
+  if (!existsSync(file)) continue
+
+  const extension = extname(file).toLowerCase()
+  const stats = lstatSync(file)
+  const size = stats.size
+
+  if (stats.isSymbolicLink() && controlledMediaPath.test(file)) {
+    violations.push({
+      file,
+      reason: "media paths must not be symbolic links",
+      size,
+    })
+    continue
+  }
+
+  const blockedSuffix = prohibitedSuffix(file)
+  if (blockedSuffix) {
+    violations.push({
+      file,
+      reason: `${blockedSuffix} source/archive files belong in object storage`,
+      size,
+    })
+    continue
+  }
+
+  const limit = limits.get(extension)
+  if (limit && size > limit) {
+    violations.push({
+      file,
+      reason: `${extension} exceeds the ${formatMiB(limit)} Git limit`,
+      size,
+    })
+    continue
+  }
+
+  if (controlledMediaPath.test(file) && !limit && !allowedMediaSidecars.has(extension)) {
+    violations.push({
+      file,
+      reason: `${extension || "extensionless"} is not a classified web-media format`,
+      size,
+    })
+  }
+}
+
+if (violations.length > 0) {
+  console.error("Media policy violations:\n")
+  for (const violation of violations) {
+    console.error(`- ${violation.file} (${formatMiB(violation.size)}): ${violation.reason}`)
+    console.error(
+      `::error file=${escapeWorkflowCommandProperty(violation.file)}::${violation.reason}; file size ${formatMiB(violation.size)}`,
+    )
+  }
+  console.error(
+    "\nStore the original in the portfolio object store and commit only its versioned URL/manifest entry.",
+  )
+  process.exit(1)
+}
+
+console.log(`Media guard passed for ${files.length} changed file(s).`)

--- a/scripts/media-guard.mjs
+++ b/scripts/media-guard.mjs
@@ -52,8 +52,26 @@ const prohibitedSuffixes = [
   ".zip",
 ]
 
+const controlledMediaRoot = /^(?:public|generated_audio|generated_imgs)(?:\/|$)|^content\/music\/source(?:\/|$)/i
 const controlledMediaPath = /(?:^|\/)(?:audios?|downloads?|fonts?|images?|media|videos?)(?:\/|$)/i
-const allowedMediaSidecars = new Set([".css", ".csv", ".json", ".lrc", ".md", ".srt", ".txt", ".vtt", ".xml"])
+const allowedMediaSidecars = new Set([
+  ".css",
+  ".csv",
+  ".html",
+  ".js",
+  ".json",
+  ".lrc",
+  ".map",
+  ".md",
+  ".mjs",
+  ".srt",
+  ".txt",
+  ".vtt",
+  ".webmanifest",
+  ".xml",
+  ".yaml",
+  ".yml",
+])
 
 function parseBaseArgument() {
   const index = process.argv.indexOf("--base")
@@ -118,6 +136,10 @@ function prohibitedSuffix(file) {
   return prohibitedSuffixes.find((suffix) => lower.endsWith(suffix)) || null
 }
 
+function isControlledMediaFile(file) {
+  return controlledMediaRoot.test(file) || controlledMediaPath.test(file)
+}
+
 const files = changedFiles()
 const violations = []
 
@@ -126,7 +148,7 @@ for (const file of files) {
   const stats = lstatSync(file)
   const size = stats.size
 
-  if (stats.isSymbolicLink() && controlledMediaPath.test(file)) {
+  if (stats.isSymbolicLink() && isControlledMediaFile(file)) {
     violations.push({
       file,
       reason: "media paths must not be symbolic links",
@@ -155,7 +177,7 @@ for (const file of files) {
     continue
   }
 
-  if (controlledMediaPath.test(file) && !limit && !allowedMediaSidecars.has(extension)) {
+  if (isControlledMediaFile(file) && !limit && !allowedMediaSidecars.has(extension)) {
     violations.push({
       file,
       reason: `${extension || "extensionless"} is not a classified web-media format`,

--- a/scripts/media-guard.mjs
+++ b/scripts/media-guard.mjs
@@ -77,7 +77,7 @@ function changedFiles() {
   const githubBase = process.env.GITHUB_BASE_REF
     ? `origin/${process.env.GITHUB_BASE_REF}`
     : null
-  const base = requestedBase || githubBase || (hasRef("HEAD^") ? "HEAD^" : null)
+  const base = requestedBase || (githubBase && hasRef(githubBase) ? githubBase : null) || (hasRef("HEAD^") ? "HEAD^" : null)
 
   const args = base
     ? ["diff", "--no-renames", "--name-only", "--diff-filter=AM", "-z", `${base}...HEAD`]

--- a/scripts/tests/media-guard.contract.mjs
+++ b/scripts/tests/media-guard.contract.mjs
@@ -6,6 +6,8 @@ import { dirname, join } from "node:path"
 import test from "node:test"
 import { fileURLToPath } from "node:url"
 
+// The .contract suffix keeps repository-wide Vitest discovery from treating
+// this Node-native suite as a Vitest module.
 const MIB = 1024 * 1024
 const guard = fileURLToPath(new URL("../media-guard.mjs", import.meta.url))
 
@@ -36,8 +38,8 @@ function commit(root, message = "scenario") {
   git(root, "commit", "--quiet", "-m", message)
 }
 
-function run(root, base, env = {}) {
-  return spawnSync(process.execPath, base ? [guard, "--base", base] : [guard], {
+function run(root, base, env = {}, extraArguments = []) {
+  return spawnSync(process.execPath, base ? [guard, ...extraArguments, "--base", base] : [guard, ...extraArguments], {
     cwd: root,
     encoding: "utf8",
     env: { ...process.env, ...env },
@@ -51,7 +53,7 @@ test("allows classified media at the exact size boundary", async (t) => {
 
   const result = run(root, base)
   assert.equal(result.status, 0, result.stderr)
-  assert.match(result.stdout, /passed for 1 changed file/u)
+  assert.match(result.stdout, /passed for 1 changed path/u)
 })
 
 test("rejects oversized classified web media", async (t) => {
@@ -122,7 +124,7 @@ test("rejects dangling symlinks in controlled media paths", async (t) => {
 
   const result = run(root, base)
   assert.equal(result.status, 1)
-  assert.match(result.stderr, /media paths must not be symbolic links/u)
+  assert.match(result.stderr, /must not be symbolic links/u)
 })
 
 test("escapes workflow-command messages derived from hostile extensions", async (t) => {
@@ -175,4 +177,132 @@ test("allows explicit text and config sidecars at controlled roots", async (t) =
 
   const result = run(root, base)
   assert.equal(result.status, 0, result.stderr)
+})
+
+test("rejects unclassified media in nested monorepo public roots", async (t) => {
+  const { root, base } = await repository(t)
+  await write(root, "apps/web/public/root.jxl", "unclassified media")
+  commit(root)
+
+  const result = run(root, base)
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /\.jxl is not a classified web-media format/u)
+})
+
+test("rejects classified-media symlinks outside controlled paths", async (t) => {
+  const { root, base } = await repository(t)
+  await write(root, "payload.bin", Buffer.alloc(3 * MIB))
+  await mkdir(join(root, "assets"), { recursive: true })
+  await symlink("../payload.bin", join(root, "assets/hero.png"))
+  commit(root)
+
+  const result = run(root, base)
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /must not be symbolic links/u)
+  assert.match(result.stderr, /unclassified file exceeds the 2\.00 MiB Git limit/u)
+})
+
+test("rejects regular-file to symlink type changes", async (t) => {
+  const { root } = await repository(t)
+  await write(root, "public/images/hero.png", "baseline image")
+  commit(root, "tracked image")
+  const typeChangeBase = git(root, "rev-parse", "HEAD").trim()
+  await rm(join(root, "public/images/hero.png"))
+  await symlink("../../payload.bin", join(root, "public/images/hero.png"))
+  commit(root)
+
+  const result = run(root, typeChangeBase)
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /must not be symbolic links/u)
+})
+
+test("rejects oversized allowed sidecars", async (t) => {
+  const { root, base } = await repository(t)
+  await write(root, "generated_imgs/catalog.json", Buffer.alloc(512 * 1024 + 1))
+  commit(root)
+
+  const result = run(root, base)
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /\.json sidecar exceeds the 0\.50 MiB Git limit/u)
+})
+
+test("rejects oversized generic files outside media paths", async (t) => {
+  const { root, base } = await repository(t)
+  await write(root, "payload.bin", Buffer.alloc(2 * MIB + 1))
+  commit(root)
+
+  const result = run(root, base)
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /unclassified file exceeds the 2\.00 MiB Git limit/u)
+})
+
+test("rejects aggregate governed-media debt", async (t) => {
+  const { root, base } = await repository(t)
+  for (let index = 0; index < 6; index += 1) {
+    await write(root, `public/images/asset-${index}.png`, Buffer.alloc(MIB))
+  }
+  commit(root)
+
+  const result = run(root, base)
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /governed media changes exceed the 5\.00 MiB pull-request budget/u)
+})
+
+test("rejects aggregate repository bloat", async (t) => {
+  const { root, base } = await repository(t)
+  for (let index = 0; index < 11; index += 1) {
+    await write(root, `fixtures/chunk-${index}.txt`, Buffer.alloc(2 * MIB))
+  }
+  commit(root)
+
+  const result = run(root, base)
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /changed files exceed the 20\.00 MiB pull-request budget/u)
+})
+
+test("protects the media-guard trust roots from deletion", async (t) => {
+  const { root } = await repository(t)
+  await write(root, ".github/workflows/media-guard.yml", "name: trusted\n")
+  commit(root, "trusted policy")
+  const policyBase = git(root, "rev-parse", "HEAD").trim()
+  await rm(join(root, ".github/workflows/media-guard.yml"))
+  commit(root)
+
+  const result = run(root, policyBase, {}, ["--protect-policy"])
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /trust roots require an administrator-authorized policy update/u)
+})
+
+test("rejects Git submodules masquerading as media files", async (t) => {
+  const { root, base } = await repository(t)
+  const source = await mkdtemp(join(tmpdir(), "media-guard-submodule-"))
+  t.after(() => rm(source, { recursive: true, force: true }))
+  git(source, "init", "--quiet")
+  git(source, "config", "user.email", "media-guard@example.test")
+  git(source, "config", "user.name", "Media Guard Test")
+  await write(source, "README.md", "submodule payload\n")
+  git(source, "add", ".")
+  git(source, "commit", "--quiet", "-m", "payload")
+  git(root, "-c", "protocol.file.allow=always", "submodule", "add", "--quiet", source, "public/images/hero.png")
+  commit(root)
+
+  const result = run(root, base)
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /must be regular files/u)
+})
+
+test("rejects Git LFS pointer media", async (t) => {
+  const { root, base } = await repository(t)
+  await write(
+    root,
+    "public/images/hero.png",
+    "version https://git-lfs.github.com/spec/v1\n" +
+      `oid sha256:${"a".repeat(64)}\n` +
+      "size 1073741824\n",
+  )
+  commit(root)
+
+  const result = run(root, base)
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /Git LFS pointers are not permitted/u)
 })

--- a/scripts/tests/media-guard.test.mjs
+++ b/scripts/tests/media-guard.test.mjs
@@ -147,3 +147,32 @@ test("falls back to HEAD^ when the GitHub base ref is unavailable", async (t) =>
   assert.match(result.stderr, /\.mp4 exceeds the 2\.00 MiB Git limit/u)
   assert.doesNotMatch(result.stderr, /unknown revision|ambiguous argument/u)
 })
+
+for (const filename of [
+  "public/root.jxl",
+  "generated_imgs/root.jxl",
+  "generated_audio/root.jxl",
+  "content/music/source/root.jxl",
+]) {
+  test(`rejects unclassified media at controlled root ${filename}`, async (t) => {
+    const { root, base } = await repository(t)
+    await write(root, filename, "unclassified media")
+    commit(root)
+
+    const result = run(root, base)
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /\.jxl is not a classified web-media format/u)
+  })
+}
+
+test("allows explicit text and config sidecars at controlled roots", async (t) => {
+  const { root, base } = await repository(t)
+  await write(root, "public/manifest.webmanifest", "{}")
+  await write(root, "generated_audio/catalog.json", "{}")
+  await write(root, "generated_imgs/README.md", "metadata\n")
+  await write(root, "content/music/source/lyrics.lrc", "[00:00.00]Instrumental\n")
+  commit(root)
+
+  const result = run(root, base)
+  assert.equal(result.status, 0, result.stderr)
+})

--- a/scripts/tests/media-guard.test.mjs
+++ b/scripts/tests/media-guard.test.mjs
@@ -36,10 +36,11 @@ function commit(root, message = "scenario") {
   git(root, "commit", "--quiet", "-m", message)
 }
 
-function run(root, base) {
-  return spawnSync(process.execPath, [guard, "--base", base], {
+function run(root, base, env = {}) {
+  return spawnSync(process.execPath, base ? [guard, "--base", base] : [guard], {
     cwd: root,
     encoding: "utf8",
+    env: { ...process.env, ...env },
   })
 }
 
@@ -134,4 +135,15 @@ test("escapes workflow-command messages derived from hostile extensions", async 
   assert.equal(result.status, 1)
   assert.match(result.stderr, /%0A::error::injected is not a classified web-media format/u)
   assert.doesNotMatch(result.stderr, /(?:^|\n)::error::injected/mu)
+})
+
+test("falls back to HEAD^ when the GitHub base ref is unavailable", async (t) => {
+  const { root } = await repository(t)
+  await write(root, "public/video/oversized.mp4", Buffer.alloc(2 * MIB + 1))
+  commit(root)
+
+  const result = run(root, null, { GITHUB_BASE_REF: "missing-base-ref" })
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /\.mp4 exceeds the 2\.00 MiB Git limit/u)
+  assert.doesNotMatch(result.stderr, /unknown revision|ambiguous argument/u)
 })

--- a/scripts/tests/media-guard.test.mjs
+++ b/scripts/tests/media-guard.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import { execFileSync, spawnSync } from "node:child_process"
-import { mkdir, mkdtemp, rename, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, rename, rm, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 import test from "node:test"
@@ -90,7 +90,7 @@ test("treats renamed destinations as additions", async (t) => {
 
 test("escapes workflow-command properties in hostile filenames", async (t) => {
   const { root, base } = await repository(t)
-  const filename = "public/images/a:b,c%25\r\n::warning.png"
+  const filename = "public/images/a:b,c%25\r\n::warning::injected.png"
   await write(root, filename, Buffer.alloc(MIB + 1))
   commit(root)
 
@@ -98,16 +98,40 @@ test("escapes workflow-command properties in hostile filenames", async (t) => {
   assert.equal(result.status, 1)
   assert.match(
     result.stderr,
-    /::error file=public\/images\/a%3Ab%2Cc%2525%0D%0A%3A%3Awarning\.png::/u,
+    /::error file=public\/images\/a%3Ab%2Cc%2525%0D%0A%3A%3Awarning%3A%3Ainjected\.png::/u,
   )
+  assert.doesNotMatch(result.stderr, /(?:^|\n)::warning::injected\.png/mu)
 })
 
-test("rejects unclassified files in controlled media paths", async (t) => {
+test("rejects unclassified files in plural controlled media paths", async (t) => {
   const { root, base } = await repository(t)
-  await write(root, "public/images/hero.jxl", "next-generation image")
+  await write(root, "public/videos/hero.jxl", "next-generation video")
   commit(root)
 
   const result = run(root, base)
   assert.equal(result.status, 1)
   assert.match(result.stderr, /\.jxl is not a classified web-media format/u)
+})
+
+test("rejects dangling symlinks in controlled media paths", async (t) => {
+  const { root, base } = await repository(t)
+  await mkdir(join(root, "public/images"), { recursive: true })
+  await symlink("missing-target.png", join(root, "public/images/hero.png"))
+  commit(root)
+
+  const result = run(root, base)
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /media paths must not be symbolic links/u)
+})
+
+test("escapes workflow-command messages derived from hostile extensions", async (t) => {
+  const { root, base } = await repository(t)
+  const filename = "public/images/asset.\n::error::injected"
+  await write(root, filename, "unclassified")
+  commit(root)
+
+  const result = run(root, base)
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /%0A::error::injected is not a classified web-media format/u)
+  assert.doesNotMatch(result.stderr, /(?:^|\n)::error::injected/mu)
 })

--- a/scripts/tests/media-guard.test.mjs
+++ b/scripts/tests/media-guard.test.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict"
+import { execFileSync, spawnSync } from "node:child_process"
+import { mkdir, mkdtemp, rename, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import test from "node:test"
+import { fileURLToPath } from "node:url"
+
+const MIB = 1024 * 1024
+const guard = fileURLToPath(new URL("../media-guard.mjs", import.meta.url))
+
+async function repository(t) {
+  const root = await mkdtemp(join(tmpdir(), "media-guard-"))
+  t.after(() => rm(root, { recursive: true, force: true }))
+  git(root, "init", "--quiet")
+  git(root, "config", "user.email", "media-guard@example.test")
+  git(root, "config", "user.name", "Media Guard Test")
+  await write(root, "README.md", "baseline\n")
+  git(root, "add", ".")
+  git(root, "commit", "--quiet", "-m", "baseline")
+  return { root, base: git(root, "rev-parse", "HEAD").trim() }
+}
+
+function git(cwd, ...args) {
+  return execFileSync("git", args, { cwd, encoding: "utf8" })
+}
+
+async function write(root, path, value) {
+  const target = join(root, path)
+  await mkdir(dirname(target), { recursive: true })
+  await writeFile(target, value)
+}
+
+function commit(root, message = "scenario") {
+  git(root, "add", "-A")
+  git(root, "commit", "--quiet", "-m", message)
+}
+
+function run(root, base) {
+  return spawnSync(process.execPath, [guard, "--base", base], {
+    cwd: root,
+    encoding: "utf8",
+  })
+}
+
+test("allows classified media at the exact size boundary", async (t) => {
+  const { root, base } = await repository(t)
+  await write(root, "public/images/hero.png", Buffer.alloc(MIB))
+  commit(root)
+
+  const result = run(root, base)
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, /passed for 1 changed file/u)
+})
+
+test("rejects oversized classified web media", async (t) => {
+  const { root, base } = await repository(t)
+  await write(root, "public/video/hero.webm", Buffer.alloc(2 * MIB + 1))
+  commit(root)
+
+  const result = run(root, base)
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /\.webm exceeds the 2\.00 MiB Git limit/u)
+})
+
+test("rejects compound and compressed archives", async (t) => {
+  const { root, base } = await repository(t)
+  await write(root, "public/downloads/source.tar.gz", "archive")
+  commit(root)
+
+  const result = run(root, base)
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /\.tar\.gz source\/archive files belong in object storage/u)
+})
+
+test("treats renamed destinations as additions", async (t) => {
+  const { root, base } = await repository(t)
+  await write(root, "legacy.bin", "legacy audio")
+  git(root, "add", "legacy.bin")
+  git(root, "commit", "--quiet", "-m", "legacy source")
+  const renameBase = git(root, "rev-parse", "HEAD").trim()
+  await mkdir(join(root, "public/audio"), { recursive: true })
+  await rename(join(root, "legacy.bin"), join(root, "public/audio/renamed.wav"))
+  commit(root)
+
+  const result = run(root, renameBase || base)
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /renamed\.wav/u)
+})
+
+test("escapes workflow-command properties in hostile filenames", async (t) => {
+  const { root, base } = await repository(t)
+  const filename = "public/images/a:b,c%25\r\n::warning.png"
+  await write(root, filename, Buffer.alloc(MIB + 1))
+  commit(root)
+
+  const result = run(root, base)
+  assert.equal(result.status, 1)
+  assert.match(
+    result.stderr,
+    /::error file=public\/images\/a%3Ab%2Cc%2525%0D%0A%3A%3Awarning\.png::/u,
+  )
+})
+
+test("rejects unclassified files in controlled media paths", async (t) => {
+  const { root, base } = await repository(t)
+  await write(root, "public/images/hero.jxl", "next-generation image")
+  commit(root)
+
+  const result = run(root, base)
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /\.jxl is not a classified web-media format/u)
+})


### PR DESCRIPTION
## Update: Rebased onto main (2026-08-15)

Cleanly rebased onto commit `42f9ef8` to resolve conflicts and ensure merge-readiness. All 24 media-guard contract tests pass. No functional changes—this is a rebase-only update.

---

## Outcome

Adds a pull-request media boundary before the existing Starlight site is migrated to the shared object store.

- rejects oversized browser media and source/archive formats
- treats renamed destinations as new files
- rejects media-path symlinks and unclassified formats
- escapes PR-controlled filenames in workflow annotations
- pins checkout/setup-node to immutable SHAs with persisted credentials disabled
- runs twenty-four isolated temporary-repository regression scenarios
- records the operational decision and reversible staging-first next step in the Operational Vault

## Scope

No current asset, URL, site component, domain, deployment, SIP substrate contract, or production route changes. This is operational governance only; the existing media remains available until a separately verified cutover and observation window.

## Verification

The exact script/test/workflow set is validated locally at 24/24 and under exact-head review on `frankxai/frankx.ai-vercel-website#456`. This branch is based on `5e04384d`; its own GitHub checks must pass before merge.

## Final fail-closed pass

- govern every file under `public/`, `generated_audio/`, `generated_imgs/`, and `content/music/source/`
- permit only an explicit safe text/config sidecar allowlist inside controlled roots
- cover all four root-path bypasses plus allowed sidecars in the 24/24 isolated regression suite
- normalize the guard script to Git mode `100644`




## Summary by CodeRabbit

* **New Features**
  * Added automated media governance checks for pull requests.
  * Flags oversized, unsupported, archived, source, symlinked, or unclassified media files.
  * Provides clear validation feedback and blocks changes that violate repository media policies.

* **Documentation**
  * Added guidance on media storage limits, approved handling, and future migration steps.

* **Tests**
  * Added coverage for file-size boundaries, renames, supported sidecars, fallback checks, and policy violations.



## Trusted enforcement pass

- run under `pull_request_target` from a copied base-branch guard; the fork/PR tree is inspected as data and never executed
- keep the token read-only with no persisted credentials, secrets, dependency install, or package cache
- reject Git type changes, all symlinks, gitlinks/submodules, Git LFS pointers, nested media roots, and unavailable changed paths
- cap controlled sidecars at 0.5 MiB, generic files at 2 MiB, governed PR bytes at 5 MiB, and total changed bytes at 20 MiB
- protect the workflow, guard, and contract; policy changes require `media-policy-change-approved` to be freshly applied by a maintainer to the exact owner/member/collaborator head
- use the Vitest-safe `media-guard.contract.mjs` filename; Node 22 adversarial contract is 24/24

Bootstrap note: GitHub reads `pull_request_target` definitions from the base branch, so this introducing PR is validated independently and by repository CI/review. Immediately after the first merge, a negative canary PR must prove the live trusted check before it becomes required.