### PR TITLE
fix(site): abort hung GitHub content attempts

### DIFF
--- a/site/src/lib/github-content.mjs
+++ b/site/src/lib/github-content.mjs
@@ -2,6 +2,7 @@ const GITHUB_API = "https://api.github.com";
 const DEFAULT_REVALIDATE_SECONDS = 3600;
 const DEFAULT_MAX_ATTEMPTS = 2;
 const DEFAULT_RETRY_DELAY_MS = 125;
+const DEFAULT_REQUEST_TIMEOUT_MS = 5000;
 
 class GitHubContentFetchError extends Error {
   /**
@@ -27,7 +28,14 @@ function isRetryableError(error) {
 
   // Native fetch rejects with TypeError for transport failures. The nested
   // cause carries the useful code on Node/undici (ETIMEDOUT, ECONNRESET, ...).
-  return error instanceof TypeError || error instanceof SyntaxError;
+  // AbortSignal.timeout() rejects with a TimeoutError; caller-driven aborts
+  // may surface as AbortError. Both are safe to retry for this idempotent GET.
+  return (
+    error instanceof TypeError ||
+    error instanceof SyntaxError ||
+    (error instanceof Error &&
+      (error.name === "TimeoutError" || error.name === "AbortError"))
+  );
 }
 
 /** @param {unknown} error */
@@ -77,6 +85,7 @@ function wait(milliseconds) {
  *   revalidateSeconds?: number,
  *   maxAttempts?: number,
  *   retryDelayMs?: number,
+ *   requestTimeoutMs?: number,
  *   fetchImpl?: typeof fetch,
  *   logger?: Pick<Console, "warn" | "error">
  * }} [options]
@@ -88,6 +97,7 @@ export async function fetchGitHubTextFile(repo, path, options = {}) {
     revalidateSeconds = DEFAULT_REVALIDATE_SECONDS,
     maxAttempts = DEFAULT_MAX_ATTEMPTS,
     retryDelayMs = DEFAULT_RETRY_DELAY_MS,
+    requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
     fetchImpl = fetch,
     logger = console,
   } = options;
@@ -103,6 +113,7 @@ export async function fetchGitHubTextFile(repo, path, options = {}) {
       const response = await fetchImpl(url, {
         headers,
         next: { revalidate: revalidateSeconds },
+        signal: AbortSignal.timeout(requestTimeoutMs),
       });
 
       if (response.status === 404) return null;

--- a/site/src/lib/github-content.test.mjs
+++ b/site/src/lib/github-content.test.mjs
@@ -51,6 +51,46 @@ test("retries a transient transport timeout and returns decoded content", async 
   assert.equal(errors.length, 0);
 });
 
+test("aborts each hung attempt at its own deadline", async () => {
+  let calls = 0;
+  const signals = [];
+  const { logger, warnings, errors } = recordingLogger();
+
+  const fetchImpl = async (_url, init) => {
+    calls += 1;
+    signals.push(init.signal);
+
+    return new Promise((_resolve, reject) => {
+      if (init.signal.aborted) {
+        reject(init.signal.reason);
+        return;
+      }
+      init.signal.addEventListener("abort", () => reject(init.signal.reason), {
+        once: true,
+      });
+    });
+  };
+
+  await assert.rejects(
+    fetchGitHubTextFile("owner/repo", "vault.jsonl", {
+      fetchImpl,
+      requestTimeoutMs: 10,
+      retryDelayMs: 0,
+      logger,
+    }),
+    (error) => error instanceof Error && error.name === "TimeoutError",
+  );
+
+  assert.equal(calls, 2);
+  assert.equal(signals.length, 2);
+  assert.notEqual(signals[0], signals[1]);
+  assert.ok(signals.every((signal) => signal.aborted));
+  assert.equal(warnings.length, 1);
+  assert.equal(warnings[0][1].error.name, "TimeoutError");
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0][1].error.name, "TimeoutError");
+});
+
 test("retries a transient GitHub 5xx response", async () => {
   let calls = 0;
   const { logger, warnings } = recordingLogger();


### PR DESCRIPTION
## Why

Follow-up to #127. The retry loop was bounded by count, but an individual `fetch()` had no deadline. A hung GitHub request could therefore consume the entire function execution window before the retry or ISR last-good fallback could run.

## Change

- give every attempt its own 5-second `AbortSignal.timeout()`
- treat timeout/abort failures as retryable for this idempotent GET
- add a deterministic hung-fetch regression test proving both attempts receive distinct signals and abort
- preserve the existing 404, authorization, cache, retry, logging, and last-good ISR behavior

No trust root, secret, environment variable, deployment setting, route, or production configuration is changed.

## Verification

- `node --test site/src/lib/github-content.test.mjs` — 6/6 pass locally
- base: `4ec5f81e7d78635ce19376bbbeda7be44c60bef2`
- head: `91cf495f5fe443b588c582e96923eb5a83d393df`

Held for exact-head GitHub and preview gates before merge.