### PR TITLE
Enforce one Vercel deploy path and draft-gate CI

### DIFF
--- a/.github/workflows/harness-check.yml
+++ b/.github/workflows/harness-check.yml
@@ -15,6 +15,7 @@ name: Harness check
 on:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [main]
 
@@ -27,7 +28,9 @@ concurrency:
 
 jobs:
   harness:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -14,20 +14,21 @@
 # pinned semver for human readability — dependabot updates both the SHA
 # and the comment together.
 
-name: Deploy site/ to Vercel
+name: Manual site/ Vercel Deploy
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "site/**"
-      - ".github/workflows/vercel-deploy.yml"
+  # Emergency/manual deploy path only. The canonical `site` Vercel project
+  # deploys automatically through Vercel's native Git integration.
   workflow_dispatch:
+    inputs:
+      confirm_production:
+        description: "Type deploy-production to confirm the manual production deploy"
+        required: true
+        type: string
 
 concurrency:
   group: vercel-deploy-prod
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -43,6 +44,7 @@ jobs:
     # deploy job skips cleanly and deploys stay manual
     # (cd site && pnpm dlx vercel deploy --prod --yes).
     runs-on: ubuntu-latest
+    if: ${{ github.event.inputs.confirm_production == 'deploy-production' }}
     outputs:
       has-secrets: ${{ steps.check.outputs.has }}
     steps:

--- a/docs/ops/GITOPS-COST-HEAL-2026-08-26.md
+++ b/docs/ops/GITOPS-COST-HEAL-2026-08-26.md
@@ -1,0 +1,11 @@
+# GitOps Cost Heal — 2026-08-26
+
+The canonical Vercel project is `site`, which owns `starlightintelligence.org`. The duplicate project `starlight-intelligence-system` had no unique production domain and was removed after verification; its historic deployments were permanently deleted, while the canonical project and domains were preserved.
+
+This repository now has one automatic deployment route: the canonical Vercel project's native Git integration. `.github/workflows/vercel-deploy.yml` remains available as a confirmation-gated manual production fallback, but no longer starts on every `site/` push and cannot create a second deployment for the same commit.
+
+`site/vercel.json` now ignores a deployment when Vercel's previous and current commit SHAs contain no changes under the configured `site/` root. If either SHA is unavailable or Git cannot determine the diff, the command exits non-zero and Vercel builds, preserving the fail-open safety posture.
+
+The high-frequency Harness check now skips draft PR iterations, runs when a draft becomes ready, cancels stale runs through its existing concurrency guard, and has a 20-minute ceiling. No required branch-protection status was configured on `main`, so this changes cost timing without bypassing a required merge check.
+
+Rollback is a normal Git revert. Re-enabling automatic CLI deployment is safe only after native Git deployment is explicitly disabled for the canonical Vercel project.

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": null
+  "ignoreCommand": "if [ -z \"${VERCEL_GIT_PREVIOUS_SHA:-}\" ] || [ -z \"${VERCEL_GIT_COMMIT_SHA:-}\" ]; then exit 1; fi; git diff --quiet \"$VERCEL_GIT_PREVIOUS_SHA\" \"$VERCEL_GIT_COMMIT_SHA\" -- . >/dev/null 2>&1; [ $? -eq 0 ]"
 }


### PR DESCRIPTION
## Outcome

Removes the automatic second Vercel deployment route while preserving a confirmation-gated manual fallback.

## Changes

- makes the Vercel CLI production workflow manual-only
- requires the exact deploy-production confirmation input
- enables site-scoped ignored-build diffing
- skips Harness check on draft iterations and reruns it on ready_for_review
- adds a 20-minute Harness ceiling

## Live infrastructure

The duplicate Vercel project starlight-intelligence-system was removed after verifying canonical project site owns starlightintelligence.org and www.starlightintelligence.org.

## Verification

- edited YAML and JSON parse
- ignored-build command skips identical SHAs and fails open when SHAs are absent
- canonical Vercel project remains READY with production domains intact