### PR TITLE
fix(mesh): bump SIS skills_unrooted after web-production plugin

### DIFF
--- a/context/empire/portfolio-mesh.json
+++ b/context/empire/portfolio-mesh.json
@@ -28,7 +28,7 @@
       "note": "only repo whose published counts matched its filesystem at the 2026-07-25 audit; guarded by scripts/check-agent-harness.mjs",
       "measured": {
         "skills": 88,
-        "skills_unrooted": 10,
+        "skills_unrooted": 11,
         "installed_skills": 4,
         "agents": 144,
         "commands": 28,

--- a/context/empire/portfolio-mesh.yaml
+++ b/context/empire/portfolio-mesh.yaml
@@ -36,7 +36,7 @@ repos:
     note: "only repo whose published counts matched its filesystem at the 2026-07-25 audit; guarded by scripts/check-agent-harness.mjs"
     measured:
       skills: 88
-      skills_unrooted: 10
+      skills_unrooted: 11
       installed_skills: 4
       agents: 144
       commands: 28


### PR DESCRIPTION
## Summary
- `mesh:check` on `main` (`483ae1e5d12c`) fails because SIS-local counts drifted, not because siblings are missing.
- #116 added `plugins/starlight-web-production/skills/starlight-web-production/SKILL.md`. The counting contract records plugin `SKILL.md` as `skills_unrooted`, so CI's SIS-only remeasure is **11** against committed **10**.
- The 18 `never measured` sibling lines are **warn-only** and already present on the last green run; `--check` still fail-closes on generated vs committed after date strip.
- This PR updates the two generated artifacts only (`10` → `11`). It does **not** weaken `--check`.

## Test Plan
- [ ] Harness check `Portfolio-mesh drift guard` is green on this head
- [ ] Diff is only `context/empire/portfolio-mesh.yaml` and `portfolio-mesh.json` (`skills_unrooted` 10→11)
- [ ] `--check` still fails if those generated files are hand-edited away from a fresh SIS measure