### PR TITLE
chore: install Starlight Intelligence editorial contract

### DIFF
--- a/.agents/skills/frank-brand-editor/SKILL.md
+++ b/.agents/skills/frank-brand-editor/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: frank-brand-editor
+description: Use for any public copy in this repository. Load CREATOR.md, preserve facts and search intent, and run the Starlight editorial gate.
+---
+
+# Repository brand editor
+
+Read `CREATOR.md` and the managed editorial block in `AGENTS.md`. Apply them to websites, UI labels, articles, social copy, email, sales material, and scripts. Preserve exact quotations, code, legal wording, and necessary technical terms. Run the repository's pinned editorial audit before release.

--- a/.cursor/rules/editorial.mdc
+++ b/.cursor/rules/editorial.mdc
@@ -1,12 +1,7 @@
-# STARLIGHT CENTRAL COMMAND: Starlight-Intelligence-System
-
-You are the **Central Brain** of the FrankX ecosystem.
-
-## Core Mandates
-- **Master Coordination**: You oversee all other repositories (Arcanea, FrankX, etc.).
-- **Global Memory**: You are the source of truth for machine-wide context and agent history.
-- **Autonomous Ops**: Execute with full autonomy (`--yolo`) to maintain system health.
-- **Machine Audit**: Perform periodic sweeps of all repo `MEMORY.md` files to update the global state.
+---
+description: Portfolio brand and editorial contract
+alwaysApply: true
+---
 
 <!-- STARLIGHT-EDITORIAL:START -->
 ## Editorial contract

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,13 +1,3 @@
-# STARLIGHT CENTRAL COMMAND: Starlight-Intelligence-System
-
-You are the **Central Brain** of the FrankX ecosystem.
-
-## Core Mandates
-- **Master Coordination**: You oversee all other repositories (Arcanea, FrankX, etc.).
-- **Global Memory**: You are the source of truth for machine-wide context and agent history.
-- **Autonomous Ops**: Execute with full autonomy (`--yolo`) to maintain system health.
-- **Machine Audit**: Perform periodic sweeps of all repo `MEMORY.md` files to update the global state.
-
 <!-- STARLIGHT-EDITORIAL:START -->
 ## Editorial contract
 

--- a/.github/workflows/starlight-editorial-contract.yml
+++ b/.github/workflows/starlight-editorial-contract.yml
@@ -1,0 +1,11 @@
+name: Starlight editorial contract
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  editorial-contract:
+    uses: frankxai/starlight-design-intelligence/.github/workflows/editorial-contract.yml@50ae34c7ac06e6c083f277ca96c3bde8f0a39b43

--- a/.starlight/editorial-contract.json
+++ b/.starlight/editorial-contract.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": "starlight.editorial_contract.v1",
+  "brand_id": "sis",
+  "source": {
+    "repository": "frankxai/starlight-design-intelligence",
+    "ref": "50ae34c7ac06e6c083f277ca96c3bde8f0a39b43",
+    "profile": "brand-packs/sis/COPY.md",
+    "profile_sha256": "1e11c5df6eb132b4125ee164c0182941b7834fff26681772862eeed065ee0e87"
+  },
+  "content_roots": [
+    "app",
+    "components",
+    "content",
+    "data",
+    "lib",
+    "pages",
+    "src"
+  ],
+  "generated_files": [
+    "CREATOR.md",
+    "AGENTS.md",
+    "CLAUDE.md",
+    "GEMINI.md",
+    ".github/copilot-instructions.md",
+    ".cursor/rules/editorial.mdc",
+    ".agents/skills/frank-brand-editor/SKILL.md",
+    ".github/workflows/starlight-editorial-contract.yml",
+    ".starlight/editorial-contract.json"
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -315,3 +315,17 @@ For any site, app, landing page, dashboard, visual identity, brand, motion, medi
 - C:\Users\frank\starlight\repos\VISUAL_QA_GATE.md
 
 When motion, scroll, generated media, GIF/video, or premium polish matters, route through the Motion Design Studio plugin/skills and verify the result visually.
+
+<!-- STARLIGHT-EDITORIAL:START -->
+## Editorial contract
+
+Brand: **Starlight Intelligence Systems** (`sis`)
+
+- Read `CREATOR.md` before changing public or customer-facing copy.
+- Apply the registered brand voice and the shared editorial gate.
+- Reject generated prestige language, rhetorical contrast formulas, invented claims, and abstract labels that hide simple facts.
+- Keep public labels in sentence case.
+- Run the changed-copy editorial audit before release.
+
+Pinned source: https://github.com/frankxai/starlight-design-intelligence/blob/50ae34c7ac06e6c083f277ca96c3bde8f0a39b43/brand-packs/sis/COPY.md
+<!-- STARLIGHT-EDITORIAL:END -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,3 +340,17 @@ High-leverage rules for every Claude Code session. Distilled from Karpathy's 202
 - Prefer one careful pass with verification over many fast passes; speed without a check loop compounds error and erodes trust.
 - When tests, types, or runtime disagree with your mental model, the mental model is wrong — re-read, do not rationalize.
 - Hallucination is the default behavior of the substrate, not a bug to be scolded away; design every workflow assuming outputs must be checked before they become irreversible.
+
+<!-- STARLIGHT-EDITORIAL:START -->
+## Editorial contract
+
+Brand: **Starlight Intelligence Systems** (`sis`)
+
+- Read `CREATOR.md` before changing public or customer-facing copy.
+- Apply the registered brand voice and the shared editorial gate.
+- Reject generated prestige language, rhetorical contrast formulas, invented claims, and abstract labels that hide simple facts.
+- Keep public labels in sentence case.
+- Run the changed-copy editorial audit before release.
+
+Pinned source: https://github.com/frankxai/starlight-design-intelligence/blob/50ae34c7ac06e6c083f277ca96c3bde8f0a39b43/brand-packs/sis/COPY.md
+<!-- STARLIGHT-EDITORIAL:END -->

--- a/CREATOR.md
+++ b/CREATOR.md
@@ -1,0 +1,39 @@
+<!-- STARLIGHT-EDITORIAL:START -->
+# Starlight Intelligence Systems voice
+
+Pinned source: https://github.com/frankxai/starlight-design-intelligence/blob/50ae34c7ac06e6c083f277ca96c3bde8f0a39b43/brand-packs/sis/COPY.md
+
+# Starlight Intelligence editorial language
+
+## Reader and decision
+
+Write for AI architects, technical founders, institutions, investors, and operators designing long-lived intelligence infrastructure. The reader should understand the architectural consequence and the next decision.
+
+## Voice
+
+- Visionary, sober, systemic, and benevolent.
+- Move from consequence to architecture to decision.
+- Use technical nouns with stable meanings.
+- Label deployed systems, active experiments, proposals, and aspirations accurately.
+- Support important claims with primary evidence, traces, evaluations, or working artifacts.
+
+## Native language
+
+Agent owner, memory boundary, trace, evaluation, provenance, control, handoff, operator, cost, latency, risk, evidence.
+
+Celestial terms can organize information. They should never replace the system state being described.
+
+## Avoid
+
+- Science-fiction fog and AGI prophecy.
+- Cosmic decoration presented as architecture.
+- Institutional boilerplate.
+- Claims about humanity without a concrete mechanism or source.
+- Mythic Arcanea language.
+
+## Examples
+
+“Every agent needs an owner, a memory boundary, and a visible record of action.”
+
+“This evaluation shows where the workflow failed, who owns the next decision, and which evidence is still missing.”
+<!-- STARLIGHT-EDITORIAL:END -->


### PR DESCRIPTION
Installs the Starlight Intelligence editorial contract pinned to `50ae34c7ac06e6c083f277ca96c3bde8f0a39b43`.

- preserves existing agent instructions through managed blocks
- autoloads the contract for Codex, Claude, Gemini, Cursor, and Copilot
- installs the repository-local brand editor skill
- blocks new public-copy hard failures through changed-line CI

Canonical source: frankxai/starlight-design-intelligence#14

---
Consolidated into main by [PR #133](https://github.com/frankxai/Starlight-Intelligence-System/pull/133), commit `3f9f53eea13012319d5a6878ce6eef0a29b99123`, on 2026-09-06. This original PR is closed as superseded after exact-head source verification. Integration reconciliations, independent review, and scope limits are recorded in the linked PR and branch audit. Original source history remains in this PR.
