### PR TITLE
Fix GitHub avatar 400 error on /vaults page

### DIFF
--- a/site/next.config.ts
+++ b/site/next.config.ts
@@ -49,6 +49,16 @@ const nextConfig: NextConfig = {
   poweredByHeader: false,
   // Default compression — Vercel sets this independently, but explicit is better.
   compress: true,
+  // Allow Next.js Image Optimization for GitHub avatars used in vault registry.
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "github.com",
+        pathname: "/**",
+      },
+    ],
+  },
   async headers() {
     return [
       {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The Frank avatar on https://starlightintelligence.org/vaults was returning HTTP 400 when trying to load from:
```
https://starlightintelligence.org/_next/image?url=https%3A%2F%2Fgithub.com%2Ffrankxai.png&w=48&q=75
```

## Root Cause

Next.js Image Optimization requires explicit `remotePatterns` configuration in `next.config.ts` for external image domains. The config had no `images` section, so `github.com` was blocked by default.

## Solution

Added minimal `images.remotePatterns` configuration to allow GitHub avatars:

```typescript
images: {
  remotePatterns: [
    {
      protocol: "https",
      hostname: "github.com",
      pathname: "/**",
    },
  ],
},
```

## User-Visible Impact

Visitors to `/vaults` now see Frank's GitHub avatar correctly rendered instead of a 400 error.

## Testing

- ✅ Build passes with TypeScript validation
- ✅ All existing checks pass (metrics contract, public install contract, layout contract)
- ✅ No new dependencies or security surface

Closes #45
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c646dfd-6d81-4dad-802f-73a770e04fc6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c646dfd-6d81-4dad-802f-73a770e04fc6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

