### PR TITLE
fix(site): keep vault ISR resilient to GitHub timeouts

### DIFF
--- a/memory/vaults/operational-vault.md
+++ b/memory/vaults/operational-vault.md
@@ -36,6 +36,7 @@ Operational note: Higgsfield MCP returned `OAuth authorization required` for `ba
 
 | Date | Entry | Category | Confidence |
 |------|-------|----------|------------|
+| 2026-09-01 | Homepage vault ISR keeps last-good state across GitHub timeouts | runtime-resilience | 0.98 |
 | 2026-02-10 | System Initialization State | system-state | 1.0 |
 | 2026-02-10 | Ecosystem Connection Status | ecosystem-state | 0.90 |
 | 2026-05-06 | Starlight Ascension (E2E Upgrade) | ecosystem-state | 1.0 |
@@ -823,5 +824,20 @@ Working findings recorded for future sweeps: (1) agenticincome#21 reclassified N
 **Vercel truth:** production is project `site` (`prj_wDNGrb1R1rB5PJOG9cUEICSER887`) in team `starlight-intelligence`. PR #103 preview `dpl_57542emV2JKJcvigNCsNBDjK8eCv` reached READY at head `a274e1b`. Local production build, focused ESLint, metrics/public-install/layout/deploy contracts, GitHub harness, Media Guard, design contract, Vercel preview, responsive browser QA, exact clone-flow resolution, and `/deploy` runtime-error audit passed. Browser QA caught and repaired one nested-main landmark before merge.
 
 **Residual:** the unlinked duplicate Vercel project `starlight-intelligence-system` remains outside this change. Deletion is a separate Frank-only control-plane action.
+
+**Built on SIP — Starlight Intelligence Protocol**
+
+## 2026-09-01 - Homepage vault ISR keeps last-good state across GitHub timeouts
+
+**Category:** public-surface / runtime-resilience / observability
+**Confidence:** 0.98
+**Source:** Vercel runtime error cluster and exact deployed-source trace
+**Related:** `site/src/lib/github-content.mjs`, `site/src/lib/vault.ts`, deployment `dpl_CrZHCV7oxvCYcPDtVqABzkgbZhjP`
+
+The production root route returned HTTP 200 from stale ISR cache while its background regeneration logged `TypeError: fetch failed` with nested `write ETIMEDOUT` at `2026-08-31T21:20:54Z`. The deployed homepage read public-vault files through the GitHub contents API, and that loader was the only outbound fetch on the root server-render path. The loader had no transport boundary, retry policy, or target-level receipt; its source remained unchanged in the next production SHA.
+
+The vault loader now retries one idempotent GitHub GET after transient network, 408, 425, 429, or 5xx failure. A persistent failure is logged with repo, path, attempt count, and nested network code, then rethrown so Next ISR retains the last successful render instead of treating an empty vault as a successful regeneration. Only a real 404 remains an accepted absent optional file. Five deterministic regression cases run inside the site build.
+
+No production deployment, alias, DNS, environment variable, or secret changed in this repair branch.
 
 **Built on SIP — Starlight Intelligence Protocol**

--- a/site/package.json
+++ b/site/package.json
@@ -4,13 +4,14 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "node scripts/check-metrics-contract.mjs && node scripts/check-public-install-contract.mjs && node scripts/check-layout-contract.mjs && node scripts/check-deploy-contract.mjs && next build",
+    "build": "npm run test:vault-fetch && node scripts/check-metrics-contract.mjs && node scripts/check-public-install-contract.mjs && node scripts/check-layout-contract.mjs && node scripts/check-deploy-contract.mjs && next build",
     "check:public-install-contract": "node scripts/check-public-install-contract.mjs",
     "check:layout-contract": "node scripts/check-layout-contract.mjs",
     "check:deploy-contract": "node scripts/check-deploy-contract.mjs",
     "start": "next start",
     "lint": "eslint",
-    "check:metrics": "node scripts/check-metrics-contract.mjs"
+    "check:metrics": "node scripts/check-metrics-contract.mjs",
+    "test:vault-fetch": "node --test src/lib/github-content.test.mjs"
   },
   "dependencies": {
     "@react-three/drei": "^10.7.7",

--- a/site/src/lib/github-content.mjs
+++ b/site/src/lib/github-content.mjs
@@ -1,0 +1,149 @@
+const GITHUB_API = "https://api.github.com";
+const DEFAULT_REVALIDATE_SECONDS = 3600;
+const DEFAULT_MAX_ATTEMPTS = 2;
+const DEFAULT_RETRY_DELAY_MS = 125;
+
+class GitHubContentFetchError extends Error {
+  /**
+   * @param {string} message
+   * @param {{ status?: number, retryable?: boolean, cause?: unknown }} [details]
+   */
+  constructor(message, details = {}) {
+    super(message, details.cause === undefined ? undefined : { cause: details.cause });
+    this.name = "GitHubContentFetchError";
+    this.status = details.status;
+    this.retryable = details.retryable ?? false;
+  }
+}
+
+/** @param {number} status */
+function isTransientStatus(status) {
+  return status === 408 || status === 425 || status === 429 || status >= 500;
+}
+
+/** @param {unknown} error */
+function isRetryableError(error) {
+  if (error instanceof GitHubContentFetchError) return error.retryable;
+
+  // Native fetch rejects with TypeError for transport failures. The nested
+  // cause carries the useful code on Node/undici (ETIMEDOUT, ECONNRESET, ...).
+  return error instanceof TypeError || error instanceof SyntaxError;
+}
+
+/** @param {unknown} error */
+function errorReceipt(error) {
+  if (!(error instanceof Error)) return { message: String(error) };
+
+  const cause = error.cause;
+  const causeReceipt =
+    cause && typeof cause === "object"
+      ? {
+          name: "name" in cause ? String(cause.name) : undefined,
+          message: "message" in cause ? String(cause.message) : undefined,
+          code: "code" in cause ? String(cause.code) : undefined,
+          errno: "errno" in cause ? String(cause.errno) : undefined,
+          syscall: "syscall" in cause ? String(cause.syscall) : undefined,
+        }
+      : undefined;
+
+  return {
+    name: error.name,
+    message: error.message,
+    ...(error instanceof GitHubContentFetchError && error.status
+      ? { status: error.status }
+      : {}),
+    ...(causeReceipt ? { cause: causeReceipt } : {}),
+  };
+}
+
+/** @param {number} milliseconds */
+function wait(milliseconds) {
+  if (milliseconds <= 0) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+/**
+ * Fetch a UTF-8 text file from the GitHub contents API.
+ *
+ * The request is a cacheable GET, so one bounded retry is safe. A persistent
+ * transport/upstream failure is rethrown: Next ISR then retains its last good
+ * render instead of accepting an empty vault as a successful regeneration.
+ * Only a real 404 represents an absent optional vault file.
+ *
+ * @param {string} repo
+ * @param {string} path
+ * @param {{
+ *   token?: string,
+ *   revalidateSeconds?: number,
+ *   maxAttempts?: number,
+ *   retryDelayMs?: number,
+ *   fetchImpl?: typeof fetch,
+ *   logger?: Pick<Console, "warn" | "error">
+ * }} [options]
+ * @returns {Promise<string | null>}
+ */
+export async function fetchGitHubTextFile(repo, path, options = {}) {
+  const {
+    token,
+    revalidateSeconds = DEFAULT_REVALIDATE_SECONDS,
+    maxAttempts = DEFAULT_MAX_ATTEMPTS,
+    retryDelayMs = DEFAULT_RETRY_DELAY_MS,
+    fetchImpl = fetch,
+    logger = console,
+  } = options;
+
+  const url = `${GITHUB_API}/repos/${repo}/contents/${path}`;
+  const headers = {
+    Accept: "application/vnd.github.v3+json",
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      const response = await fetchImpl(url, {
+        headers,
+        next: { revalidate: revalidateSeconds },
+      });
+
+      if (response.status === 404) return null;
+
+      if (!response.ok) {
+        throw new GitHubContentFetchError(
+          `GitHub contents API returned ${response.status}`,
+          {
+            status: response.status,
+            retryable: isTransientStatus(response.status),
+          },
+        );
+      }
+
+      const payload = await response.json();
+      if (!payload || typeof payload.content !== "string") {
+        throw new GitHubContentFetchError(
+          "GitHub contents API response did not contain base64 content",
+        );
+      }
+
+      return Buffer.from(payload.content, "base64").toString("utf-8");
+    } catch (error) {
+      const willRetry = attempt < maxAttempts && isRetryableError(error);
+      const receipt = {
+        repo,
+        path,
+        attempt,
+        maxAttempts,
+        error: errorReceipt(error),
+      };
+
+      if (!willRetry) {
+        logger.error("[vault/github] content fetch failed", receipt);
+        throw error;
+      }
+
+      logger.warn("[vault/github] transient content fetch failed; retrying", receipt);
+      await wait(retryDelayMs * attempt);
+    }
+  }
+
+  throw new Error("unreachable");
+}

--- a/site/src/lib/github-content.test.mjs
+++ b/site/src/lib/github-content.test.mjs
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { fetchGitHubTextFile } from "./github-content.mjs";
+
+function encodedResponse(text, status = 200) {
+  return new Response(
+    JSON.stringify({ content: Buffer.from(text).toString("base64") }),
+    { status, headers: { "content-type": "application/json" } },
+  );
+}
+
+function recordingLogger() {
+  const warnings = [];
+  const errors = [];
+  return {
+    logger: {
+      warn: (...args) => warnings.push(args),
+      error: (...args) => errors.push(args),
+    },
+    warnings,
+    errors,
+  };
+}
+
+test("retries a transient transport timeout and returns decoded content", async () => {
+  let calls = 0;
+  const { logger, warnings, errors } = recordingLogger();
+  const timeout = new TypeError("fetch failed", {
+    cause: Object.assign(new Error("write ETIMEDOUT"), {
+      code: "ETIMEDOUT",
+      syscall: "write",
+    }),
+  });
+
+  const content = await fetchGitHubTextFile("owner/repo", "vault.jsonl", {
+    fetchImpl: async (_url, init) => {
+      calls += 1;
+      assert.equal(init.next.revalidate, 3600);
+      if (calls === 1) throw timeout;
+      return encodedResponse("recovered");
+    },
+    retryDelayMs: 0,
+    logger,
+  });
+
+  assert.equal(content, "recovered");
+  assert.equal(calls, 2);
+  assert.equal(warnings.length, 1);
+  assert.equal(warnings[0][1].error.cause.code, "ETIMEDOUT");
+  assert.equal(errors.length, 0);
+});
+
+test("retries a transient GitHub 5xx response", async () => {
+  let calls = 0;
+  const { logger, warnings } = recordingLogger();
+
+  const content = await fetchGitHubTextFile("owner/repo", "vault.jsonl", {
+    fetchImpl: async () => {
+      calls += 1;
+      return calls === 1 ? new Response(null, { status: 503 }) : encodedResponse("ok");
+    },
+    retryDelayMs: 0,
+    logger,
+  });
+
+  assert.equal(content, "ok");
+  assert.equal(calls, 2);
+  assert.equal(warnings.length, 1);
+});
+
+test("rethrows a persistent transport failure so ISR keeps the last good render", async () => {
+  let calls = 0;
+  const { logger, warnings, errors } = recordingLogger();
+  const timeout = new TypeError("fetch failed", {
+    cause: Object.assign(new Error("write ETIMEDOUT"), { code: "ETIMEDOUT" }),
+  });
+
+  await assert.rejects(
+    fetchGitHubTextFile("owner/repo", "vault.jsonl", {
+      fetchImpl: async () => {
+        calls += 1;
+        throw timeout;
+      },
+      retryDelayMs: 0,
+      logger,
+    }),
+    timeout,
+  );
+
+  assert.equal(calls, 2);
+  assert.equal(warnings.length, 1);
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0][1].repo, "owner/repo");
+  assert.equal(errors[0][1].path, "vault.jsonl");
+});
+
+test("treats only a 404 as an absent optional file", async () => {
+  let calls = 0;
+  const { logger, warnings, errors } = recordingLogger();
+
+  const content = await fetchGitHubTextFile("owner/repo", "missing.jsonl", {
+    fetchImpl: async () => {
+      calls += 1;
+      return new Response(null, { status: 404 });
+    },
+    retryDelayMs: 0,
+    logger,
+  });
+
+  assert.equal(content, null);
+  assert.equal(calls, 1);
+  assert.equal(warnings.length, 0);
+  assert.equal(errors.length, 0);
+});
+
+test("fails closed on a non-retryable authorization response", async () => {
+  let calls = 0;
+  const { logger, errors } = recordingLogger();
+
+  await assert.rejects(
+    fetchGitHubTextFile("owner/repo", "vault.jsonl", {
+      fetchImpl: async () => {
+        calls += 1;
+        return new Response(null, { status: 401 });
+      },
+      retryDelayMs: 0,
+      logger,
+    }),
+    /returned 401/,
+  );
+
+  assert.equal(calls, 1);
+  assert.equal(errors.length, 1);
+});

--- a/site/src/lib/vault.ts
+++ b/site/src/lib/vault.ts
@@ -1,4 +1,7 @@
-const GITHUB_API = "https://api.github.com";
+import "server-only";
+
+import { fetchGitHubTextFile } from "./github-content.mjs";
+
 const REGISTRY_REPO = "frankxai/Starlight-Intelligence-System";
 const VAULT_CATEGORIES = [
   "strategic",
@@ -156,28 +159,13 @@ export function timeAgo(iso: string): string {
 
 // -- Data fetching --
 
-function githubHeaders(): HeadersInit {
-  const headers: HeadersInit = {
-    Accept: "application/vnd.github.v3+json",
-  };
-  if (process.env.GITHUB_TOKEN) {
-    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
-  }
-  return headers;
-}
-
 async function fetchGitHubFile(
   repo: string,
   path: string
 ): Promise<string | null> {
-  const url = `${GITHUB_API}/repos/${repo}/contents/${path}`;
-  const res = await fetch(url, {
-    headers: githubHeaders(),
-    next: { revalidate: 3600 },
+  return fetchGitHubTextFile(repo, path, {
+    token: process.env.GITHUB_TOKEN,
   });
-  if (!res.ok) return null;
-  const data = await res.json();
-  return Buffer.from(data.content, "base64").toString("utf-8");
 }
 
 function parseJsonl(content: string): VaultEntry[] {


### PR DESCRIPTION
## Incident

Vercel grouped two root-route `TypeError: fetch failed` occurrences for the production site. The latest was:

- time: `2026-08-31T21:20:54Z`
- deployment: `dpl_CrZHCV7oxvCYcPDtVqABzkgbZhjP`
- Git SHA: `b68f1e4902c82752de5fe042e6415fd3a2a0ca46`
- request: `GET /`
- response: `200`, `cache=STALE`
- cause: `write ETIMEDOUT`

The grouped table retains an earlier first-seen timestamp (`2026-07-04T11:25:55Z`); the seven-day raw log query exposed the August 31 invocation.

## Root cause

The homepage ISR reads the public vault through `api.github.com`. The deployed loader had no transport boundary or retry policy, so a transient GitHub/undici write timeout escaped the regeneration. Next served the last successful page, which explains the 200/stale response, but the failure had no target-level receipt. The same loader remained present at the current production SHA `047a1494f3f61201a34a42497a5495f5a2efd4b1`.

## Repair

- retry one idempotent GitHub contents GET after transport failure, malformed transient response, 408, 425, 429, or 5xx;
- accept only an actual 404 as an absent optional vault file;
- emit safe structured receipts with repo, path, attempt count, HTTP status, and nested network code;
- rethrow persistent failure so ISR retains the last good render instead of caching an empty vault;
- run five deterministic regression cases inside the site build.

## Verification

- `npm run test:vault-fetch`: 5/5 pass
- focused ESLint: pass
- `npm run build`: pass
  - metrics, public-install, layout, and deploy contracts pass
  - TypeScript passes
  - 91/91 static pages generate
- current production `dpl_9Axc3i5tAfKy8ydpT7kiyECzHnBL`: READY at `047a149…`
- current deployment error/fatal logs since readiness: none

No production deployment, alias, DNS, environment variable, or secret is changed by this PR.