### PR TITLE
fix(site): make homepage CTAs honest about source-only distribution

### DIFF
--- a/site/src/app/page.tsx
+++ b/site/src/app/page.tsx
@@ -186,8 +186,8 @@ const PRODUCT_ROUTES: RouteCard[] = [
   },
   {
     href: "/download",
-    title: "Starter Kits",
-    desc: "Download forkable starter packages for agents, plugins, and SIP use.",
+    title: "Source & Modules",
+    desc: "Build from current source or download published plugin modules.",
     icon: BadgeCheck,
   },
   {
@@ -374,7 +374,7 @@ export default async function HomePage() {
               <div className="mt-6 flex flex-wrap gap-2.5">
                 <DoorLink href="/quickstart" label="Quickstart" />
                 <DoorLink href="/explainer" label="Explainer" />
-                <DoorLink href="/download" label="Starter kits" />
+                <DoorLink href="/download" label="Source & modules" />
               </div>
             </div>
 
@@ -712,10 +712,10 @@ export default async function HomePage() {
           </p>
           <div className="mt-9 flex flex-col items-center justify-center gap-3 sm:flex-row">
             <Link
-              href="/download"
+              href="/quickstart"
               className="inline-flex min-h-12 items-center justify-center gap-2 rounded-md bg-white px-6 py-3 text-sm font-semibold text-slate-950 transition-micro hover:bg-slate-200"
             >
-              Get the starter
+              Build from source
               <ArrowRight size={16} aria-hidden="true" />
             </Link>
             <Link

--- a/site/src/lib/nav.ts
+++ b/site/src/lib/nav.ts
@@ -25,7 +25,7 @@ export const NAV_GROUPS: NavGroup[] = [
     label: "Build",
     items: [
       { href: "/quickstart", label: "Quickstart", desc: "Five minutes to first context" },
-      { href: "/download", label: "Download", desc: "Fork the SIP Starter" },
+      { href: "/download", label: "Source & Modules", desc: "Build SIP source or get modules" },
       { href: "/cockpit", label: "Cockpit", desc: "The spec-trace console" },
       { href: "/architecture", label: "Architecture", desc: "How the pieces fit together" },
     ],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Production https://starlightintelligence.org still advertised a "Download starter" / "Get the starter" CTA as if a v8.3.0 SIP Starter archive exists. The ZIP at
```
https://github.com/frankxai/Starlight-Intelligence-System/releases/download/v8.3.0/starlight-sip-starter-v8.3.0.zip
```
is HTTP 404, and there is no v8.3.0 GitHub release. Latest release is v8.2.1 with zero assets.

The `/download` page itself became honest in commit ee0d37a / PR #51 — it reports `status: "source-only"`, shows "Inspect source" and "Build current source" buttons, and includes the clear note:
> "A checksum-backed SIP Starter archive has not been published for this version, so this surface routes to source instead of manufacturing a release."

**However**, the homepage still advertised the missing archive through:
- Primary CTA: "Get the starter" → /download
- "Starter Kits" card: "Download forkable starter packages..."
- Nav label: "Download" / "Fork the SIP Starter"

## Solution

Make homepage and nav CTAs honest to match the source-only distribution reality:

### Changed
- **Homepage final CTA**: "Get the starter" → "Build from source" (now points to `/quickstart` instead of `/download`)
- **Homepage product routes card**: "Starter Kits" → "Source & Modules" with description "Build from current source or download published plugin modules."
- **Homepage "Two Ways In" section**: "Starter kits" → "Source & modules"
- **Nav description**: "Download" → "Source & Modules" with "Build SIP source or get modules"

### Preserved
- `/download` page already honest (unchanged)
- `/download/latest.json` endpoint already returns `status: "source-only"` with empty `assets` array (unchanged)
- Plugin starter ZIPs that actually exist (Codex Plugin Starter, Intelligence Wrapper Kits) remain available as downloads (unchanged)

## Testing

Contract checks pass:
```
✓ Metrics contract verified (144 agents, 88 skill rules, 6 vaults, 15 horizon letters)
✓ Public install contract passed across 92 files
✓ Layout contract passed
```

## Constraints followed

✓ **No GitHub release created** — did not create, tag, or invent any release or attach fake ZIP assets  
✓ **PR #77 untouched** — did not rebase, comment on, or use the `agent/codex/media-governance` branch  
✓ **Vercel project `starlight-intelligence-system` untouched** — no project settings changed, canonical door stays  
✓ **No domain redirects** — did not 301 starlightintelligence.org or merge doors  
✓ **Surgical site changes** — only touched `site/src/app/page.tsx` and `site/src/lib/nav.ts`

## Result

After merge, homepage will no longer advertise a missing v8.3.0 SIP Starter archive. Users see:
- Primary CTA: "Build from source" → `/quickstart` (honest source workflow)
- Product routes: "Source & Modules" (accurate description)
- Nav: "Source & Modules" (no false promise of downloadable starter)

The `/download` page continues to report source-only status and provide the git clone workflow.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a7a0a3b-ab9d-467b-b5cc-bdf7250ae7fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a7a0a3b-ab9d-467b-b5cc-bdf7250ae7fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

