### PR TITLE
Reference intelligence: Refero + Manus operating layer

### DIFF
--- a/REFERENCE-INTELLIGENCE.md
+++ b/REFERENCE-INTELLIGENCE.md
@@ -1,0 +1,136 @@
+# Starlight Reference Intelligence
+
+Reference intelligence turns external design evidence and Frank's preference decisions into executable constraints for agents. It is not a bookmark collection and it is not permission to copy.
+
+## Authority order
+
+When sources disagree, use this order:
+
+1. Brand constitution, product truth, and repository-local `taste.md` / `design.md`.
+2. Approved preference receipts in the private Starlight Quality Index.
+3. A locked primary reference with bounded secondary references.
+4. Live research from Refero or another named source.
+5. General model knowledge.
+
+External references inform decisions. They never override owned canon, accessibility, factual integrity, product behavior, or production constraints.
+
+## System boundaries
+
+| Surface | Role | May do | Must not do |
+|---|---|---|---|
+| ChatGPT Work Mode | Direction, live public research, visual review, human curation | Inspect public references, compare options, write approved decisions to Notion/GitHub | Pretend a connector is persistent when it is not available in the current session |
+| Codex / Claude Code | Primary implementation and visual QA | Query Refero, compile repo-local design contracts, implement, render, compare, test | Build substantial visual work from vague adjectives alone |
+| Hermes | Persistent curator and scheduled research operator | Watch approved sources, normalize records, maintain freshness, prepare candidate packs | Promote candidates to canon without an approval receipt |
+| Manus | Burst execution worker | Produce alternative prototypes, wide research, or isolated full-project explorations | Become the source of truth, silently publish production, or overwrite canonical repos |
+| Notion | Human curation cockpit | Triage, approve, reject, annotate, assign brand/surface roles | Hold the only machine-executable copy of a design decision |
+| GitHub | Executable truth | Store contracts, catalogs, receipts, schemas, and project-local overrides | Store secrets or redistribute unlicensed source assets |
+
+## Reference classes
+
+Every item has exactly one rights class:
+
+- `reference-only`: analyze principles; do not ship the source asset, composition, copy, or proprietary font.
+- `licensed-production`: production use is allowed only within recorded license boundaries.
+- `owned-or-generated`: owned, commissioned, or generated source that may enter production after provenance and quality gates.
+- `unknown`: intake only. It cannot influence production until resolved.
+
+Every item also has a decision state: `candidate`, `approved`, `rejected`, or `archived`.
+
+## Required record
+
+A usable record contains:
+
+- stable ID, title, canonical URL, owner/creator, capture date, last verification date;
+- source type: style, screen, flow, site, component, motion, imagery, copy, or tool;
+- rights class and evidence;
+- applicable brands, surfaces, and bounded role;
+- observed principles, signature memory, and anti-reference;
+- hard constraints and explicit non-transferable traits;
+- quality, distinctiveness, relevance, and confidence scores;
+- decision owner, decision state, and rationale;
+- production artifacts or preference receipts created from the item.
+
+A URL without this context is only an inbox item.
+
+## Operating loop
+
+1. **Capture** a URL, screenshot, Refero style/screen/flow ID, or owned artifact.
+2. **Normalize** provenance, rights, source type, brand, surface, and role.
+3. **Extract principles**: hierarchy, rhythm, typography posture, material, interaction causality, media treatment, proof behavior, or journey logic.
+4. **Reject copying**: record what must not be transferred.
+5. **Compare** candidates against the same real product content and target viewport.
+6. **Approve** one dominant foundation; assign secondary references narrow jobs.
+7. **Compile** the decision into repo-local `DESIGN.md`, tokens, component rules, and a reference lock.
+8. **Implement and render** mobile plus desktop states.
+9. **Judge** deterministic gates first, then blind or producer-independent taste review for consequential work.
+10. **Record the preference receipt**: winner, loser, rationale, judge, confidence, and links to rendered evidence.
+11. **Refresh or archive** when the live source, brand strategy, or implementation constraints change.
+
+## Reference lock
+
+Before substantial visual implementation, record:
+
+```text
+Primary foundation: <approved source or owned direction>
+Preserve: <3-5 signature traits>
+Secondary sources: <source -> one bounded job>
+Role rules: <CTA-only, typography-only, flow-only, etc.>
+Media strategy: <owned/generated/licensed/placeholder + dimensions>
+Reject: <generic defaults and source traits that must not transfer>
+Token commitments: <canvas, type, accent, spacing, radius, border/shadow>
+Decision owner: <human>
+```
+
+One source owns the foundation. Secondary sources do not get averaged into a safe centroid.
+
+## Hard rejection gates
+
+Reject an artifact regardless of its taste score when it contains:
+
+- copied or unlicensed production material;
+- fabricated product proof or unsupported claims;
+- inaccessible interaction or illegible responsive states;
+- broken production constraints, runtime errors, or missing core states;
+- generic AI decoration replacing required product/media evidence;
+- no traceable reference lock for substantial visual work;
+- visual polish that contradicts the brand constitution or product truth.
+
+## Refero
+
+Refero is the default live research surface for web/product design evidence. Its three useful layers are styles, screens, and flows. The public Refero Styles library can provide agent-readable `DESIGN.md` material; the MCP adds live search across curated styles, product screens, and user flows.
+
+Official Codex installation:
+
+```bash
+codex plugin marketplace add referodesign/refero_skill
+codex plugin add refero@refero
+```
+
+Restart Codex and complete OAuth on first connection. The remote endpoint is `https://api.refero.design/mcp`. Project configs are kept under `integrations/mcp/`; no token belongs in Git.
+
+For Hermes running locally, add the remote MCP entry from `integrations/mcp/refero.hermes.yaml`, then run `hermes mcp login refero`. For a remote/headless Hermes gateway, use the dashboard OAuth flow, paste-back/SSH forwarding, or Hermes' official `mcp-oauth-remote-gateway` skill.
+
+## Manus
+
+Manus is an optional worker, not a design authority. Invoke it when the task benefits from autonomous wide research, a disposable alternative prototype, or long-running isolated execution. Keep Codex as the primary canonical implementation path.
+
+Install the official API v2 guidance for Codex:
+
+```bash
+npx skills add https://open.manus.ai/docs --skill manus-api --agent codex --global --yes
+```
+
+Store `MANUS_API_KEY` in the local secret manager or environment, never in Git. Use API v2 projects for shared instructions, files for inputs, tasks for execution, webhooks for completion, and website endpoints only for intentionally isolated Manus-hosted experiments. Export winning code/artifacts to a branch and run the normal Starlight review gates before promotion.
+
+Hermes may call Manus API v2 as a worker after a scoped local integration is configured. Give it a project/task allowlist, budget ceiling, output destination, and explicit confirmation gate for publishing or external writes.
+
+## Cost posture
+
+Use free/public Refero Styles and owned references for ordinary work. Use Refero MCP when screen/flow evidence materially changes a build. Use Manus credits only when autonomous breadth or execution latency is worth paying for. Neither tool replaces the preference memory accumulated in the Quality Index.
+
+## Canonical stores
+
+- Human cockpit: Notion — **Taste, Design & Worldbuilding** → **Taste & Reference Library**.
+- Machine preference memory: private `starlight-quality-index/references/catalog.yaml`.
+- Agent operating contract: this file plus repository-local `taste.md` and `design.md`.
+- Production artifacts: their owning product repositories and governed media fabric.

--- a/integrations/apis/manus-reference-worker.md
+++ b/integrations/apis/manus-reference-worker.md
@@ -1,0 +1,54 @@
+# Manus Reference Worker
+
+This adapter position lets Codex or Hermes delegate bounded work to Manus API v2 without making Manus the source of truth.
+
+## Use for
+
+- wide reference research that benefits from autonomous breadth;
+- a disposable alternative site or interaction prototype;
+- long-running isolated work where a webhook is more useful than holding a local agent session;
+- presentation, report, or data-processing variants that will be reviewed before use.
+
+Do not delegate ordinary repo edits, small visual fixes, or work Codex can complete with direct source access.
+
+## Contract
+
+Every invocation supplies:
+
+- `purpose`, `brand`, `surface`, and `acceptance_criteria`;
+- canonical input files or URLs;
+- an output destination that is not a production branch;
+- a maximum credit/budget policy enforced by the caller;
+- a timeout and webhook/polling policy;
+- a list of allowed connectors;
+- explicit publication and external-write policy;
+- the reference lock from `REFERENCE-INTELLIGENCE.md`.
+
+Every result returns:
+
+- task and project IDs;
+- files, checkpoints, or URLs produced;
+- source ledger and limitations;
+- cost/usage receipt;
+- comparison against acceptance criteria;
+- a promotion recommendation, never an automatic canon decision.
+
+## Authentication
+
+Use API v2 at `https://api.manus.ai` with `MANUS_API_KEY` in a secret manager or local environment. Never commit keys. API keys provide broad account access; use separate development and production keys and rotate any exposed value.
+
+Install current API guidance for Codex:
+
+```bash
+npx skills add https://open.manus.ai/docs --skill manus-api --agent codex --global --yes
+```
+
+## Default policy
+
+- Allowed without a second gate: create an isolated task, attach approved input files, read results, stop a task.
+- Requires a human confirmation gate: connector writes, public website publication, custom-domain changes, production repository writes, outbound messages, and spending beyond the caller's declared ceiling.
+- Forbidden: secrets in prompts or artifacts, source-of-truth promotion by Manus, and production publication from an unreviewed checkpoint.
+
+## Promotion
+
+A winning output is exported into an owning GitHub repository branch. Codex performs deterministic validation, visual comparison, accessibility checks, and preference review. Notion receives the decision record. Manus-hosted state remains an experiment unless explicitly adopted.

--- a/integrations/mcp/refero.hermes.yaml
+++ b/integrations/mcp/refero.hermes.yaml
@@ -1,0 +1,9 @@
+# Merge this block into ~/.hermes/config.yaml.
+# Authentication is completed interactively; no token belongs in this file or Git.
+mcp_servers:
+  refero:
+    url: "https://api.refero.design/mcp"
+    auth: oauth
+    tools:
+      prompts: true
+      resources: true

--- a/integrations/mcp/refero.mcp.json
+++ b/integrations/mcp/refero.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "refero": {
+      "type": "http",
+      "url": "https://api.refero.design/mcp"
+    }
+  }
+}

--- a/taste.md
+++ b/taste.md
@@ -52,3 +52,16 @@ A public surface is not complete until mobile behavior, reduced motion, claim ev
 design.md remains the local asset handoff. When it conflicts with this authority or the pinned SIS brand pack, evidence legibility and the immutable pack win.
 
 **Built on SIP — Starlight Intelligence Protocol**
+
+## Reference intelligence
+
+For substantial site, app, landing page, dashboard, visual identity, motion, media, or journey work, follow [REFERENCE-INTELLIGENCE.md](REFERENCE-INTELLIGENCE.md) before implementation.
+
+- Research is evidence, not design authority. Repository truth and approved preference memory remain higher-order constraints.
+- Lock one dominant foundation. Assign every secondary reference one bounded role; never average references into a generic middle.
+- Record source, rights class, observed principles, anti-reference, applicable brand/surface, decision owner, and state.
+- Refero may supply live styles, screens, and flows. Public Refero Styles pages may be used when MCP is unavailable.
+- Manus may produce isolated candidates or wide research. It cannot promote canon, publish production, or write canonical branches without an explicit human gate.
+- A winning candidate becomes preference memory only when the receipt records what beat what, why, who judged it, and with what confidence.
+
+A polished artifact with unclear rights, failed accessibility, fabricated proof, broken production behavior, or no traceable reference lock is rejected regardless of its taste score.


### PR DESCRIPTION
## Outcome

Adds a governed reference-intelligence layer to the existing Starlight taste authority.

- defines authority, rights classes, reference locks, promotion gates, and preference receipts
- wires the official Refero remote MCP for Codex/Claude-compatible clients and Hermes
- defines Manus as a bounded burst worker rather than a source of truth
- binds repository-local `taste.md` to the new contract
- keeps all credentials out of Git

## Verification

- branch is 5 commits ahead of `main`, 0 behind
- no existing files except `taste.md` were modified
- connector templates contain endpoints only, no tokens
