### PR TITLE
Add implicit Starlight Web Production plugin

### DIFF
--- a/WEB-PRODUCTION-KERNEL.md
+++ b/WEB-PRODUCTION-KERNEL.md
@@ -1,0 +1,51 @@
+# Starlight Web Production Kernel
+
+The kernel makes reference-led art direction, deliberate technology selection, and production proof persistent across web work. It is not a universal visual theme.
+
+## Persistence model
+
+| Layer | Responsibility |
+|---|---|
+| Personal Codex plugin | Implicitly invokes the web-production discipline in new relevant threads and exposes Refero MCP |
+| Repository `AGENTS.md` / `DESIGN.md` | Narrows the kernel to the product, brand, route, and implementation constraints |
+| Reference Intelligence | Governs provenance, rights, reference locks, and preference receipts |
+| Notion Taste & Reference Library | Human capture, approval, rejection, annotation, and freshness |
+| GitHub | Executable skills, contracts, catalog, tokens, components, evidence, and release receipts |
+
+New threads load installed plugin skills and MCP tools. Existing threads do not retroactively acquire a changed plugin; start a new thread after installation or update.
+
+## Default web production flow
+
+1. Read product truth, brand canon, current design contract, and prior receipts.
+2. Capture current desktop and mobile states plus real product proof.
+3. Query Refero or current attributable sources and create a rights-aware source ledger.
+4. Resolve exactly three materially different directions for consequential visual work.
+5. Lock one foundation, bounded secondary roles, tokens, media, component lane, motion lane, and rejection rules.
+6. Build static composition and responsive behavior before motion.
+7. Add only the technology earned by the selected interaction job.
+8. Render desktop, mobile, interactive, loading/error, and reduced-motion evidence.
+9. Verify accessibility, performance, claims, privacy, analytics, production, and rollback.
+10. Record the decision and preference receipt.
+
+## Technology posture
+
+| Need | Default lane | Escalate when |
+|---|---|---|
+| Design evidence | Refero styles, screens, and flows | The category needs live competitor or specialist references |
+| Accessible primitives | Semantic HTML, existing system, shadcn with Radix/Base UI/React Aria | Bespoke behavior is a real product differentiator |
+| Expressive component recipe | Aceternity registry item, inspected and fully restyled | The interaction cannot be expressed cleanly in the owned system |
+| Microinteraction | CSS and platform APIs | State, layout, gestures, or interruption require Motion |
+| UI animation | Motion for React | A deterministic multi-element timeline or scroll sequence requires GSAP |
+| Cinematic sequence | GSAP with `@gsap/react` and scoped cleanup | Spatial 3D is central enough to justify Three.js/R3F/Spline |
+
+Aceternity supplies editable recipes, not identity. GSAP supplies temporal control, not taste. Refero supplies evidence, not permission to copy.
+
+## Release rule
+
+A premium claim is invalid without inspectable mobile and desktop composition, owned product proof, accessible and reduced-motion behavior, current production evidence, and rollback. A visually impressive component that weakens comprehension, brand distinctiveness, or performance is a rejected component.
+
+## Package
+
+The reproducible plugin lives at `plugins/starlight-web-production/`. Its skill is implicitly invokable and its MCP configuration points to the official Refero remote endpoint. The personal marketplace installation is marked `INSTALLED_BY_DEFAULT`; Refero still requires first-use OAuth.
+
+See `REFERENCE-INTELLIGENCE.md` for the source, rights, approval, and receipt contract.

--- a/plugins/starlight-web-production/.codex-plugin/plugin.json
+++ b/plugins/starlight-web-production/.codex-plugin/plugin.json
@@ -1,0 +1,43 @@
+{
+  "name": "starlight-web-production",
+  "version": "0.1.0",
+  "description": "Reference-led art direction, implementation, motion, and production proof for the Starlight portfolio.",
+  "author": {
+    "name": "Starlight Intelligence",
+    "url": "https://starlightintelligence.org"
+  },
+  "homepage": "https://github.com/frankxai/Starlight-Intelligence-System/blob/main/WEB-PRODUCTION-KERNEL.md",
+  "repository": "https://github.com/frankxai/Starlight-Intelligence-System",
+  "license": "MIT",
+  "keywords": [
+    "web-design",
+    "reference-intelligence",
+    "aceternity",
+    "gsap",
+    "motion",
+    "nextjs"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Starlight Web Production",
+    "shortDescription": "Direct distinctive, production-proven web releases.",
+    "longDescription": "Turns brand truth and sourced design evidence into original, accessible web surfaces with explicit component and motion choices, rendered verification, and production receipts.",
+    "developerName": "Starlight Intelligence",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Reference research",
+      "Web art direction",
+      "Design engineering",
+      "Motion direction",
+      "Release verification"
+    ],
+    "websiteURL": "https://starlightintelligence.org",
+    "defaultPrompt": [
+      "Use $starlight-web-production to direct this web release.",
+      "Use $starlight-web-production to redesign this surface.",
+      "Use $starlight-web-production to audit this site."
+    ],
+    "brandColor": "#7C5CFF"
+  }
+}

--- a/plugins/starlight-web-production/.mcp.json
+++ b/plugins/starlight-web-production/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "refero": {
+      "type": "http",
+      "url": "https://api.refero.design/mcp"
+    }
+  }
+}

--- a/plugins/starlight-web-production/skills/starlight-web-production/SKILL.md
+++ b/plugins/starlight-web-production/skills/starlight-web-production/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: starlight-web-production
+description: Direct, build, redesign, or audit high-value websites, landing pages, product UI, design systems, and web releases for FrankX, Starlight, Arcanea, GenCreator, Agentic Income, Reality Architect, or the related portfolio. Use for web work where reference research, original art direction, component and motion selection, responsive implementation, and production proof matter; do not use for backend-only changes.
+---
+
+# Starlight Web Production
+
+Treat distinctive quality as a release property. A framework, component library, screenshot, or animation technique is evidence or material—not the design direction.
+
+## Authority
+
+Read the owning repository's constitution, `AGENTS.md`, `taste.md`, `design.md` or `DESIGN.md`, tokens, components, analytics, and prior decision receipts. The order of authority is:
+
+1. product truth and brand constitution;
+2. repository-local design contract;
+3. approved taste/reference records;
+4. a locked primary reference and bounded secondary references;
+5. live research;
+6. model defaults.
+
+Never let Aceternity, GSAP, Refero, shadcn, a template, or a trend become the brand.
+
+## Operating sequence
+
+1. Capture the current desktop and mobile truth. For greenfield work, capture the host context and gather real product states, proof, media, and copy.
+2. State one recipient, one job, one promise, one action, one signature proof, and the intended feeling/understanding.
+3. Research before composition. Prefer Refero styles/screens/flows when available; otherwise use current public, attributable sources. Record URL, owner, date, rights, observed principle, bounded use, and anti-reference.
+4. For consequential visual work, produce exactly three materially different directions using the same real content. Resolve composition, type, imagery, interaction, motion posture, feasibility, and mobile behavior.
+5. Record the selected direction. When the user explicitly delegates direction, select the highest-scoring option and record why; otherwise obtain the decision before implementation.
+6. Establish static hierarchy, copy, proof, tokens, responsive behavior, and conversion path before motion.
+7. Choose the smallest technology lane that expresses the selected direction. Read [technology-lanes.md](references/technology-lanes.md) before adding UI or motion dependencies.
+8. Implement against the existing framework and design system. Do not rewrite a stack merely to reach a preferred library.
+9. Render and inspect desktop, mobile, interactive, loading/error, and reduced-motion states. Test keyboard order, focus, contrast, reflow, links, claims, privacy, analytics, performance, and failures proportional to the surface.
+10. Record commit, checks, preview, production URL, post-deploy inspection, rollback, and the preference receipt.
+
+## Reference lock
+
+Before substantial implementation, record:
+
+```text
+Primary foundation:
+Preserve:
+Secondary reference -> one bounded job:
+Media strategy and rights:
+Component lane:
+Motion lane and named job:
+Reject:
+Token commitments:
+Decision owner:
+```
+
+One source owns the foundation. Secondary sources never get averaged into generic premium minimalism.
+
+## Release gates
+
+Block promotion when the surface lacks a current visual capture, real product proof, an explicit reference lock, mobile composition, reduced-motion behavior, accessible interaction, or a production rollback. Copy-paste components must be restyled into owned tokens and inspected for dependencies, semantics, responsiveness, performance, and license boundaries.
+
+Motion must orient, explain, confirm, reveal causality, or create one brand memory. A marketing surface normally earns at most one signature sequence. Do not animate multiple libraries against the same DOM property.
+
+## Output
+
+For builds, return the experience thesis, selected direction, preview, changed artifacts, visual and engineering evidence, verifier verdict, production proof, and rollback. For audits, return current captures, the first three release blockers, the governing rule, the smallest corrective release, and evidence limits.

--- a/plugins/starlight-web-production/skills/starlight-web-production/agents/openai.yaml
+++ b/plugins/starlight-web-production/skills/starlight-web-production/agents/openai.yaml
@@ -1,0 +1,13 @@
+interface:
+  display_name: "Starlight Web Production"
+  short_description: "Direct distinctive, production-proven web releases"
+  default_prompt: "Use $starlight-web-production to direct and ship this web surface."
+dependencies:
+  tools:
+    - type: "mcp"
+      value: "refero"
+      description: "Refero design styles, product screens, and user flows"
+      transport: "streamable_http"
+      url: "https://api.refero.design/mcp"
+policy:
+  allow_implicit_invocation: true

--- a/plugins/starlight-web-production/skills/starlight-web-production/references/technology-lanes.md
+++ b/plugins/starlight-web-production/skills/starlight-web-production/references/technology-lanes.md
@@ -1,0 +1,66 @@
+# Technology lanes
+
+Verify current versions, documentation, licenses, and repository compatibility before installation. The lane is selected by the interaction job, not by novelty.
+
+## Research and direction
+
+- **Refero** — default live design evidence for styles, real product screens, and user flows. Extract principles and preserve provenance; never copy a composition or treat search output as canon. MCP: `https://api.refero.design/mcp`.
+- **Owned repository evidence** — product states, media, analytics, tokens, and existing components outrank external inspiration.
+
+## Interface foundation
+
+- Preserve the project's framework. For established Starlight portfolio repos, prefer compatible stable Next.js, React, TypeScript, and Tailwind versions already selected by the repo.
+- Use semantic HTML and platform CSS first.
+- Use **shadcn/ui** as an owned-code distribution layer and **Radix UI**, **Base UI**, or **React Aria** primitives when their accessibility and behavior fit the project.
+- A shared Starlight registry may distribute owned tokens, primitives, sections, hooks, and rules. Third-party registry items never enter it unless redistribution rights explicitly permit that.
+
+## Aceternity UI
+
+Use Aceternity as a recipe source for a selected interaction or composition—not as a theme. Inspect the code before installation and replace demo content, tokens, type, spacing, motion, and imagery.
+
+Project registry configuration:
+
+```json
+{
+  "registries": {
+    "@aceternity": "https://ui.aceternity.com/registry/{name}.json"
+  }
+}
+```
+
+Inspect before adding:
+
+```bash
+npx shadcn@latest view @aceternity
+npx shadcn@latest search @aceternity -q "<job>"
+npx shadcn@latest add @aceternity/<component>
+```
+
+Free and purchased items may have different or item-specific terms. Record the item URL and license evidence. Aceternity's commercial license permits end products and modification but prohibits redistribution of source items and template/marketplace resale.
+
+Reject the familiar AI-site defaults unless the chosen direction truly requires them: decorative aurora, beams, meteors, gratuitous bento grids, auto-scrolling logo strips, glowing borders, pointer followers, and typewriter copy.
+
+## Motion decision ladder
+
+1. **CSS / platform APIs** — hover, focus, simple reveal, view transitions, and scroll-driven effects when browser support and fallbacks are adequate.
+2. **Motion for React** — component state, layout, presence, gesture, spring, and interruptible UI animation. It is MIT-licensed; import from `motion/react`.
+3. **GSAP + `@gsap/react`** — multi-element timelines, ScrollTrigger choreography, complex SVG/text sequencing, pinning, or deterministic cinematic control. Use `useGSAP()` with scoped cleanup. GSAP's Standard License covers ordinary commercial use at no charge but is not an MIT code-redistribution grant; reverify exceptions before productizing animation tooling.
+4. **Three.js / React Three Fiber / Spline** — only when spatial interaction or authored 3D is central to the experience thesis and a static/mobile fallback exists.
+
+Do not make two animation systems own the same element/property. Each motion system needs a named job, bundle justification, reduced-motion posture, teardown behavior, and frame/performance inspection.
+
+## Selection tests
+
+Choose a dependency only when it wins against native code on at least one structural dimension: accessibility, interaction correctness, authoring leverage, runtime performance, maintainability, or signature expression. Reject it when its primary contribution is recognizable decoration.
+
+## Canonical sources
+
+- Refero Styles: https://styles.refero.design/
+- Refero MCP skill: https://github.com/referodesign/refero_skill
+- Aceternity components and CLI: https://ui.aceternity.com/components and https://ui.aceternity.com/components/cli
+- Aceternity license: https://ui.aceternity.com/licence
+- shadcn registry: https://ui.shadcn.com/docs/registry
+- Motion: https://motion.dev/ and https://motion.dev/docs/react
+- GSAP license and React integration: https://gsap.com/community/standard-license/ and https://gsap.com/resources/React/
+
+Last verified: 2026-08-30.


### PR DESCRIPTION
## Outcome

Makes reference-led web production a reusable, implicitly invoked capability for new Codex threads.

- adds the personal/team-reproducible `starlight-web-production` plugin package
- exposes the official Refero MCP endpoint
- encodes source-led direction, reference locks, component/motion selection, responsive QA, and production proof
- defines Aceternity as an inspected recipe source rather than identity
- routes motion through CSS → Motion → GSAP → 3D by interaction need
- records current license and integration boundaries in a maintained technology-lanes reference

## Verification

- skill validator: passed
- plugin validator: passed
- JSON manifests: valid
- no credentials or third-party source components included
- new-thread loading required after plugin installation/update