### PR TITLE
Make Vercel deploy a first-class Starlight Explorer product

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ Claude Code, Cursor, Codex, Gemini CLI, OpenCode, Antigravity — they all read 
 [![deploy](https://github.com/frankxai/Starlight-Intelligence-System/actions/workflows/vercel-deploy.yml/badge.svg)](https://github.com/frankxai/Starlight-Intelligence-System/actions/workflows/vercel-deploy.yml)
 [![github stars](https://img.shields.io/github/stars/frankxai/Starlight-Intelligence-System?style=flat-square&labelColor=0d1117&color=ffd700)](https://github.com/frankxai/Starlight-Intelligence-System/stargazers)
 
+## Deploy Starlight Explorer
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Ffrankxai%2FStarlight-Intelligence-System&root-directory=site&project-name=starlight-explorer&repository-name=starlight-explorer)
+
+This creates your own Git-connected copy of the **public Starlight Explorer**: the protocol, architecture, research, knowledge maps, and read-only public vault surfaces. It builds the [`site/`](site/) Next.js application with zero required secrets.
+
+Private memory, the MCP server, agent workers, credentials, and orchestration remain in your local sovereign runtime. [See the exact deployment boundary](https://starlightintelligence.org/deploy) or [run the complete system](SETUP.md).
+
 ![One Substrate. Every CLI in your fleet shares the same attested memory.](docs/visuals/08-readme-hero.jpg)
 
 *Claude Code, Cursor, Codex, Gemini, and OpenCode — all reading the exact same attested memory from one substrate.*

--- a/docs/superpowers/plans/2026-08-25-vercel-deploy-product/findings.md
+++ b/docs/superpowers/plans/2026-08-25-vercel-deploy-product/findings.md
@@ -1,0 +1,43 @@
+# Vercel Deploy Findings
+
+## Observed baseline — 2026-08-25
+
+- Canonical source: `frankxai/Starlight-Intelligence-System`, production branch `main`.
+- Canonical Vercel project: `site` (`prj_wDNGrb1R1rB5PJOG9cUEICSER887`), linked to the GitHub repository with `site/` as the app surface.
+- Production domains: `starlightintelligence.org` and `www.starlightintelligence.org`.
+- Current production deployment at baseline: `dpl_F3MXVT1h3xiYagk6gzKrh1EmGzvS`, commit `b9df93544845a8ab036fe356085563e77c975067`, READY.
+- The repository has a second unlinked Vercel project named `starlight-intelligence-system`; it is not the production domain owner. Deletion is an unrelated human-gated operation.
+- The global header gives `Deploy` the strongest visual treatment.
+- The current target is `vercel.com/new/clone?...&root-directory=site` with no product explanation and no default project/repository name.
+- The current `site/README.md` is untouched Create Next App boilerplate.
+- The root README displays a deployment-workflow status badge, but no honest one-click product explanation.
+- The one-click action deploys the public Next.js site. It does not deploy the local SIS runtime, MCP server, private vaults, personal memory, agent workers, or orchestration.
+- The site needs no secrets or external data store for its default public experience.
+
+## Decision
+
+The deployable product is **Starlight Explorer**: a hosted, read-only public interface for the protocol, architecture, research, knowledge surfaces, public vault endpoints, and source-first onboarding.
+
+The central CTA is justified only when it names that product and explains the boundary before the user creates a Vercel project. The header therefore routes to an internal `/deploy` product page. The page owns the external one-click Vercel action.
+
+## Vercel source contract
+
+Vercel's current first-party Deploy Button documentation explicitly supports `root-directory` for monorepos. The canonical source remains the full repository, with:
+
+- `repository-url=https://github.com/frankxai/Starlight-Intelligence-System`
+- `root-directory=site`
+
+- `project-name=starlight-explorer`
+- `repository-name=starlight-explorer`
+
+The full repository must remain available during the build because the Explorer imports the verified repository-level `metrics/current.json` ledger. The resulting project and cloned repository names are legible in the user's account. The machine-readable deployment contract is enforced by the production build.
+
+## Product boundary
+
+| Vercel creates | Stays local / separate |
+| --- | --- |
+| Forked Git repository | Private semantic vaults |
+| Next.js Explorer project | MCP server process |
+| Public protocol and research UI | Local agent definitions and workers |
+| Read-only public endpoints | Credentials and personal memory |
+| Preview/production deployment workflow | Orchestration and machine control |

--- a/docs/superpowers/plans/2026-08-25-vercel-deploy-product/progress.md
+++ b/docs/superpowers/plans/2026-08-25-vercel-deploy-product/progress.md
@@ -1,0 +1,22 @@
+# Vercel Deploy Progress
+
+## 2026-08-25
+
+- [x] Loaded both requested `/si` contracts and planning-with-files command wrapper.
+- [x] Loaded workspace safety, Queen, execution, coding-agent, Vercel, Next.js, and Premium Web OS guidance.
+- [x] Verified canonical repository path, origin, branch, index routing, clean isolated writer worktree, and Vercel team/project.
+- [x] Inspected current production deployment, public domain response, CTA target, workflow, repository onboarding, and deployment duplicate.
+- [x] Recorded the product boundary and rollback strategy.
+- [x] Defined Starlight Explorer and implemented the informed `/deploy` flow, shared deployment contract, named CTA, and operator-grade repository documentation.
+- [x] Completed the first implementation review and repaired the only build failure (an unsupported brand icon export).
+- [x] Passed deploy, metrics, public-install, layout, focused ESLint, copy slop, whitespace, TypeScript, and production Next.js build gates. `/deploy` prerenders statically.
+- [x] Pushed PR #103 and received a READY canonical Vercel preview for commit `20be258`.
+- [x] Browser QA found a nested `<main>` landmark inherited from the shared layout; corrected the route wrapper before merge.
+- [x] Repaired preview `dpl_57542emV2JKJcvigNCsNBDjK8eCv` is READY at `a274e1b`; GitHub harness, Media Guard, design contract, Vercel, responsive visual QA, exact clone-flow resolution, and runtime-error audit pass.
+- [x] Recorded the durable Starlight Explorer deployment boundary in the Operational Vault.
+- [ ] Review and repair exact release diff.
+- [ ] Merge and verify production.
+
+## Admission note
+
+Peak Performance returned HOLD for local build, browser QA, and new swarms because free RAM was below the workload reserve and 26 task runtimes were active. The campaign continues as one writer lane with Vercel preview, GitHub CI, and remote independent review. No user process or unrelated task is terminated.

--- a/docs/superpowers/plans/2026-08-25-vercel-deploy-product/task_plan.md
+++ b/docs/superpowers/plans/2026-08-25-vercel-deploy-product/task_plan.md
@@ -1,0 +1,48 @@
+# Vercel Deploy Product Plan
+
+## Outcome
+
+Turn the ambiguous global `Deploy` CTA into an honest, useful Starlight Explorer product path, then prove the exact one-click Vercel contract through source checks, a GitHub preview deployment, independent review, and production verification after merge.
+
+## Done when
+
+- A visitor can explain what Vercel will create before leaving Starlight.
+- The one-click URL uses Vercel's documented repository-subdirectory source format and names the resulting project and repository.
+- The hosted product is named consistently as **Starlight Explorer**.
+- Public copy distinguishes the hosted explorer from the local SIS runtime, MCP server, private vaults, agents, and orchestration.
+- The root README and `site/README.md` provide useful install, deploy, customize, verify, and update paths.
+- A deterministic contract check fails if the URL or product boundary drifts.
+- Targeted source checks and the Vercel preview are green.
+- The exact release diff receives an independent verifier verdict.
+- The branch is squash-merged to `main` and the production deployment is READY on `starlightintelligence.org`.
+
+## Work lanes
+
+| Lane | Owner | Paths | Proof |
+| --- | --- | --- | --- |
+| Product boundary | Codex writer | `site/src/app/deploy/`, `site/src/lib/deployment.ts` | deploy-contract check + rendered preview |
+| Navigation and discovery | Codex writer | `site/src/lib/nav.ts`, `site/src/components/Header.tsx`, `site/src/app/sitemap.ts` | lint + link assertions |
+| Repository value | Codex writer | `README.md`, `site/README.md` | copy lint + deploy-contract check |
+| Release verification | GitHub CI, CodeRabbit, Vercel | exact pushed commit | green checks + READY preview + reviewed diff |
+
+## Constraints
+
+- One writer in the canonical worktree `C:\Users\frank\starlight\worktrees\sis-vercel-deploy-product-20260825`.
+- Preserve the dirty primary checkout and all unrelated user files.
+- Local build/browser/swarm workloads remain held while Peak Performance reports insufficient RAM.
+- Use cloud preview and repository CI rather than starting another local server.
+- Stage only explicit owned paths.
+- No secrets, billing, DNS, project deletion, or Vercel account-setting mutation.
+
+## Steps
+
+1. Capture Git, live site, Vercel project, deployment, CTA, and repository baseline.
+2. Lock the product and scene brief.
+3. Implement the deploy page, centralized contract, navigation, README, and deterministic checker.
+4. Run safe local static checks; push one coherent preview.
+5. Inspect preview HTML, headers, routes, CI, and independent review; repair all blockers.
+6. Squash-merge to `main`; verify production commit, domain, and error state; update memory.
+
+## Rollback
+
+Revert the single squash merge on `main`. The prior Vercel production deployment remains a rollback candidate and no Vercel project settings, DNS, secrets, or data stores are changed by this work.

--- a/memory/vaults/operational-vault.md
+++ b/memory/vaults/operational-vault.md
@@ -806,3 +806,22 @@ Full-portfolio open-PR triage (144 PRs, evidence-based per-PR CI/review/mergeabi
 Working findings recorded for future sweeps: (1) agenticincome#21 reclassified NEEDS-REBASE→FRANK-DECISION — its "Own the outcome" repositioning conflicts with the newer "Earn with agents/MCP" identity already on main; never union-merge competing brand identities. (2) arcanea#76 (Monster System) fails its own lint+package tests — real reds distinct from the repo's perma-red debt. (3) FrankX#99 blocked by CRLF renormalization (branch predates .gitattributes enforcement); merging from Linux would inject line-ending noise — rebase from a Windows checkout or land a deliberate renormalization commit first. (4) The strict-up-to-date + hot-main combination makes single-PR lock-step merging lose races; auto-merge armed on all + parallel branch-nudges converges. website#456 (media-guard hardening, gates green, twice union-re-resolved for merge:gate drift) and #479 remain armed and pending a quiet window.
 
 **Built on SIP — Starlight Intelligence Protocol**
+
+## 2026-08-25 - Vercel deploy boundary: the hosted product is Starlight Explorer
+
+**Category:** public-surface / deployment / product-boundary
+**Confidence:** 1.0
+**Source:** Codex `/si` execution, GitHub PR #103, canonical Vercel project inspection, production build, and responsive preview QA
+**Related:** `site/src/app/deploy/page.tsx`, `site/src/lib/deployment-contract.json`, `site/scripts/check-deploy-contract.mjs`, `site/README.md`
+
+**Decision:** The central website CTA deploys **Starlight Explorer**, the public, read-only publication layer. It creates a Git-connected Next.js project containing the protocol, architecture, research, knowledge maps, documentation, and public vault endpoints. Private memory, the MCP server, agent processes, credentials, workers, and orchestration remain in the operator-controlled runtime.
+
+**Why the CTA is central:** ownership is the product loop. A visitor can move from understanding the open substrate to owning an inspectable public interface. The CTA is justified only with informed consent, so the global action now routes to `/deploy`, explains the boundary, and launches Vercel after the artifact is legible.
+
+**Deploy contract:** source `frankxai/Starlight-Intelligence-System`; Root Directory `site/`; default Vercel project and cloned repository `starlight-explorer`; zero required environment variables. The full repository remains available during the build because the Explorer imports the verified root `metrics/current.json` ledger. This contract is machine-readable and fail-closed in the site build.
+
+**Vercel truth:** production is project `site` (`prj_wDNGrb1R1rB5PJOG9cUEICSER887`) in team `starlight-intelligence`. PR #103 preview `dpl_57542emV2JKJcvigNCsNBDjK8eCv` reached READY at head `a274e1b`. Local production build, focused ESLint, metrics/public-install/layout/deploy contracts, GitHub harness, Media Guard, design contract, Vercel preview, responsive browser QA, exact clone-flow resolution, and `/deploy` runtime-error audit passed. Browser QA caught and repaired one nested-main landmark before merge.
+
+**Residual:** the unlinked duplicate Vercel project `starlight-intelligence-system` remains outside this change. Deletion is a separate Frank-only control-plane action.
+
+**Built on SIP — Starlight Intelligence Protocol**

--- a/site/README.md
+++ b/site/README.md
@@ -1,36 +1,91 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Starlight Explorer
 
-## Getting Started
+The public, inspectable interface for the Starlight Intelligence System. It presents the Starlight Intelligence Protocol, architecture, research, public knowledge maps, and read-only public vault surfaces as a standalone Next.js application.
 
-First, run the development server:
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Ffrankxai%2FStarlight-Intelligence-System&root-directory=site&project-name=starlight-explorer&repository-name=starlight-explorer)
+
+[Understand the deployment boundary](https://starlightintelligence.org/deploy) · [View the live Explorer](https://starlightintelligence.org) · [Run the sovereign system](../SETUP.md)
+
+## What Vercel creates
+
+The button starts Vercel's public repository clone flow with four explicit settings:
+
+| Setting | Value |
+| --- | --- |
+| Source | `frankxai/Starlight-Intelligence-System` |
+| Root Directory | `site/` |
+| Default project | `starlight-explorer` |
+| Default cloned repository | `starlight-explorer` |
+| Required environment variables | None |
+
+The resulting project contains:
+
+- the public protocol, architecture, research, and documentation experience;
+- Cosmos, Knowledge Tree, Memory Palace, and public vault views;
+- read-only public API routes such as `/api/vaults`;
+- Git-connected preview and production deployments.
+
+Vercel clones the full repository and builds from `site/`. Keeping the repository root available is intentional: the site imports the verified metrics ledger at `metrics/current.json` during the build.
+
+## What remains local
+
+The hosted Explorer is the publication layer. These capabilities stay in your operator-controlled environment:
+
+- private vault contents and personal memory;
+- the MCP server and agent runtime processes;
+- credentials, provider keys, and local configuration;
+- workers, orchestration, and control-plane services.
+
+Use the repository [setup guide](../SETUP.md) when the goal is to run the intelligence system itself.
+
+## Run locally
+
+From the repository root:
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+cd site
+corepack pnpm install --frozen-lockfile
+corepack pnpm dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open `http://localhost:3000`. A full checkout is required because the build reads the repository-level metrics ledger.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Quality gates
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+```bash
+corepack pnpm check:metrics
+corepack pnpm check:public-install-contract
+corepack pnpm check:layout-contract
+corepack pnpm check:deploy-contract
+corepack pnpm lint
+corepack pnpm build
+```
 
-## Learn More
+The deployment contract is machine-readable at [`src/lib/deployment-contract.json`](src/lib/deployment-contract.json). The build fails when the source, Root Directory, zero-secret promise, CTA language, or documentation drifts from that contract.
 
-To learn more about Next.js, take a look at the following resources:
+## Verify a deployment
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+After Vercel reports `Ready`, open:
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+- `/protocol` — the open substrate specification;
+- `/architecture` — the system model;
+- `/research` — published substrate research;
+- `/api/vaults` — the read-only public vault index.
 
-## Deploy on Vercel
+Git integration creates previews for future commits. Connect a custom domain only after the generated Vercel URL passes those checks.
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+## Customize and update
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+Edit routes in `src/app`, shared components in `src/components`, and public assets in `public`. Preserve the deployment contract when changing the project boundary.
+
+To pull future upstream work into the cloned repository:
+
+```bash
+git remote add upstream https://github.com/frankxai/Starlight-Intelligence-System.git
+git fetch upstream
+git merge upstream/main
+```
+
+Review the diff and let Vercel create a preview before merging changes into the production branch.
+
+**Built on SIP — Starlight Intelligence Protocol v1.1.1**

--- a/site/design-evidence/vercel-deploy-product-2026-08-25.md
+++ b/site/design-evidence/vercel-deploy-product-2026-08-25.md
@@ -1,0 +1,86 @@
+# Starlight Explorer Deploy Product Brief
+
+## Surface
+
+Public hybrid product/marketing route at `/deploy` plus the global CTA, repository onboarding, and deterministic deploy contract.
+
+## Audience and job
+
+The primary visitor is an experienced AI builder, technical founder, or agent-system operator. They want a public, inspectable surface they can own and adapt without confusing a hosted website with the local intelligence runtime.
+
+Their first useful win is understanding the deployment boundary in under a minute, then creating a named Vercel project without secrets or hidden infrastructure.
+
+## Language brief
+
+- Visitor vocabulary: fork, project, public site, deployment, source, endpoint, local runtime, private memory.
+- Internal vocabulary to avoid: Queen lanes, estate control plane, swarm admission, provider routing.
+- Dominant anxiety: “Am I deploying the actual agent system, or only a website?”
+- Required proof: exact source directory, exact outputs, explicit exclusions, no-secret requirement, update path, public route examples.
+- Emotional transition: ambiguity → control.
+- Primary action: **Deploy Starlight Explorer**.
+
+## Product loop
+
+1. Inspect the two-layer boundary.
+2. Confirm what Vercel will create and what remains local.
+3. Open the preconfigured Vercel clone flow.
+4. Receive a forked repository and hosted Explorer.
+5. Verify protocol, source, and health routes.
+6. Customize source and let Git integration create future previews.
+
+## Scene brief
+
+## Concepts considered
+
+1. **Boundary ledger — selected.** An asymmetric source-to-host trace paired with a precise hosted/local ledger. It answers the visitor's dominant question with the fewest visual primitives and no new runtime.
+2. **Deployment terminal receipt.** A full console metaphor that made the page feel like an internal operator surface and raised the cognitive load for first-time visitors.
+3. **Two-plane constellation.** A spatial hosted/local diagram that fit the brand world but needed custom motion or WebGL to explain the deployment sequence reliably.
+
+## Component inventory
+
+- Reuse: global `Header`, `Footer`, `StarlightMark`, layout typography, dot grid, focus behavior, and `transition-micro` motion token.
+- Add: one static `/deploy` route, one machine-readable deployment contract, and one contract checker.
+- External action: Vercel clone flow only after the boundary is visible.
+- New dependencies, media, WebGL, and client state: none.
+
+### Scene 1 — The boundary
+
+- Job: answer the deploy question immediately.
+- Dominant idea: a central deployment corridor splitting into hosted Explorer and local intelligence runtime.
+- Copy: concrete nouns and mechanisms; no hype.
+- Interaction: compact source → build → live trace with inspectable labels.
+- Static first frame: fully understandable without motion or JavaScript state.
+- Mobile: trace becomes a vertical sequence; two boundary panels stack.
+- Reduced motion: identical static composition.
+
+### Scene 2 — What arrives
+
+- Job: make the one-click artifact tangible.
+- Evidence: forked repo, Next.js project, public routes, Git previews, zero required secrets.
+- Composition: one evidence ledger, not a generic equal-card feature grid.
+
+### Scene 3 — What stays sovereign
+
+- Job: prevent category error.
+- Evidence: private vaults, MCP runtime, workers, credentials, and orchestration remain outside Vercel.
+
+### Scene 4 — Deploy and verify
+
+- Job: create the project with informed consent.
+- Primary CTA: Deploy Starlight Explorer.
+- Secondary routes: inspect source and run the local quickstart.
+- After-action proof: named route checks and update instructions.
+
+## Motion and assets
+
+Motion job: reveal the deployment trace from source to public URL. Use existing CSS/Track A timing only; no new runtime, image, 3D, video, or external asset. The static story carries the entire meaning.
+
+## Quality and performance budget
+
+- Reuse existing Starlight tokens, typography, header, footer, and page shell.
+- No new dependency or client component.
+- No new remote asset or rights surface.
+- Keep the route server-rendered and mostly static.
+- Keyboard focus, tap targets, semantics, contrast, mobile composition, and reduced-motion behavior must remain native.
+
+**Built on SIP — Starlight Intelligence Protocol v1.1.1**

--- a/site/package.json
+++ b/site/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "node scripts/check-metrics-contract.mjs && node scripts/check-public-install-contract.mjs && node scripts/check-layout-contract.mjs && next build",
+    "build": "node scripts/check-metrics-contract.mjs && node scripts/check-public-install-contract.mjs && node scripts/check-layout-contract.mjs && node scripts/check-deploy-contract.mjs && next build",
     "check:public-install-contract": "node scripts/check-public-install-contract.mjs",
     "check:layout-contract": "node scripts/check-layout-contract.mjs",
+    "check:deploy-contract": "node scripts/check-deploy-contract.mjs",
     "start": "next start",
     "lint": "eslint",
     "check:metrics": "node scripts/check-metrics-contract.mjs"

--- a/site/scripts/check-deploy-contract.mjs
+++ b/site/scripts/check-deploy-contract.mjs
@@ -1,0 +1,67 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const siteRoot = resolve(scriptDir, "..");
+const repoRoot = resolve(siteRoot, "..");
+const contractPath = resolve(siteRoot, "src/lib/deployment-contract.json");
+const contract = JSON.parse(readFileSync(contractPath, "utf8"));
+
+const failures = [];
+const expect = (condition, message) => {
+  if (!condition) failures.push(message);
+};
+const read = (relativePath) => readFileSync(resolve(repoRoot, relativePath), "utf8");
+
+expect(contract.schemaVersion === "1.0.0", "deployment contract schemaVersion must be 1.0.0");
+expect(contract.productName === "Starlight Explorer", "deployment product must be named Starlight Explorer");
+expect(
+  contract.repositoryUrl === "https://github.com/frankxai/Starlight-Intelligence-System",
+  "deployment source must be the canonical public repository",
+);
+expect(contract.rootDirectory === "site", "Vercel root directory must be site");
+expect(contract.projectName === "starlight-explorer", "default Vercel project name must be stable");
+expect(contract.repositoryName === "starlight-explorer", "default cloned repository name must be stable");
+expect(
+  Array.isArray(contract.requiredEnvironmentVariables) && contract.requiredEnvironmentVariables.length === 0,
+  "the default public Explorer must remain deployable without environment variables",
+);
+
+for (const relativePath of [
+  "site/package.json",
+  "site/vercel.json",
+  "site/src/app/deploy/page.tsx",
+  "site/src/lib/deployment.ts",
+  "metrics/current.json",
+]) {
+  expect(existsSync(resolve(repoRoot, relativePath)), `missing deploy source: ${relativePath}`);
+}
+
+const deploymentSource = read("site/src/lib/deployment.ts");
+for (const parameter of ["repository-url", "root-directory", "project-name", "repository-name"]) {
+  expect(deploymentSource.includes(parameter), `deployment URL is missing ${parameter}`);
+}
+
+const navSource = read("site/src/lib/nav.ts");
+const headerSource = read("site/src/components/Header.tsx");
+const deployPage = read("site/src/app/deploy/page.tsx");
+const siteReadme = read("site/README.md");
+const rootReadme = read("README.md");
+
+expect(navSource.includes('href: "/deploy"'), "Build navigation must expose /deploy");
+expect(headerSource.includes("Deploy Explorer"), "global CTA must name the deployable product");
+expect(deployPage.toLowerCase().includes("sovereign runtime"), "deploy page must explain the sovereign runtime boundary");
+expect(deployPage.includes("Zero required environment variables"), "deploy page must state the environment contract");
+expect(siteReadme.includes("What Vercel creates"), "site README must document the hosted artifact");
+expect(siteReadme.includes("What remains local"), "site README must document the local boundary");
+expect(rootReadme.includes("Deploy Starlight Explorer"), "root README must name the deployable product");
+
+if (failures.length > 0) {
+  console.error("Deploy contract failed:\n" + failures.map((failure) => `- ${failure}`).join("\n"));
+  process.exit(1);
+}
+
+console.log(
+  `Deploy contract passed: ${contract.productName} → ${contract.repositoryUrl} (${contract.rootDirectory}/), ${contract.requiredEnvironmentVariables.length} required environment variables.`,
+);

--- a/site/src/app/deploy/page.tsx
+++ b/site/src/app/deploy/page.tsx
@@ -1,0 +1,268 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  ArrowRight,
+  ArrowUpRight,
+  Check,
+  CircleDot,
+  Cloud,
+  Code2,
+  Database,
+  GitBranch,
+  LockKeyhole,
+  Server,
+} from "lucide-react";
+import { GITHUB_URL } from "@/lib/nav";
+import { DEPLOYMENT_CONTRACT, VERCEL_DEPLOY_URL } from "@/lib/deployment";
+
+export const metadata: Metadata = {
+  title: "Deploy Starlight Explorer",
+  description:
+    "Create your own public Starlight Explorer on Vercel while the sovereign intelligence runtime and private memory remain local.",
+  openGraph: {
+    title: "Deploy Starlight Explorer — Starlight Intelligence",
+    description:
+      "One repository clone, one Vercel project, and a precise boundary between the public Explorer and your local intelligence runtime.",
+    type: "website",
+    images: [
+      {
+        url: "/opengraph-image",
+        width: 1200,
+        height: 630,
+        alt: "Deploy Starlight Explorer",
+      },
+    ],
+  },
+};
+
+const trace = [
+  { label: "Source", value: "frankxai/Starlight-Intelligence-System", icon: GitBranch },
+  { label: "Build root", value: "site/", icon: Code2 },
+  { label: "Runtime", value: "Next.js on Vercel", icon: Cloud },
+] as const;
+
+export default function DeployPage() {
+  return (
+    <div className="min-h-screen overflow-hidden bg-[#060609] text-slate-100">
+      <section className="relative border-b border-white/[0.06] px-6 pb-20 pt-20 md:pb-28 md:pt-28">
+        <div className="dot-grid pointer-events-none absolute inset-0 opacity-20" aria-hidden="true" />
+        <div
+          className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_72%_22%,rgba(124,58,237,0.16),transparent_34%),radial-gradient(circle_at_20%_70%,rgba(34,211,238,0.08),transparent_30%)]"
+          aria-hidden="true"
+        />
+
+        <div className="relative mx-auto max-w-6xl">
+          <div className="grid items-end gap-12 lg:grid-cols-[1.05fr_0.95fr]">
+            <div>
+              <p className="font-mono text-[11px] font-medium uppercase tracking-[0.24em] text-cyan-300">
+                Public interface · sovereign boundary
+              </p>
+              <h1 className="mt-6 max-w-4xl text-5xl font-semibold leading-[0.98] tracking-[-0.045em] text-white md:text-7xl">
+                Give Starlight a public home.
+              </h1>
+              <p className="mt-7 max-w-2xl text-lg leading-8 text-slate-300 md:text-xl">
+                Vercel creates your hosted <strong className="font-medium text-white">Starlight Explorer</strong>.
+                Your private memory, agent runtime, credentials, and orchestration stay in the environment you control.
+              </p>
+              <div className="mt-9 flex flex-col gap-3 sm:flex-row">
+                <a
+                  href={VERCEL_DEPLOY_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex min-h-12 items-center justify-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold text-[#060609] transition-micro hover:bg-cyan-50"
+                >
+                  Deploy Starlight Explorer
+                  <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+                </a>
+                <a
+                  href={GITHUB_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex min-h-12 items-center justify-center gap-2 rounded-full border border-white/[0.14] px-6 py-3 text-sm font-medium text-white transition-micro hover:border-white/30 hover:bg-white/[0.05]"
+                >
+                  Inspect the source
+                  <Code2 className="h-4 w-4" aria-hidden="true" />
+                </a>
+              </div>
+              <p className="mt-4 flex items-center gap-2 text-xs text-slate-500">
+                <LockKeyhole className="h-3.5 w-3.5 text-emerald-400" aria-hidden="true" />
+                Zero required environment variables. Vercel shows every setting before creation.
+              </p>
+            </div>
+
+            <div className="relative border border-white/[0.10] bg-[#0b0b12]/80 p-5 shadow-[0_24px_80px_rgba(0,0,0,0.35)] backdrop-blur-xl md:p-7">
+              <div className="mb-6 flex items-center justify-between border-b border-white/[0.07] pb-4">
+                <div>
+                  <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-slate-500">Deployment trace</p>
+                  <p className="mt-1 text-sm font-medium text-white">One source. Explicit boundary.</p>
+                </div>
+                <span className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-wider text-emerald-300">
+                  <CircleDot className="h-3.5 w-3.5" aria-hidden="true" /> Ready
+                </span>
+              </div>
+              <ol className="space-y-1" aria-label="Deployment trace">
+                {trace.map((item, index) => {
+                  const Icon = item.icon;
+                  return (
+                    <li key={item.label} className="grid grid-cols-[2.5rem_1fr] gap-3">
+                      <div className="flex flex-col items-center" aria-hidden="true">
+                        <span className="flex h-9 w-9 items-center justify-center border border-cyan-300/20 bg-cyan-300/[0.05] text-cyan-200">
+                          <Icon className="h-4 w-4" />
+                        </span>
+                        {index < trace.length - 1 && <span className="h-8 w-px bg-white/[0.10]" />}
+                      </div>
+                      <div className="pt-1.5">
+                        <p className="text-xs text-slate-500">{item.label}</p>
+                        <p className="mt-0.5 break-words font-mono text-xs text-slate-200">{item.value}</p>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ol>
+              <div className="mt-6 border-t border-white/[0.07] pt-5">
+                <div className="flex items-center justify-between gap-4 font-mono text-[10px] uppercase tracking-[0.16em] text-slate-500">
+                  <span>Result</span>
+                  <span className="text-violet-300">your-project.vercel.app</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-white/[0.06] px-6 py-20 md:py-28">
+        <div className="mx-auto max-w-6xl">
+          <div className="grid gap-12 lg:grid-cols-[0.68fr_1.32fr]">
+            <div>
+              <p className="font-mono text-[11px] uppercase tracking-[0.22em] text-slate-500">01 / The boundary</p>
+              <h2 className="mt-4 text-3xl font-semibold tracking-tight text-white md:text-4xl">
+                Two layers. One informed action.
+              </h2>
+              <p className="mt-5 max-w-md leading-7 text-slate-400">
+                The public Explorer communicates the protocol and exposes public artifacts. The sovereign runtime keeps the parts that carry identity, authority, and private context close to the operator.
+              </p>
+            </div>
+
+            <div className="border-l border-white/[0.10]">
+              <div className="grid gap-px bg-white/[0.08] md:grid-cols-2">
+                <article className="bg-[#0a0a10] p-7 md:p-8">
+                  <Cloud className="h-5 w-5 text-cyan-300" aria-hidden="true" />
+                  <p className="mt-5 font-mono text-[10px] uppercase tracking-[0.2em] text-cyan-300">Vercel creates</p>
+                  <h3 className="mt-2 text-xl font-medium text-white">The public Explorer</h3>
+                  <ul className="mt-6 space-y-4">
+                    {DEPLOYMENT_CONTRACT.publicSurfaces.map((item) => (
+                      <li key={item} className="flex gap-3 text-sm leading-6 text-slate-300">
+                        <Check className="mt-1 h-4 w-4 shrink-0 text-emerald-400" aria-hidden="true" />
+                        {item}
+                      </li>
+                    ))}
+                  </ul>
+                </article>
+
+                <article className="bg-[#0a0a10] p-7 md:p-8">
+                  <Database className="h-5 w-5 text-violet-300" aria-hidden="true" />
+                  <p className="mt-5 font-mono text-[10px] uppercase tracking-[0.2em] text-violet-300">Your environment retains</p>
+                  <h3 className="mt-2 text-xl font-medium text-white">The sovereign runtime</h3>
+                  <ul className="mt-6 space-y-4">
+                    {DEPLOYMENT_CONTRACT.localOnly.map((item) => (
+                      <li key={item} className="flex gap-3 text-sm leading-6 text-slate-300">
+                        <LockKeyhole className="mt-1 h-4 w-4 shrink-0 text-violet-300" aria-hidden="true" />
+                        {item}
+                      </li>
+                    ))}
+                  </ul>
+                </article>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-white/[0.06] bg-[#08080d] px-6 py-20 md:py-28">
+        <div className="mx-auto max-w-6xl">
+          <div className="grid gap-12 lg:grid-cols-[1fr_1fr]">
+            <div>
+              <p className="font-mono text-[11px] uppercase tracking-[0.22em] text-slate-500">02 / What happens</p>
+              <h2 className="mt-4 text-3xl font-semibold tracking-tight text-white md:text-4xl">
+                A transparent clone flow.
+              </h2>
+              <ol className="mt-9 space-y-7">
+                {[
+                  ["01", "Clone", `Vercel copies the public repository into your selected Git provider as “${DEPLOYMENT_CONTRACT.repositoryName}”.`],
+                  ["02", "Configure", `The project name is prefilled as “${DEPLOYMENT_CONTRACT.projectName}” and the build root is fixed to ${DEPLOYMENT_CONTRACT.rootDirectory}/.`],
+                  ["03", "Build", "Next.js compiles the public experience from inspectable source. No database, integration, or secret is requested."],
+                  ["04", "Own", "Your Git repository becomes the source of future previews and production releases."],
+                ].map(([number, title, body]) => (
+                  <li key={number} className="grid grid-cols-[2.75rem_1fr] gap-4">
+                    <span className="font-mono text-xs text-cyan-300">{number}</span>
+                    <div>
+                      <h3 className="font-medium text-white">{title}</h3>
+                      <p className="mt-1 text-sm leading-6 text-slate-400">{body}</p>
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            </div>
+
+            <aside className="self-start border border-white/[0.10] bg-[#060609] p-7 md:p-9" aria-labelledby="proof-heading">
+              <div className="flex items-start justify-between gap-6">
+                <div>
+                  <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-emerald-300">After deploy</p>
+                  <h2 id="proof-heading" className="mt-2 text-2xl font-semibold text-white">Verify the useful surfaces.</h2>
+                </div>
+                <Server className="h-5 w-5 shrink-0 text-emerald-300" aria-hidden="true" />
+              </div>
+              <div className="mt-7 divide-y divide-white/[0.07] border-y border-white/[0.07]">
+                {DEPLOYMENT_CONTRACT.verificationRoutes.map((route) => (
+                  <div key={route} className="flex min-h-12 items-center justify-between gap-4 py-3">
+                    <code className="text-sm text-slate-200">{route}</code>
+                    <span className="font-mono text-[10px] uppercase tracking-wider text-slate-500">public</span>
+                  </div>
+                ))}
+              </div>
+              <p className="mt-6 text-sm leading-6 text-slate-400">
+                Connect a custom domain when the project is ready. Git integration creates a preview for each change before production.
+              </p>
+            </aside>
+          </div>
+        </div>
+      </section>
+
+      <section className="px-6 py-20 md:py-28">
+        <div className="mx-auto grid max-w-6xl gap-10 border border-white/[0.10] bg-[linear-gradient(135deg,rgba(124,58,237,0.12),rgba(34,211,238,0.05)_55%,transparent)] p-8 md:grid-cols-[1fr_auto] md:items-end md:p-12">
+          <div>
+            <p className="font-mono text-[11px] uppercase tracking-[0.22em] text-violet-300">03 / Create your copy</p>
+            <h2 className="mt-4 max-w-2xl text-3xl font-semibold tracking-tight text-white md:text-5xl">
+              Make the Explorer yours.
+            </h2>
+            <p className="mt-5 max-w-2xl leading-7 text-slate-300">
+              Start with the working public system, inspect every line, then shape the routes, identity, and research surface around the intelligence you want to share.
+            </p>
+          </div>
+          <div className="flex flex-col gap-3 sm:flex-row md:flex-col">
+            <a
+              href={VERCEL_DEPLOY_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex min-h-12 items-center justify-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold text-[#060609] transition-micro hover:bg-cyan-50"
+            >
+              Deploy on Vercel
+              <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+            </a>
+            <Link
+              href="/quickstart"
+              className="inline-flex min-h-12 items-center justify-center gap-2 rounded-full border border-white/[0.14] px-6 py-3 text-sm font-medium text-white transition-micro hover:border-white/30 hover:bg-white/[0.05]"
+            >
+              Run the local system
+              <ArrowRight className="h-4 w-4" aria-hidden="true" />
+            </Link>
+          </div>
+        </div>
+        <div className="mx-auto mt-8 flex max-w-6xl items-center gap-2 text-xs text-slate-500">
+          <GitBranch className="h-3.5 w-3.5" aria-hidden="true" />
+          Deployment contract v{DEPLOYMENT_CONTRACT.schemaVersion} · MIT source · Built on SIP
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/site/src/app/sitemap.ts
+++ b/site/src/app/sitemap.ts
@@ -10,6 +10,7 @@ const STATIC_ROUTES = [
   "/perspectives/personal-superintelligence-for-everyone",
   "/protocol",
   "/download",
+  "/deploy",
   "/quickstart",
   "/architecture",
   "/explainer",
@@ -49,7 +50,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority:
       path === ""
         ? 1.0
-        : path === "/protocol" || path === "/download" || path === "/quickstart" || path === "/research"
+        : path === "/protocol" || path === "/download" || path === "/deploy" || path === "/quickstart" || path === "/research"
           ? 0.9
           : 0.7,
   }));

--- a/site/src/components/Header.tsx
+++ b/site/src/components/Header.tsx
@@ -137,14 +137,12 @@ function HeaderContent({ pathname }: { pathname: string }) {
             </svg>
             GitHub
           </a>
-          <a
+          <Link
             href={DEPLOY_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="ml-1 rounded-full bg-white px-4 py-1.5 text-[13px] font-medium text-[#060609] transition-micro hover:bg-white/90"
+            className="ml-1 whitespace-nowrap rounded-full bg-white px-4 py-1.5 text-[13px] font-medium text-[#060609] transition-micro hover:bg-white/90"
           >
-            Deploy
-          </a>
+            Deploy Explorer
+          </Link>
         </div>
 
         {/* Mobile toggle */}
@@ -206,14 +204,12 @@ function HeaderContent({ pathname }: { pathname: string }) {
               >
                 GitHub
               </a>
-              <a
+              <Link
                 href={DEPLOY_URL}
-                target="_blank"
-                rel="noopener noreferrer"
                 className="flex-1 rounded-lg bg-white px-4 py-2.5 text-center text-[14px] font-medium text-[#060609] transition-micro hover:bg-white/90"
               >
-                Deploy
-              </a>
+                Deploy Explorer
+              </Link>
             </div>
           </div>
         </div>

--- a/site/src/lib/deployment-contract.json
+++ b/site/src/lib/deployment-contract.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": "1.0.0",
+  "productName": "Starlight Explorer",
+  "repositoryUrl": "https://github.com/frankxai/Starlight-Intelligence-System",
+  "rootDirectory": "site",
+  "projectName": "starlight-explorer",
+  "repositoryName": "starlight-explorer",
+  "requiredEnvironmentVariables": [],
+  "publicSurfaces": [
+    "Protocol, architecture, research, and documentation",
+    "Public knowledge maps, Cosmos, and Memory Palace",
+    "Read-only public vault index and API routes",
+    "Git-connected preview and production deployments"
+  ],
+  "localOnly": [
+    "Private vault contents and operator memory",
+    "MCP server and agent runtime processes",
+    "Credentials, provider keys, and local configuration",
+    "Workers, orchestration, and control-plane services"
+  ],
+  "verificationRoutes": [
+    "/protocol",
+    "/architecture",
+    "/research",
+    "/api/vaults"
+  ]
+}

--- a/site/src/lib/deployment.ts
+++ b/site/src/lib/deployment.ts
@@ -1,0 +1,15 @@
+import deploymentContract from "./deployment-contract.json";
+
+export const DEPLOYMENT_CONTRACT = Object.freeze(deploymentContract);
+export const DEPLOY_PAGE_URL = "/deploy";
+
+const deployParams = [
+  ["repository-url", deploymentContract.repositoryUrl],
+  ["root-directory", deploymentContract.rootDirectory],
+  ["project-name", deploymentContract.projectName],
+  ["repository-name", deploymentContract.repositoryName],
+] as const;
+
+export const VERCEL_DEPLOY_URL = `https://vercel.com/new/clone?${deployParams
+  .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
+  .join("&")}`;

--- a/site/src/lib/nav.ts
+++ b/site/src/lib/nav.ts
@@ -24,6 +24,7 @@ export const NAV_GROUPS: NavGroup[] = [
   {
     label: "Build",
     items: [
+      { href: "/deploy", label: "Deploy Explorer", desc: "Own the public Starlight interface" },
       { href: "/quickstart", label: "Quickstart", desc: "Five minutes to first context" },
       { href: "/download", label: "Source & Modules", desc: "Build SIP source or get modules" },
       { href: "/cockpit", label: "Cockpit", desc: "The spec-trace console" },
@@ -45,8 +46,7 @@ export const NAV_GROUPS: NavGroup[] = [
 
 export const GITHUB_URL = "https://github.com/frankxai/Starlight-Intelligence-System";
 export const ARCANEA_URL = "https://arcanea.ai";
-export const DEPLOY_URL =
-  "https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Ffrankxai%2FStarlight-Intelligence-System&root-directory=site";
+export { DEPLOY_PAGE_URL as DEPLOY_URL } from "@/lib/deployment";
 
 /** External + newcomer links — Footer "Connect" column. */
 export const CONNECT_LINKS: { href: string; label: string; external?: boolean }[] = [

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -1,3 +1,4 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "ignoreCommand": null
 }


### PR DESCRIPTION
Defines the Vercel artifact as Starlight Explorer, adds an informed /deploy experience, makes the hosted/local boundary explicit, replaces the site boilerplate with operator documentation, and enforces the clone settings through a build-time deployment contract. Local evidence: focused ESLint, copy scan, four contract gates, TypeScript, and the full Next.js production build pass.