### PR TITLE
Correct rights-holder attribution and define SIS license split

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Frank Riemer / Starlight Holding
+Copyright (c) 2026 Frank Riemer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,20 @@
+# Licensing boundary
+
+**Current rights holder:** Frank Riemer  
+**Current repository license:** MIT, as stated in `LICENSE`
+
+This file records the migration target; it does not revoke rights already granted under MIT.
+
+## Target decomposition
+
+| Material | Target license |
+|---|---|
+| SIP protocol, schemas, interoperability contracts, reference SDKs, and public connectors | Apache-2.0 |
+| Commercial cockpit, hosted system, enterprise control plane, and public server source | FSL-1.1-ALv2 or proprietary/private |
+| Arcanea canon, characters, music, narratives, images, designs, and brand assets | All rights reserved by Frank Riemer |
+| Deliberately reusable public tutorials | CC BY 4.0, only when explicitly marked |
+| Third-party material | Its upstream license and notices |
+
+Until the repository is split at those boundaries, `LICENSE` remains authoritative for the current release. New canon and commercially sensitive product material must not be added to the MIT-governed surface.
+
+A future Dutch eenmanszaak does not become a separate copyright owner. A future BV must receive the IP through a written assignment before its name appears as rights holder.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Starlight Intelligence System
-Copyright (c) 2026 Frank Riemer / Starlight Holding
+Copyright (c) 2026 Frank Riemer
 
 This product is licensed under the MIT License (see LICENSE).
 
@@ -37,7 +37,7 @@ Substrate spec documents (SIP.md and the file-contract files listed above):
 
 Arcanea canon (Guardian names, Vel'Tara archetypes, Hz grounding, realm
 and essence vocabulary — when present in forks that opt-in to it):
-    CC-BY-NC 4.0, © Arcanea BV. Lives in a separate repo
+    CC-BY-NC 4.0, © Frank Riemer. Lives in a separate repo
     (frankxai/arcanea-ecosystem). Compose-only; canon is not redistributed
     under the MIT license of this repository.
 
@@ -45,8 +45,9 @@ and essence vocabulary — when present in forks that opt-in to it):
 Trademarks
 ================================================================================
 
-ARCANEA, FRANKX, STARLIGHT INTELLIGENCE — registered or in registration.
-All rights reserved.
+ARCANEA, FRANKX, and STARLIGHT INTELLIGENCE are brand identifiers claimed by
+Frank Riemer. Registration status is not asserted here. No trademark rights
+are granted by this repository.
 
 "Built on SIP" is an attestation phrase, not a trademark. Use of the
 phrase requires actual SIP composition per /sip-attest rules.

--- a/cockpit/LICENSE
+++ b/cockpit/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Frank Riemer / Starlight Holding
+Copyright (c) 2026 Frank Riemer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/cockpit/NOTICE
+++ b/cockpit/NOTICE
@@ -1,5 +1,5 @@
 Cockpit Continuity
-Copyright (c) 2026 Frank Riemer / Starlight Holding
+Copyright (c) 2026 Frank Riemer
 
 Built on the Starlight Intelligence Protocol (SIP) substrate.
 

--- a/docs/drafts/LICENSE-draft.md
+++ b/docs/drafts/LICENSE-draft.md
@@ -41,7 +41,7 @@ If Arcanea-run-graph stays separately governed, suggest a parallel LICENSE there
 ```
 MIT License
 
-Copyright (c) 2026 Arcanea BV / FrankX <frank@frankx.ai>
+Copyright (c) 2026 Frank Riemer <frank@frankx.ai>
 
 [ same MIT text as above ]
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@arcanea/starlight-intelligence-system",
   "version": "8.3.0",
-  "description": "Starlight Intelligence System \u2014 substrate (SIP protocol, alliance forging method, attestation) + reference operational layer (6 semantic vaults, SQLite hybrid retrieval, temporal reasoning, MCP server, platform adapters, sanitization gateway, empirical sandbox, active healing)",
+  "description": "Starlight Intelligence System — substrate (SIP protocol, alliance forging method, attestation) + reference operational layer (6 semantic vaults, SQLite hybrid retrieval, temporal reasoning, MCP server, platform adapters, sanitization gateway, empirical sandbox, active healing)",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/frankxai/Starlight-Intelligence-System.git"
@@ -164,7 +164,7 @@
     "gemini-cli",
     "platform-adapters"
   ],
-  "author": "FrankX <frank@frankx.ai>",
+  "author": "Frank Riemer <frank@frankx.ai>",
   "license": "MIT",
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",


### PR DESCRIPTION
## Decision

Frank Riemer is the current rights holder. Non-existent Starlight and Arcanea entities must not appear in legal notices.

## Changes

- corrects root and cockpit license/NOTICE attribution
- corrects the obsolete license draft
- replaces the package author brand alias with Frank Riemer
- avoids asserting trademark registration status
- documents the target decomposition:
  - Apache-2.0 for SIP, schemas, SDKs, and connectors
  - FSL-1.1-ALv2 or proprietary/private for cockpit and commercial control planes
  - all rights reserved for Arcanea canon and brand assets

## Important

The current repository remains MIT until those layers are physically split. This PR does not revoke existing MIT rights; it prevents false ownership claims and records the migration boundary.