### PR TITLE
Fix public vault count honesty on starlightintelligence.org

### DIFF
--- a/site/src/app/page.tsx
+++ b/site/src/app/page.tsx
@@ -157,7 +157,7 @@ const OPERATING_STEPS: OperatingStep[] = [
   },
   {
     title: "Recall",
-    desc: "Vaults retrieve strategic, technical, creative, and operational memory.",
+    desc: "Public vault and operator-held local memory retrieve what the run is allowed to see.",
     icon: Database,
   },
   {

--- a/site/src/components/OperationalProofConsole.tsx
+++ b/site/src/components/OperationalProofConsole.tsx
@@ -25,7 +25,7 @@ type ProofLane = {
 const PROOF_LANES: ProofLane[] = [
   {
     label: "Memory",
-    value: "6 vaults",
+    value: "1 public vault",
     state: "context locked",
     icon: Database,
     tone: "text-blue-600",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the remaining vault count honesty issues on the public site to match the live API state (GET /api/vaults returns count:1).

## Changes

1. **Proof Console** (`OperationalProofConsole.tsx`): Changed Memory value from "6 vaults" to "1 public vault"
2. **Operating Loop** (`page.tsx`): Updated Recall description from "Vaults retrieve strategic, technical, creative, and operational memory" to "Public vault and operator-held local memory retrieve what the run is allowed to see"

## Context

- Previous PR #92 already updated navigation, Durable Memory section, census chip, and Horizon copy
- `metrics/current.json` already correctly shows `starlight_vaults: { value: 1 }`
- These were the last two visible honesty issues on the homepage

## Verification

After deploy, homepage will no longer claim "6 vaults" anywhere visible to users. The distinction between the one public vault (Horizon) and the six operator-private categories is now clear throughout the site.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb0ab70a-e2dd-4ecc-85e0-dfe76fc4f3e2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb0ab70a-e2dd-4ecc-85e0-dfe76fc4f3e2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

