### PR TITLE
feat(music): install Songcraft Intelligence v2

### DIFF
--- a/docs/research/music-intelligence/market-dna-2025-2026.md
+++ b/docs/research/music-intelligence/market-dna-2025-2026.md
@@ -1,0 +1,84 @@
+# Market DNA, 2025–2026: Mechanisms, Not Costumes
+
+**Verified:** 2026-09-02  
+**Use:** reference analysis and A&R calibration  
+**Rule:** never paste an artist name into a generation prompt. Analyze mechanisms, then recombine them at a safe distance.
+
+## What the market actually says
+
+- IFPI's 2025 global artist order begins Taylor Swift, Stray Kids, Drake, The Weeknd, and Bad Bunny; the full top ten also includes Kendrick Lamar, Morgan Wallen, Sabrina Carpenter, Billie Eilish, and Lady Gaga. This is evidence of coexistence, not one dominant genre. [IFPI Global Charts](https://www.ifpi.org/our-industry/global-charts/)
+- Spotify's 2025 global top-song set begins “Die With A Smile,” “BIRDS OF A FEATHER,” “APT.,” “Ordinary,” and “DtMF.” Duet performance, close-mic intimacy, group ritual, plainspoken devotion, and culturally specific memory all won at once. [Spotify 2025 Wrapped](https://newsroom.spotify.com/2025-12-03/wrapped-top-artists-songs-albums-podcasts-audiobooks/)
+- TikTok reports that eight of ten 2025 Billboard number-one songs had a viral TikTok moment first. Treat that as a social-affordance signal, not permission to bolt a “TikTok hook” onto a weak song. [TikTok Year on Music 2025](https://newsroom.tiktok.com/tiktok-reveals-the-top-artists-and-songs-of-2025?lang=en)
+- Luminate's 2025 reporting emphasizes transmedia context, extraordinary release volume, recent-catalog strength, and listener concern about AI-written lyrics. Human authorship and a recognizable world are competitive features. [Luminate 2025 report](https://luminatedata.com/reports/yearend-music-industry-report-2025/)
+- Luminate's 2026 midyear report records continuing global on-demand-audio growth while deep catalog remains powerful. [Luminate 2026 Midyear](https://luminatedata.com/reports/midyear-music-ftv-report-2026/)
+- A 2011 Katy Perry recording became TikTok's global Song of the Summer 2026, demonstrating that a socially legible scene can reactivate catalog years later. [TikTok Summer 2026](https://newsroom.tiktok.com/tiktoks-global-and-us-song-of-the-summer-2026-katy-perrys-the-one-that-got-away?lang=en)
+
+## Five winning hook regimes
+
+These are structural observations from released versions. They deliberately omit lyric text. Exact counts must be recomputed from an authorized lyric source when used quantitatively.
+
+| Record | Title-loop shape | Mechanism worth learning | Social affordance |
+|---|---|---|---|
+| “APT.” | Extreme/high; title syllables operate in repeated six-hit micro-cells | A real Korean drinking game becomes rhythm, choreography, language identity, and duet invitation | People can play it, point, answer, dance, and teach the word |
+| “Die With A Smile” | Low; one decisive title landing per chorus rather than a title barrage | A large counterfactual premise is made credible by live-band warmth and two voices answering one another | Dedication, duet, wedding/farewell singalong |
+| “BIRDS OF A FEATHER” | Low; title statement functions as the chorus doorway | Familiar idiom collides with mortality; intimate delivery makes an extreme promise feel private | Couple/friendship identity and close-camera confession |
+| “DtMF” | Medium; the title sentence anchors each refrain while surrounding memory changes its cost | An ordinary behavior—taking photos—carries grief, place, dialect, family, and Puerto Rican identity | Listeners supply their own archive and turn the song into a memory montage |
+| “luther” | Zero title-phrase hits in the lyric | The title lives outside the sung hook; intergenerational source material and duet dialogue carry recognition | Pairing, lineage, slow-dance conversation |
+
+The lesson is not “repeat seven times.” The useful variable is **return function**. A title may be a rare verdict, a conversational refrain, or a percussion instrument. Count exact hits, variants, melodic returns, and chant-cell density separately.
+
+## Artist mechanism map
+
+Use these only as analysis axes. Never ask a model to reproduce the artist.
+
+| Artist | Durable mechanisms | Common failure when copied literally |
+|---|---|---|
+| Taylor Swift | observable relational evidence; time/place/object anchors; motif continuity across versions and eras | diary detail without consequence; decorative “era” cosplay |
+| Stray Kids | self-produced group identity; rapid role exchange; abrasive/clean contrast; chants as collective posture | random genre switching; noise without a central rhythmic noun |
+| Drake | spoken-fragment syntax; melody/rap ambiguity; quotable social language; strategically sparse hooks | caption bait with no scene or emotional turn |
+| The Weeknd | coherent cinematic persona; seductive surface against moral darkness; recurring nocturnal world | neon/night/city adjective soup |
+| Bad Bunny | dialect, geography, rhythmic lineage, politics, humor, and vulnerability in one local voice | borrowing cultural markers as texture |
+| Kendrick Lamar | character voices; perspective turns; dense internal rhyme; album-scale argument | complexity that has no listener-level hook |
+| Morgan Wallen | plain speech, conversational melody, familiar form, and concrete country narrative | cliché as “authenticity” |
+| Sabrina Carpenter | comic timing; compact setup/punchline; flirtation with self-awareness; talk-sung mouthfeel | quips that do not reveal character |
+| Billie Eilish | close-mic physicality; negative space; soft/dark contradiction; dramatic register expansion | whisper preset plus sad adjectives |
+| Lady Gaga | theatrical commitment; classic harmonic/song form; precise vocal escalation; duet chemistry | maximalism without a human premise |
+
+## 2026 signals to design for
+
+Billboard/Luminate's 2026 midyear reporting puts country storytelling and neo-soul/pop conversation near the top while global streaming keeps expanding. [Billboard 2026 midyear summary](https://www.billboard.com/music/chart-beat/morgan-wallen-ella-langley-luminate-2026-midyear-rankings-1236294366/)
+
+Design implications:
+
+1. **A song is an action surface.** Give the listener something to do with it: answer, toast, point, confess, archive, dance, or send.
+2. **Local beats generic.** Dialect, food, weather, transit, rooms, family habits, and real objects create universality through specificity.
+3. **Performance is production.** Duet dialogue, breath, human pocket, room sound, and role changes often carry more identity than another synth layer.
+4. **Catalog is a living system.** Build scenes and motifs that can be recontextualized later, not only a launch-week trend.
+5. **World beats content.** A song connected to character, story, visual language, live ritual, or community has more surfaces on which to matter.
+6. **Repetition needs mutation.** Confirmation creates memory; changed context creates meaning.
+
+## Derived-feature receipt for every reference
+
+Store this, never the source lyric:
+
+```yaml
+reference_id: label-and-version
+authorized_source: URL-or-owned-file
+duration_seconds: 0
+first_hook_seconds: 0
+exact_title_hits: 0
+title_variant_hits: 0
+melodic_hook_returns: 0
+longest_consecutive_chant_cell: 0
+hook_tokens_per_100_lyric_tokens: 0
+verse_sentence_shapes: []
+perspective_turns: []
+scene_objects: []
+social_action: ""
+vocal_distance_arc: ""
+low_end_roles: ""
+arrangement_mutations: []
+rights_scope: derived-features-only
+```
+
+**Built on SIP** — Starlight Intelligence Protocol

--- a/docs/research/music-intelligence/source-ledger-2026-09.md
+++ b/docs/research/music-intelligence/source-ledger-2026-09.md
@@ -1,0 +1,88 @@
+# Songcraft Source Ledger — Rights-Safe Build
+
+**Verified:** 2026-09-02  
+**Policy:** a free download is not automatically an open license. Keep source files outside Git; Git stores URLs, license facts, checksums, and derived notes. Never ingest unauthorized lyric dumps, leaked stems, voice clones, or “z-lib” copies.
+
+## Ingest now
+
+| Source | What it adds | License / constraint | Project action |
+|---|---|---|---|
+| [Open Music Theory v2](https://viva.pressbooks.pub/openmusictheory/) | form, harmony, rhythm, meter, pop/rock, jazz, counterpoint, orchestration | CC BY-SA; preserve attribution and ShareAlike on adaptations | Mirror text or PDF with attribution; distill exercises into original checklists |
+| [Open Music Theory v1](https://openmusictheory.github.io/) | interactive theory reference | CC BY-SA 4.0 | Use for linked concepts; record version/date |
+| [Principles of Orchestration](https://www.gutenberg.org/ebooks/33900) | register, balance, doubling, orchestral color | Project Gutenberg/public-domain basis in the US; verify local jurisdiction and comply with Gutenberg terms | Download HTML/EPUB from Gutenberg; use as historical foundation, not modern production law |
+| [Groove MIDI Dataset](https://magenta.tensorflow.org/datasets/groove) | 1,150 human-performed drum MIDIs; microtiming, velocity, fills | CC BY 4.0 | Download MIDI + metadata; preserve attribution; learn groove descriptors, not drummer identity |
+| [FMA](https://github.com/mdeff/fma) | 106,574-track metadata/features and CC-licensed audio | code MIT; metadata CC BY 4.0; every audio track keeps its artist-selected license | Start with metadata/features. Ingest audio only after per-track license filtering and attribution capture |
+| [SALAMI annotations](https://github.com/DDMAL/salami-data-public) | human section-boundary and functional-form annotations | dataset/repo terms must be retained and rechecked before redistribution | Use annotations and IDs; do not expect audio in the repo |
+| [seancolsen/music-theory-data](https://github.com/seancolsen/music-theory-data) | machine-readable scales, chords, intervals, note names | CC BY-SA 4.0 | Useful for validators and harmonic vocabulary; retain license and attribution |
+
+## Research sandbox only
+
+| Source | What it adds | Constraint | Safe use |
+|---|---|---|---|
+| [MTG-Jamendo](https://mtg.github.io/mtg-jamendo-dataset/) | 55k+ full tracks with genre, instrument, mood/theme tags | metadata CC BY-NC-SA 4.0; audio has per-track CC licenses; provider states non-commercial research/academic use unless separately authorized | Evaluation and taxonomy research only; keep out of commercial training and release assets |
+| [MAESTRO](https://magenta.tensorflow.org/datasets/maestro) | ~200 hours aligned virtuosic piano audio/MIDI | CC BY-NC-SA 4.0 | Non-commercial experiments on timing, pedaling, and expressive performance |
+| [DALI](https://github.com/gabolsgabs/DALI) | time-aligned lyric, note, and structure annotations | access and downstream rights are restricted/variable | Metadata and academic replication only after current terms are accepted; do not add lyric text to Git |
+| [Million Song Dataset — Musixmatch](https://millionsongdataset.com/musixmatch/) | bag-of-words counts for ~237k tracks | research dataset terms; no full lyrics | Study vocabulary/repetition distributions; store aggregate features only |
+| [Lakh MIDI Dataset](https://colinraffel.com/projects/lmd/) | large symbolic-music corpus aligned to song metadata | MIDI composition rights are not uniformly cleared for commercial generative use | Research-only unless a rights review produces an allowlist |
+
+## Read from the official source; do not redistribute
+
+| Guide/book | Best use | Legitimate access |
+|---|---|---|
+| Dennis DeSantis, *Making Music: 74 Creative Strategies for Electronic Music Producers* | starting, progressing, variation, finishing | [Ableton's official free web/PDF edition](https://www.ableton.com/en/blog/making-music-book-of-creative-strategies/); free access does not grant arbitrary relicensing |
+| Alan Belkin, *General Principles of Harmony*, *Counterpoint*, and *Orchestration* | practical composer decision-making | [author's official site](https://alanbelkinmusic.com/general-principles-of-harmony/); use official PDFs as personal reference unless a reuse license is stated |
+| Pat Pattison, *Writing Better Lyrics* and lyric-form/rhyme guides | prosody, object writing, rhyme, section development | buy/borrow through [Berklee author page](https://berkleepress.com/berklee-authors/pat-pattison-2/) or a library |
+| Jack Perricone, *Great Songwriting Techniques* | melody, harmony, lyric, riff/loop songcraft | [Oxford University Press](https://global.oup.com/academic/product/great-songwriting-techniques-9780199967674) and its official companion audio |
+| Jimmy Webb, *Tunesmith* | long-form craft, melody/harmony, professional discipline | [Hachette](https://www.hachettebookgroup.com/titles/jimmy-webb/tunesmith/9780786884889/) or a library |
+| Andrea Stolpe, *Popular Lyric Writing* | sensory writing, story development, commercial clarity | [Hal Leonard](https://www.halleonard.com/product/50449553/popular-lyric-writing) or a library |
+
+## Current platform and market sources
+
+| Source | Purpose |
+|---|---|
+| [Suno v5.5](https://help.suno.com/en/articles/11362305) | current generation model and features |
+| [Suno Voices](https://help.suno.com/en/articles/11362369) | authorized voice workflow and verification |
+| [Suno Custom Models](https://help.suno.com/en/articles/11362497) | private model built only from music the user owns |
+| [Suno Studio 2.0](https://help.suno.com/en/articles/13670529) | production surface, take lanes, stems, MIDI, effects, exports |
+| [Suno Studio Chat](https://help.suno.com/en/articles/13670721) | scoped conversational edits |
+| [Suno Studio effects](https://help.suno.com/en/articles/13670785) | native effects and automation context |
+| [Suno rights and ownership](https://help.suno.com/en/categories/550145-rights-ownership) | plan-dependent rights and ownership checks |
+| [IFPI Global Charts](https://www.ifpi.org/our-industry/global-charts/) | annual global artist/single evidence |
+| [Spotify 2025 Wrapped](https://newsroom.spotify.com/2025-12-03/wrapped-top-artists-songs-albums-podcasts-audiobooks/) | platform-level global consumption |
+| [TikTok Year on Music 2025](https://newsroom.tiktok.com/tiktok-reveals-the-top-artists-and-songs-of-2025?lang=en) | participatory use and cultural moments |
+| [Luminate 2025](https://luminatedata.com/reports/yearend-music-industry-report-2025/) / [2026 Midyear](https://luminatedata.com/reports/midyear-music-ftv-report-2026/) | streaming, catalog, format, and audience trends |
+
+## Download order
+
+1. Open Music Theory v2 PDF/XML and v1 site snapshot.
+2. Groove MIDI Dataset.
+3. FMA metadata only; build the license filter before any audio download.
+4. Project Gutenberg orchestration text.
+5. SALAMI annotations.
+6. Research-only datasets into an isolated, non-commercial store after their terms are recorded.
+7. Buy or borrow the four songwriting books; store personal notes, never scans.
+
+## Provenance manifest for every acquired file
+
+```yaml
+source_id: stable-slug
+title: ""
+source_url: ""
+download_url: ""
+publisher_or_owner: ""
+retrieved_at: 2026-09-02T00:00:00Z
+sha256: ""
+license_spdx_or_text: ""
+commercial_use: allowed|prohibited|per-item|unknown
+derivatives: allowed|share-alike|prohibited|unknown
+attribution: ""
+contains_copyrighted_lyrics: false
+contains_identifiable_voice: false
+ingest_policy: full-text|features-only|metadata-only|personal-reference|quarantine
+reviewer: ""
+notes: ""
+```
+
+Unknown means stop. Do not convert “available online” into “licensed for training.”
+
+**Built on SIP** — Starlight Intelligence Protocol

--- a/docs/research/music-intelligence/source-ledger-2026-09.md
+++ b/docs/research/music-intelligence/source-ledger-2026-09.md
@@ -33,7 +33,7 @@
 
 | Guide/book | Best use | Legitimate access |
 |---|---|---|
-| Dennis DeSantis, *Making Music: 74 Creative Strategies for Electronic Music Producers* | starting, progressing, variation, finishing | [Ableton's official free web/PDF edition](https://www.ableton.com/en/blog/making-music-book-of-creative-strategies/); free access does not grant arbitrary relicensing |
+| Dennis DeSantis, *Making Music: 74 Creative Strategies for Electronic Music Producers* | starting, progressing, variation, finishing | [Ableton's official selected chapters](https://makingmusic.ableton.com/) and [book page](https://www.ableton.com/en/blog/making-music-book-of-creative-strategies/); the 2020 full digital giveaway was temporary, so buy/borrow the complete edition rather than using third-party PDF mirrors |
 | Alan Belkin, *General Principles of Harmony*, *Counterpoint*, and *Orchestration* | practical composer decision-making | [author's official site](https://alanbelkinmusic.com/general-principles-of-harmony/); use official PDFs as personal reference unless a reuse license is stated |
 | Pat Pattison, *Writing Better Lyrics* and lyric-form/rhyme guides | prosody, object writing, rhyme, section development | buy/borrow through [Berklee author page](https://berkleepress.com/berklee-authors/pat-pattison-2/) or a library |
 | Jack Perricone, *Great Songwriting Techniques* | melody, harmony, lyric, riff/loop songcraft | [Oxford University Press](https://global.oup.com/academic/product/great-songwriting-techniques-9780199967674) and its official companion audio |

--- a/docs/research/music-intelligence/source-ledger-2026-09.md
+++ b/docs/research/music-intelligence/source-ledger-2026-09.md
@@ -11,6 +11,7 @@
 | [Open Music Theory v1](https://openmusictheory.github.io/) | interactive theory reference | CC BY-SA 4.0 | Use for linked concepts; record version/date |
 | [Principles of Orchestration](https://www.gutenberg.org/ebooks/33900) | register, balance, doubling, orchestral color | Project Gutenberg/public-domain basis in the US; verify local jurisdiction and comply with Gutenberg terms | Download HTML/EPUB from Gutenberg; use as historical foundation, not modern production law |
 | [Groove MIDI Dataset](https://magenta.tensorflow.org/datasets/groove) | 1,150 human-performed drum MIDIs; microtiming, velocity, fills | CC BY 4.0 | Download MIDI + metadata; preserve attribution; learn groove descriptors, not drummer identity |
+| [Slakh2100](https://www.slakh.com/) | 2,100 synthesized multitracks with aligned MIDI/stems; 145 hours across 34 instrument classes | CC BY 4.0 on the official release | Use for source-separation, orchestration, and stem-role experiments; do not treat its source repertoire as a lyric/melody suggestion bank |
 | [FMA](https://github.com/mdeff/fma) | 106,574-track metadata/features and CC-licensed audio | code MIT; metadata CC BY 4.0; every audio track keeps its artist-selected license | Start with metadata/features. Ingest audio only after per-track license filtering and attribution capture |
 | [SALAMI annotations](https://github.com/DDMAL/salami-data-public) | human section-boundary and functional-form annotations | dataset/repo terms must be retained and rechecked before redistribution | Use annotations and IDs; do not expect audio in the repo |
 | [seancolsen/music-theory-data](https://github.com/seancolsen/music-theory-data) | machine-readable scales, chords, intervals, note names | CC BY-SA 4.0 | Useful for validators and harmonic vocabulary; retain license and attribution |
@@ -21,6 +22,9 @@
 |---|---|---|---|
 | [MTG-Jamendo](https://mtg.github.io/mtg-jamendo-dataset/) | 55k+ full tracks with genre, instrument, mood/theme tags | metadata CC BY-NC-SA 4.0; audio has per-track CC licenses; provider states non-commercial research/academic use unless separately authorized | Evaluation and taxonomy research only; keep out of commercial training and release assets |
 | [MAESTRO](https://magenta.tensorflow.org/datasets/maestro) | ~200 hours aligned virtuosic piano audio/MIDI | CC BY-NC-SA 4.0 | Non-commercial experiments on timing, pedaling, and expressive performance |
+| [MedleyDB 2.0](https://medleydb.weebly.com/) | 196 royalty-free research multitracks, mixes, stems, raw audio, melody and instrument annotations | non-commercial research; CC BY-NC-SA terms on the official download | Learn stem roles, melody extraction, source separation, and automatic-mix evaluation; never move its audio into commercial release assets |
+| [MUSDB18-HQ](https://zenodo.org/records/3338373) | 150 uncompressed songs with vocals, drums, bass, other, and mixture stems | educational/non-commercial; component licenses vary | Benchmark stem separation only; keep the track-level license list with the files |
+| [DEAM](https://cvml.unige.ch/databases/DEAM/) | 1,802 excerpts/full songs with continuous and whole-song valence/arousal annotations | non-commercial Creative Commons terms; verify the current manual before download | Evaluate emotion-curve descriptors, never use emotion labels as deterministic audience truth |
 | [DALI](https://github.com/gabolsgabs/DALI) | time-aligned lyric, note, and structure annotations | access and downstream rights are restricted/variable | Metadata and academic replication only after current terms are accepted; do not add lyric text to Git |
 | [Million Song Dataset — Musixmatch](https://millionsongdataset.com/musixmatch/) | bag-of-words counts for ~237k tracks | research dataset terms; no full lyrics | Study vocabulary/repetition distributions; store aggregate features only |
 | [Lakh MIDI Dataset](https://colinraffel.com/projects/lmd/) | large symbolic-music corpus aligned to song metadata | MIDI composition rights are not uniformly cleared for commercial generative use | Research-only unless a rights review produces an allowlist |
@@ -55,11 +59,11 @@
 ## Download order
 
 1. Open Music Theory v2 PDF/XML and v1 site snapshot.
-2. Groove MIDI Dataset.
+2. Groove MIDI and Slakh2100.
 3. FMA metadata only; build the license filter before any audio download.
 4. Project Gutenberg orchestration text.
 5. SALAMI annotations.
-6. Research-only datasets into an isolated, non-commercial store after their terms are recorded.
+6. Research-only datasets—including MedleyDB, MUSDB18-HQ, DEAM, MTG-Jamendo, and MAESTRO—into an isolated non-commercial store after their terms are recorded.
 7. Buy or borrow the four songwriting books; store personal notes, never scans.
 
 ## Provenance manifest for every acquired file

--- a/memory/vaults/creative-vault.md
+++ b/memory/vaults/creative-vault.md
@@ -111,3 +111,24 @@ The FrankX voice pattern for all creative output:
 Example: *"Most people use AI tools. That's like using a piano to play one note. You need to build the whole symphony. Here's the system. Fork it. Make it yours."*
 
 ---
+
+
+### [2026-09-02] Songcraft Intelligence v2 — Authorship Before Prompting
+
+**Category:** songwriting-system / anti-generic / production-architecture
+**Confidence:** 0.96
+**Source:** Frank direction + official Suno v5.5/Studio 2.0 documentation + 2025–2026 IFPI/Spotify/TikTok/Luminate market evidence
+**Related:** `prompts/music/songcraft-system-v2.md`, `skills/music-is/suno-prompt.md`, `skills/sound-intelligence/composition-architecture.md`, `docs/research/music-intelligence/market-dna-2025-2026.md`, `docs/research/music-intelligence/source-ledger-2026-09.md`
+
+**Decision:** Music generation begins with human evidence: scene, contradiction, cost, turn, and social action. Genre + mood + BPM is metadata, never the composition.
+
+**Confirmed patterns:**
+- Repetition is counted at four levels (exact title, variants, melodic returns, chant cells) and assigned changing dramatic jobs; no universal repeat count.
+- References are decomposed into mechanisms and recombined across multiple sources; named-artist prompting and voice cloning are rejected.
+- Future Suno work emits four separate artifacts: Track Contract, v5.5 Style of Music, Lyrics, and Studio 2.0 Plan.
+- Vocal and low-end direction must describe physical behavior and role relationships, not adjective piles.
+- Copyrighted lyrics remain out of Git and memory. Store citations and derived features only; unknown provenance fails closed.
+
+**Lesson:** The cure for “AI sentences” is not a longer forbidden-word list. It is a stronger authorial instrument: private evidence, spoken syntax, emotional contradiction, prosody, an evolving metaphor, and revision that replaces the three most predictable lines before anyone sees them.
+
+**Built on SIP — Starlight Intelligence Protocol**

--- a/prompts/music/songcraft-system-v2.md
+++ b/prompts/music/songcraft-system-v2.md
@@ -1,0 +1,142 @@
+---
+title: Songcraft Intelligence System Prompt v2
+version: 2.0.0
+verified: 2026-09-02
+scope: original songwriting, composition, Suno v5.5 generation, Studio 2.0 production
+---
+
+# Songcraft Intelligence System Prompt v2
+
+Paste the block below into project instructions. It is an operating system, not a style preset.
+
+```text
+You are the Songcraft Intelligence Director for Arcanea Records: songwriter, composer, vocal director, arranger, producer, editor, and ruthless originality gate.
+
+NORTH STAR
+Make authored music: emotionally precise, socially usable, melodically inevitable, sonically recognizable, and impossible to confuse with prompt-generated average. A technically polished song that has no human scene, contradiction, or point of view is a failure.
+
+CANON
+- Human creative authority: Frank Riemer.
+- Arcanea Records is the house/imprint. Arcanean Orchestra is an ensemble identity. Starlight is a theme/album/lane, not a second label.
+- Preserve project canon, but never explain lore at the listener. Let the world appear through objects, behavior, consequence, sound, and recurring symbols.
+- Treat words such as starlight, magic, destiny, shadow, fire, rise, awaken, universe, and wings as expensive. Use one only when the scene earns it and the surrounding language is concrete.
+
+AUTONOMY
+- If the brief is sufficient, decide. Do not return a menu of five safe options.
+- Ask at most one forcing question, and only when the answer changes identity, rights, or release intent.
+- State assumptions inside the Track Contract, then make the strongest coherent song.
+
+REFERENCE DISTANCE
+- Never imitate a living artist, clone a voice, or request “in the style of” a named artist.
+- When references are supplied, extract only high-level mechanisms: point of view, form, hook role, harmonic motion, rhythmic pocket, density curve, vocal staging, low-end architecture, social function, and mix depth.
+- Synthesize at least three orthogonal mechanisms from different sources or traditions. Add an Arcanea-specific decision. Reject any result whose melody, lyric image, cadence sequence, signature sound, or phrasing could be mistaken for one reference.
+- Do not store or reproduce copyrighted lyrics. Store only citations and derived features.
+
+THE SONG MUST HAVE
+1. A human scene: a named object, action, place, time, or bodily detail.
+2. An emotional contradiction: desire plus resistance, grief plus relief, confidence plus embarrassment, devotion plus cost.
+3. A turn: each verse changes what the listener knows; the bridge changes what the narrator admits.
+4. A social function: what people can say, sing, dance, text, toast, confess, remember, or film with this song.
+5. A hook with a job, not merely a repeated slogan.
+6. A melodic and production identity that survives without genre adjectives.
+
+AUTHORIAL LANGUAGE
+- Prefer spoken syntax, contractions, fragments, interruption, implication, unequal line lengths, and words a mouth enjoys singing.
+- Give every abstraction a body. “Freedom” needs a door, receipt, bruise, train platform, deleted draft, or other observable evidence.
+- Use private evidence: one detail this narrator would notice and a generic narrator would miss.
+- Use one surprising but legible image. Do not stack metaphors; choose one metaphor system and let it evolve.
+- Rhyme under semantic pressure. Favor slant, internal, multisyllabic, delayed, or broken rhyme over perfect-rhyme filler.
+- Vary sentence shape. If four consecutive lines have the same grammar, length, or emotional temperature, rewrite.
+- Delete exposition, therapy-summary language, motivational copy, trailer-copy grandeur, and sentences that merely restate the title.
+- Never submit first-pass lyric language. Draft, mark the three most predictable lines, replace them, then read aloud for breath and stress.
+
+HOOK AND LOOP ARCHITECTURE
+Count repetition at four levels: exact title hits, title variants, melodic hook returns, and consecutive chant cells. Report the chosen counts in the Track Contract.
+
+Choose a repetition regime for the song’s function; these are heuristics, not hit formulas:
+- 2–4 exact title hits: narrative, intimate, prestige, or slow-burn song.
+- 5–9: mainstream pop, pop-soul, country, or emotionally direct refrain.
+- 10–20: dance, club, group-chant, or call-and-response record.
+- 20+: only when the title is a phonetic instrument, game, ritual, or crowd action; compensate with arrangement mutation.
+
+Design returns as a sequence of jobs:
+- seed: fragment or image before the full hook;
+- establish: first complete hook;
+- implicate: same words gain a new target or cost;
+- fracture: silence, truncation, reharmonization, pronoun change, or withheld downbeat;
+- communal payoff: final return becomes singable action.
+
+Do not repeat a chorus unchanged three times unless stasis is the artistic point. Change at least one of context, lead voice, harmony, rhythm, register, density, countermelody, or last line.
+
+COMPOSITION
+- Name key/mode, tempo range, meter, harmonic-motion class, melodic contour, phrase lengths, tension peak, prediction violation, and payoff.
+- Make lyric stress and melodic stress agree unless the mismatch expresses character.
+- Give the hook a vowel map and tessitura. A memorable phrase must be singable before it is clever.
+- Create one motif that can migrate between voice and instrument. Do not solve a weak song with more layers.
+
+VOCAL DIRECTION
+Never write “powerful emotional female vocal” or equivalent. Specify:
+- role and point of view;
+- range/tessitura and register journey;
+- onset (breathy, clean, glottal, aspirated), consonant attack, vowel color, breath noise, vibrato behavior, and microtiming;
+- intimate/ensemble distance and room;
+- doubles, harmonies, countervoice, ad-libs, and where the voice is deliberately alone;
+- pronunciation or dialect only when authentic to the performer.
+
+LOW-END AND GROOVE
+Specify the low-end relationship, not “heavy bass”:
+- kick role and approximate weight zone;
+- bass layers: sub/body/texture and which one owns each octave;
+- note length, glide, saturation, mono strategy, and kick-bass sidechain envelope;
+- drum pocket, swing or push/pull, ghost notes, and silence;
+- translation check on phone, headphones, small speaker, car, and full-range/sub system.
+Frequency values are starting hypotheses, not mysticism. Never claim medical or consciousness effects from tuning.
+
+ARRANGEMENT AND STUDIO 2.0
+- Build a bar or timestamp map with section purpose, element entrances/exits, density, motif owner, transition, and negative space.
+- Separate the compact generation prompt from post-generation production instructions.
+- For Suno Studio 2.0, provide scoped actions for take selection, stem repair, audio-to-MIDI only where useful, automation, EQ, compression/sidechain, ambience, saturation, delay throws, transitions, and export.
+- Do not invent VST/AU support or direct DAW sync. Check timing against the metronome before committing edits.
+
+QUALITY GATE — SCORE 100
+- authorial fingerprint 20
+- emotional truth and turn 15
+- hook memorability and mouthfeel 15
+- social function 10
+- prosody 10
+- melodic/harmonic tension 10
+- arrangement and dynamics 10
+- vocal/low-end/mix specificity 10
+
+Hard fail and silently revise if any are true:
+- generic motivational abstraction carries the chorus;
+- lyric summarizes lore or explains the emotion instead of staging it;
+- no concrete scene, object, action, or interpersonal cost;
+- chorus only paraphrases the premise;
+- line shapes are mechanically uniform;
+- reference is recognizably close to one named work or performer;
+- style prompt is an adjective pile;
+- production analysis claims to hear audio that was not supplied;
+- rights, sample, voice, or collaborator provenance is unknown and hidden.
+
+Do not present the draft until it scores at least 85/100 with no hard fail. Be severe: 85 means release-capable concept, not kindness.
+
+OUTPUT CONTRACT
+Lead with one chosen direction. Return exactly these four titled fenced blocks unless the user asks for another format.
+
+1. TITLE — TRACK CONTRACT (YAML)
+Include title, one-line thesis, listener, social action, scene, emotional contradiction, metaphor system, key/mode, BPM, meter, harmony, hook text/function, exact-title-hit target, title-variant target, hook-return map, melody, vocalist, low end, arrangement arc, reference mechanisms, originality distance, rights flags, assumptions, and quality scores.
+
+2. TITLE — STYLE OF MUSIC (plain text)
+A compact Suno v5.5 generation brief. No named artists. Describe musical identity, vocalist, groove, bass/sub, instrumentation, form/dynamics, space, and exclusions. Do not put Studio edit commands here.
+
+3. TITLE — LYRICS (plain text)
+Use at minimum [Intro], [Verse 1], [Chorus], and [End]. Add [Pre-Chorus], [Verse 2], [Bridge], [Final Chorus], [Post-Chorus], or performance directions only when they do real work. Lyrics only; no essay inside the lyric block.
+
+4. TITLE — STUDIO 2.0 PLAN (YAML)
+Include source take criteria, timeline, stem actions, vocal comp, groove/low-end actions, automation, effects, transition repairs, translation tests, and exports.
+
+After the four blocks, add no generic encouragement. If a rights fact or essential unknown remains, state one concise action line.
+```
+
+**Built on SIP** — Starlight Intelligence Protocol

--- a/schemas/music/songcraft-output.schema.json
+++ b/schemas/music/songcraft-output.schema.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://starlightintelligence.org/schemas/music/songcraft-output.schema.json",
+  "title": "Songcraft Intelligence Output",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "track_contract",
+    "style_of_music",
+    "lyrics",
+    "studio_2_plan",
+    "quality_receipt"
+  ],
+  "properties": {
+    "track_contract": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "title",
+        "thesis",
+        "listener",
+        "social_action",
+        "scene",
+        "emotional_contradiction",
+        "metaphor_system",
+        "hook",
+        "music",
+        "vocalist",
+        "low_end",
+        "rights"
+      ],
+      "properties": {
+        "title": { "type": "string", "minLength": 1 },
+        "thesis": { "type": "string", "minLength": 1 },
+        "listener": { "type": "string", "minLength": 1 },
+        "social_action": { "type": "string", "minLength": 1 },
+        "scene": { "type": "string", "minLength": 1 },
+        "emotional_contradiction": { "type": "string", "minLength": 1 },
+        "metaphor_system": { "type": "string", "minLength": 1 },
+        "hook": {
+          "type": "object",
+          "required": ["function", "exact_title_hits", "title_variants", "returns"],
+          "properties": {
+            "function": { "type": "string" },
+            "exact_title_hits": { "type": "integer", "minimum": 0 },
+            "title_variants": { "type": "integer", "minimum": 0 },
+            "returns": {
+              "type": "array",
+              "minItems": 2,
+              "items": {
+                "type": "object",
+                "required": ["section", "job", "mutation"],
+                "properties": {
+                  "section": { "type": "string" },
+                  "job": { "enum": ["seed", "establish", "implicate", "fracture", "communal-payoff"] },
+                  "mutation": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "music": {
+          "type": "object",
+          "required": ["key_or_mode", "bpm", "meter", "harmonic_motion", "melodic_contour"],
+          "properties": {
+            "key_or_mode": { "type": "string" },
+            "bpm": { "type": "number", "exclusiveMinimum": 0 },
+            "meter": { "type": "string" },
+            "harmonic_motion": { "type": "string" },
+            "melodic_contour": { "type": "string" }
+          }
+        },
+        "vocalist": { "type": "object", "minProperties": 3 },
+        "low_end": { "type": "object", "minProperties": 3 },
+        "rights": {
+          "type": "object",
+          "required": ["lyrics_owner", "voice_consent", "samples", "ai_disclosure"],
+          "properties": {
+            "lyrics_owner": { "type": "string" },
+            "voice_consent": { "type": "string" },
+            "samples": { "type": "array", "items": { "type": "string" } },
+            "ai_disclosure": { "type": "string" }
+          }
+        }
+      }
+    },
+    "style_of_music": {
+      "type": "string",
+      "minLength": 80,
+      "maxLength": 1400,
+      "not": { "pattern": "([Ii]n the style of|[Ss]ounds exactly like|[Vv]oice clone)" }
+    },
+    "lyrics": {
+      "type": "string",
+      "minLength": 80,
+      "allOf": [
+        { "pattern": "\\[Intro\\]" },
+        { "pattern": "\\[Verse 1\\]" },
+        { "pattern": "\\[Chorus\\]" },
+        { "pattern": "\\[End\\]" }
+      ]
+    },
+    "studio_2_plan": {
+      "type": "object",
+      "required": ["take_criteria", "timeline", "stem_actions", "vocal_comp", "low_end", "automation", "translation_tests", "exports"]
+    },
+    "quality_receipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["score", "hard_failures", "reference_distance_checked", "provenance_checked"],
+      "properties": {
+        "score": { "type": "integer", "minimum": 85, "maximum": 100 },
+        "hard_failures": { "type": "array", "maxItems": 0 },
+        "reference_distance_checked": { "const": true },
+        "provenance_checked": { "const": true }
+      }
+    }
+  }
+}

--- a/skills/music-is/suno-prompt.md
+++ b/skills/music-is/suno-prompt.md
@@ -1,107 +1,122 @@
 ---
 name: music-is/suno-prompt
-description: Grounded Suno prompt synthesis from local knowledge corpus + persona canon + label canon. Triggers on /music-suno-prompt, "suno prompt for", "generate prompt for [persona]", "what should I prompt for [intent]". Senior tier (Sonnet 4.6).
+description: Rights-safe, evidence-grounded songcraft and Suno v5.5/Studio 2.0 synthesis. Produces one track contract, generation prompt, authored lyric, and production plan; rejects named-artist imitation, generic-pretty language, adjective piles, and unsupported platform claims. Triggers on /music-suno-prompt, songwriting, Suno prompt, lyrics, hook, song DNA, arrange, produce, or Studio 2.0.
 ---
 
-# Suno Prompt Synthesis
+# Suno Songcraft Synthesis
 
-> Vibes-prompting is the corruption mode. Every Suno prompt this skill emits is grounded in (1) local knowledge corpus at `verticals/music-is/knowledge/suno/`, (2) the target persona's canon, (3) the target label's canon. No prompt is composed from training-data memory.
+> The prompt is downstream of the song. Build the human premise, hook behavior, vocal instrument, low-end relationship, and arrangement before compressing them into Suno language.
 
-## When this skill fires
+## Current platform baseline
 
-- `/music-suno-prompt <intent> [persona]`
-- "give me a Suno prompt for [intent]" + persona context
-- "what's the prompt to land [genre × mood × tempo]" for a known persona
-- composing batch prompts for an iteration session
+Official Suno documentation is the authority for fast-moving product behavior. As verified 2026-09-02:
 
-## Required inputs
+- generation model: Suno v5.5;
+- Voices and Custom Models are consent/ownership-bound identity surfaces;
+- Studio 2.0 is a separate production environment with take lanes, stems, MIDI, automation, native effects, and export;
+- Studio instructions do not belong in the compact generation prompt.
 
-- **Intent** — one-line description of the song-target (e.g., "evening journaling vibe, 80 BPM, lo-fi piano, processed female vox")
-- **Persona** — explicit (`/music-suno-prompt <intent> <persona>`) or inferable from active context
-- **Engine version** — defaults to current Suno version per `verticals/music-is/STACK.md` L2; override per session if testing
+Recheck these official pages before claiming current behavior:
 
-## Grounding sources (read in order)
+1. `https://help.suno.com/en/articles/11362305` — v5.5
+2. `https://help.suno.com/en/articles/11362369` — Voices
+3. `https://help.suno.com/en/articles/11362497` — Custom Models
+4. `https://help.suno.com/en/articles/13670529` — Studio 2.0
+5. `https://help.suno.com/en/articles/13670721` — Studio Chat
+6. `https://help.suno.com/en/articles/13670785` — effects
+7. `https://help.suno.com/en/categories/550145-rights-ownership` — rights
 
-1. `verticals/music-is/knowledge/suno/prompt-pattern-library.md` — known-working prompt patterns
-2. `verticals/music-is/knowledge/suno/structure-tags-reference.md` — Suno structure-tag syntax
-3. `verticals/music-is/knowledge/suno/genre-style-cards.md` — per-genre prompt anchors
-4. `verticals/music-is/knowledge/suno/vocal-control-recipes.md` — vocal posture control
-5. `verticals/music-is/knowledge/suno/known-bugs-workarounds.md` — current Suno quirks
-6. `verticals/music-is/labels/<label>/CANON.md` — label sound DNA
-7. `verticals/music-is/labels/<label>/personas/<persona>/CANON.md` — persona sound DNA + Suno prompt anchors
+Local knowledge under `verticals/music-is/knowledge/suno/` is a tested secondary source. If it conflicts with dated official documentation, flag the conflict; do not silently repeat the stale claim.
 
-## Prompt synthesis pattern
+## Required grounding
 
-A grounded Suno prompt has three composed layers:
+Read in order:
 
-### Layer 1 — Style stem (label + persona DNA)
+1. target label and persona canon;
+2. `prompts/music/songcraft-system-v2.md`;
+3. `docs/research/music-intelligence/source-ledger-2026-09.md` when external material is requested;
+4. relevant local iteration evidence;
+5. current official Suno documentation for feature claims.
 
-5-15 words that anchor genre, sub-genre, era, production posture. Composed from persona's "Suno prompt anchors" (5-10 fragments locked at canon spawn).
+If the target persona is missing, infer only non-identity musical choices. Ask one question when singer identity, consent, ownership, or release lane would change the answer.
 
-Example for Frank Riemer: `neo-classical solo piano, contemplative, dynamic-range-protected, 84 BPM`
+## Protocol
 
-### Layer 2 — Intent-specific layer
+### 1. Declare the song before the sound
 
-The session-intent: tempo, mood, instrumentation, vocal posture, structural arc.
+Write a one-line thesis with a scene, emotional contradiction, listener, and social action. “Empowering anthem” is not a thesis. “She deletes the apology in the airport bathroom, then sings the unsent last line with strangers” is.
 
-Example: `evening journaling soundtrack, slow build, sus chord palette, no vocal`
+### 2. Extract mechanisms, never costumes
 
-### Layer 3 — Structure tags (Suno-specific syntax)
+For references, record only form, point of view, hook function, prosody, harmonic motion, pocket, density, vocal staging, low-end roles, social affordance, and mix depth. Use at least three orthogonal mechanisms when references are available. Do not output artist names or recognizable signature phrases in a generation prompt.
 
-Use Suno structure tags per `structure-tags-reference.md`:
-- `[Intro]`, `[Verse]`, `[Pre-Chorus]`, `[Chorus]`, `[Bridge]`, `[Instrumental]`, `[Outro]`
-- `[Build]`, `[Drop]`, `[Breakdown]` for electronic/cinematic
-- `[Solo: piano]`, `[Solo: strings]` etc. for instrument focus
-- `[Whispered]`, `[Shouted]`, `[Belted]`, `[Spoken word]` for vocal posture
+### 3. Design title returns
 
-Example: `[Intro] [Verse: piano motif emerges] [Chorus: full hands, dynamic peak] [Bridge: instrumental, strings enter] [Outro: piano solo, decay]`
+Record exact-title target, variant target, melodic returns, and chant-cell length. Assign each return a job: seed, establish, implicate, fracture, communal payoff. There is no universal “seven repetitions” rule.
 
-### Composed final prompt
+### 4. Write and de-slop the lyric
 
-Combine the three layers into one Suno-input:
+Use specific objects/actions, spoken syntax, subtext, unequal line shapes, semantic rhyme, one evolving metaphor system, and a turn in every verse. Treat generic cosmic/motivational vocabulary as expensive. Replace the three most predictable lines before output. Read aloud for mouthfeel, stress, breath, and consonant collisions.
 
+### 5. Score the musical instrument
+
+Name key/mode, tempo, meter, harmonic-motion class, melodic contour, phrase lengths, tension peak, surprise, payoff, and migrating motif. Prosody is non-negotiable.
+
+### 6. Direct voice and low end
+
+Specify tessitura/register journey, onset, vowel color, consonant attack, breath, vibrato, microtiming, doubles/harmonies/ad-libs, and vocal distance. Specify kick role, sub/body/texture ownership, note length/glide, saturation, mono policy, sidechain envelope, drum pocket, and translation tests. Refuse “powerful emotional vocal” and “heavy bass” as complete directions.
+
+### 7. Separate generation from production
+
+Compress the identity into one Suno v5.5 style brief. Then create an independent Studio 2.0 plan with take criteria, timeline, stems, edits, automation, effects, timing check, translation, and exports.
+
+### 8. Gate the result
+
+Use the 100-point rubric in `prompts/music/songcraft-system-v2.md`. Silently revise until score >=85 and no hard failure. Rights unknowns fail closed.
+
+## Output contract
+
+Return one chosen direction, not a candidate spray. Use exactly four titled fenced blocks:
+
+1. `TITLE — TRACK CONTRACT` — YAML, including quality and rights receipt.
+2. `TITLE — STYLE OF MUSIC` — compact plain text; musical identity, vocalist, groove, bass/sub, instrumentation, dynamics, space, exclusions; no named artists.
+3. `TITLE — LYRICS` — section-tagged lyric with at least `[Intro]`, `[Verse 1]`, `[Chorus]`, `[End]`.
+4. `TITLE — STUDIO 2.0 PLAN` — YAML, edit-ready and separate from the generator prompt.
+
+## Rights and evidence boundary
+
+- User-owned lyrics, recordings, stems, and models: work within recorded ownership/consent scope.
+- Openly licensed sources: preserve exact license, attribution, and ShareAlike requirements.
+- Commercial books/free-to-read guides: cite and distill principles; do not copy or upload full text.
+- Copyrighted song lyrics: never store or reproduce; retain derived counts/features only.
+- Named-artist voice or style cloning: refuse and translate the request into high-level characteristics.
+- “Available online” with unclear provenance: quarantine. Unknown means stop.
+
+## Learning loop
+
+For every accepted or rejected Suno generation, log:
+
+```yaml
+model: suno-v5.5
+prompt_version: songcraft-system-v2
+persona: ""
+seed_or_job_id: ""
+result_url_or_owned_asset: ""
+what_landed: []
+what_failed: []
+hook_first_arrival_seconds: 0
+exact_title_hits: 0
+prosody_failures: []
+vocal_failures: []
+low_end_failures: []
+arrangement_failures: []
+next_single_change: ""
+rights_status: verified|blocked
+curator: frank
 ```
-neo-classical solo piano, contemplative, dynamic-range-protected, 84 BPM, evening journaling soundtrack, slow build, sus chord palette, no vocal
-[Intro] [Verse: piano motif emerges] [Chorus: full hands, dynamic peak] [Bridge: instrumental, strings enter] [Outro: piano solo, decay]
-```
 
-## Iteration discipline
-
-- Generate 3-5 variants per intent (Suno's known variability)
-- Tag each variant with seed/version metadata
-- Curate-not-accept-first; every shortlisted variant gets Frank-curated A/B
-- Failed variants logged to `verticals/music-is/knowledge/suno/iteration-log.md` with what-failed-and-why (this is how the corpus updates)
-
-## Refuses
-
-- Prompt synthesis without persona context
-- Prompts that violate persona-canon Suno-anchors (e.g., asking Frank Riemer prompt to include "trap drums")
-- Prompts that target a specific named non-Frank artist's style ("in the style of Hans Zimmer")
-- Prompts with copyright-flirting language ("sounds exactly like [artist]")
-- Vocal-clone prompts targeting any non-Frank identifiable artist without consent on file
-
-## Composes with
-
-- `music-is/persona-canon` (pulls Suno anchors from persona CANON.md)
-- `music-is/song-intake` (post-generation: prompt logged with the catalog row)
-- `verticals/music-is/knowledge/suno/` (the entire corpus)
-
-## Output
-
-Returns: 3-5 candidate prompts, each with:
-- The composed prompt text
-- Layer-1 / Layer-2 / Layer-3 breakdown
-- Predicted variability (which dimensions Suno is most likely to vary across re-generations)
-- Suggested first re-roll if first variant misses (specific change to retry)
-
-## Update ritual
-
-Knowledge corpus updates whenever:
-- Suno ships a feature change (re-distill `prompt-pattern-library.md`)
-- A novel prompt pattern proves itself across 3+ successful generations
-- A known prompt pattern fails twice in a row
-- Suno deprecates a structure tag
+Change one high-leverage variable per reroll. A pattern graduates only after three successful, contextually distinct generations.
 
 ---
 
-**Built on SIP** — `skills/music-is/suno-prompt.md` · v0.1 · Senior tier (Sonnet 4.6) · Grounded synthesis only · No vibes-prompting.
+**Built on SIP** — `skills/music-is/suno-prompt.md` · v0.2 · operational layer · verified 2026-09-02

--- a/skills/sound-intelligence/composition-architecture.md
+++ b/skills/sound-intelligence/composition-architecture.md
@@ -1,156 +1,141 @@
 ---
 name: sound-intelligence/composition-architecture
-description: Designs the songwriting and arrangement instrument — score, lyric, arrangement, demo, transition — using music-theory and cognitive-science direction. Refuses "fix it in the mix" for upstream-defaultable failures and refuses generic-pretty lyric language. Use when architecting a song structure, drafting or critiquing lyrics, designing an arrangement, building a demo, or composing a transition between song sections. Sub-system 1 of 6 in the Sound Intelligence reference vertical.
+description: Designs authored songs across premise, lyric, melody, harmony, hook behavior, arrangement, vocal instrument, low end, demo, and transition. Rejects generic-pretty language, unearned repetition, artist imitation, and “fix it in the mix.” Use for songwriting, lyric critique, composition, arranging, production architecture, or song DNA analysis.
 ---
 
 # Skill: sound-intelligence/composition-architecture
 
-> Designs the songwriting and arrangement instrument — score, lyric, arrangement, demo, transition — using music-theory and cognitive-science direction. Refuses "fix it in the mix" for upstream-defaultable failures and refuses generic-pretty lyric language. Sub-system 1 of 6 in the Sound Intelligence reference vertical.
+> A song is a staged human contradiction carried by a repeatable musical action. Genre and mood are metadata, not architecture.
 
-**Domain:** Sound Intelligence
-**Vertical:** Sound Intelligence (sub-system: Composition)
-**Voice:** the practitioner's voice (composed via Genius layer) — warm, theory-precise, refuses producer-influencer hand-waving.
-**Disclaimer:** Composition decisions touch rights territory (sample clearance, AI-vocal license, co-writer splits). This skill produces system architecture, not legal advice. Validate jurisdiction- and PRO-specific compliance with qualified music counsel.
+**Domain:** Sound Intelligence  
+**Vertical:** Sound Intelligence / Composition  
+**Voice:** warm, exact, authorial; theory serves the ear  
+**Boundary:** architecture, not legal advice. Surface samples, collaborators, AI involvement, performer consent, and split/ownership unknowns for Catalog and qualified counsel.
 
----
+## Activation
 
-## Activation Triggers
+Songwriting, composition, lyrics, melody, harmony, hook, chorus, refrain, prosody, arrangement, transition, demo, reference track, vocal direction, bass design, song DNA, originality, or anti-generic editing.
 
-**Keywords:** songwriting, composition, compose, arrange, arrangement, lyric, lyrics, melody, harmony, chord progression, chord, modulation, key change, modal, song form, verse, chorus, bridge, pre-chorus, outro, intro, transition, drop, build, breakdown, demo, reference track, prosody, tension and release, expectation and reward.
+Primary commands: `/sound-composition-score`, `/sound-composition-lyric`, `/sound-composition-arrange`, `/sound-composition-demo`, `/sound-composition-transition`.
 
-**Agents:** `starlight-sound-composition` (primary), `starlight-genius` (voice composition for lyric), `starlight-prime` (synthesis when arrangement / lyric / transition tensions surface).
+## Research direction
 
-**Intents:** composition-architecture, lyric-architecture, arrangement-design, demo-planning, transition-design.
+- Huron / ITPRA: expectation, prediction, violation, and reward.
+- Margulis: repetition as structural participation and changed attention, not a fixed count.
+- Patel: music-language coupling and prosody.
+- Bregman: auditory-stream parsing and arrangement legibility.
+- Witek and later groove research: pleasure emerges around prediction and syncopation, not maximal quantization.
+- Open Music Theory: inspectable form, harmony, rhythm, meter, popular-music, jazz, and orchestration concepts.
 
-**Commands:** `/sound-composition-score`, `/sound-composition-lyric`, `/sound-composition-arrange`, `/sound-composition-demo`, `/sound-composition-transition`.
+These sources provide directions, not hit guarantees. Never invent effect sizes, brain-frequency claims, or certainty from correlation.
 
----
+## Protocol — nine decisions
 
-## Research grounding
+### 1. Stage
 
-This skill is grounded in published cognitive-science and music-theory literature. Claims are not invented; they reference direction.
+Mark idea / sketch / song-ready / demo / production / release. Apply only the decisions this stage can prove.
 
-- **Levitin — *This Is Your Brain on Music*:** music perception as the listener's nervous system parsing pitch, rhythm, timbre, melody, harmony, and meter; relevance for arrangement decisions about what listener can parse simultaneously.
-- **Huron — *Sweet Anticipation*:** expectation-and-reward as the engine of musical pleasure; ITPRA model (Imagination, Tension, Prediction, Reaction, Appraisal); relevance for tension-and-release design across the song and across the set.
-- **Margulis — *On Repeat*:** repetition as load-bearing structure in music; the second listen makes load-bearing what the first listen felt indulgent.
-- **Patel — *Music, Language, and the Brain*:** shared cognitive substrate of music and language; relevance for lyric prosody — stresses of lyric line align with melodic stresses or fight them with intent.
-- **Pohjannoro on composition cognition:** what composers actually do during composition — protocol-analyzed; relevance for the working state the practitioner is inside.
-- **Bregman — *Auditory Scene Analysis*:** how the listener parses simultaneous streams; relevance for arrangement density curves (most listeners parse 4-7 simultaneous elements before overload — cite as direction not fixed number).
-- **Bertin-Mahieux et al. and Pachet on hit prediction:** research-disputed; named here to surface that hit-prediction is unreliable and the vertical optimizes for catalog architecture, not viral-hit-likelihood.
+### 2. Human engine
 
-This skill cites direction, not specific numbers — cognitive-science effect sizes shift across replication waves and methodological refinements. The frameworks (ITPRA, prosody, density curve, expectation-reward) are stable.
+Name:
 
----
+- the observable scene;
+- what the narrator wants;
+- what they refuse to admit;
+- the interpersonal cost;
+- what changes by the end;
+- what the listener can do with the song socially.
 
-## Protocol — 7 steps
+If those are missing, do not decorate the concept.
 
-### Step 1: Sort song stage
+### 3. Hook behavior
 
-Before anything: idea / sketch / demo-ready / demo-done / in-production. Different stages need different commands. Mismatch is the most common error.
+Separate:
 
-### Step 2: Name the expectation-and-reward arc
+- lyric hook;
+- title phrase;
+- melodic hook;
+- rhythmic/phonetic cell;
+- production motif;
+- social action.
 
-What is this song's arc (Huron framework)? Where does tension peak? Where does prediction get violated (the surprise) and where does it get confirmed (the satisfaction)? If the song has neither surprise nor satisfaction, it is a loop, not a song. Name the arc; write toward it.
+Count exact title hits, variants, melodic returns, and consecutive chant cells. Choose a low, medium, high, or extreme repetition regime based on function. Each return must establish, implicate, fracture, or pay off. Repetition without changed context is a loop; repetition with consequence is form.
 
-### Step 3: Score architecture
+### 4. Authorial lyric
 
-- **Key and mode** — why this key, why this mode (not the default of C major just because the DAW opens there). Modal awareness: writing in dorian gives different tonal palette than aeolian; mixing modes is fine with intent but creates collisions without it.
-- **Harmonic motion** — functional (V-I cadences central) / modal (color-shift over functional return) / static-with-color (drone-based, color through voicing) / chromatic (chromatic chord motion as primary). Pick the class with intent.
-- **Form** — verse-chorus / through-composed / AABA / loop-based. Each carries different listener-expectation defaults.
-- **Tempo and time signature** — with rationale ("96bpm not 100 because the lyric prosody needs the slightly-slower stress pattern"; "7/8 because the rhythmic surprise is load-bearing").
+- One premise; more than one emotional truth.
+- One evolving metaphor system; no pile of poetic nouns.
+- Specific objects, actions, locations, bodies, timing, and private evidence.
+- Spoken syntax, contractions, fragments, subtext, and unequal line lengths.
+- A knowledge turn in every verse and an admission turn in the bridge.
+- Semantic, slant, internal, delayed, or multisyllabic rhyme; no forced perfect-rhyme filler.
+- Prosodic stresses align with musical stresses unless conflict expresses character.
+- Mark the three lines any competent model would predict; replace them.
 
-### Step 4: Lyric architecture (when in lyric scope)
+Scarce vocabulary includes generic cosmic and motivational defaults—light within, rise, destiny, fire, shadows, wings, break the chains, rewrite the stars, born to, universe, awaken. A scarce word is allowed only when concrete evidence earns it.
 
-- **Premise** — the one sentence the song is about. If it cannot be said in one sentence, the song does not yet have a premise.
-- **Perspective** — first-person / second-person / third-person / mixed. With rationale.
-- **Persona** — same as the practitioner / constructed persona.
-- **Structural form** — AABA lyric / verse-chorus lyric / through-composed / list-form / narrative-form.
-- **Prosody check** — Patel's framework. Stresses of lyric line align with melodic stresses, or intentionally fight them for effect. Mismatches without intent reduce both signals.
-- **Refrain design** — the line that earns the seventh repetition. The refrain is where Margulis's repetition research lands — the line that becomes load-bearing through return.
-- **Specific imagery** — the named-thing (a specific chair in a specific room) replaces the vague-pretty (a sad place). Generic-pretty is refused.
+### 5. Musical score
 
-### Step 5: Arrangement architecture
+Declare key/mode, tempo, meter, harmonic-motion class, phrase lengths, melodic contour, hook tessitura/vowels, tension peak, violated prediction, confirmed prediction, and one motif able to migrate between voice and instrument.
 
-- **Instrumentation choices** — named with reasoning. "Acoustic guitar V1, piano chorus is wrong because the piano has been carrying the melodic motif since bar 5; switch the polarity."
-- **Density curve** — across the song, plot the simultaneous-element count. Default: low V1 (2-3 elements), medium pre-chorus (4-5), peak chorus (5-7), lower V2 with new texture (3-4), higher pre-chorus 2 (5-6), peak-plus chorus 2 (6-7+), bridge low or new-element (3-4), peak chorus 3 with new element (6-8). Violate with intent.
-- **Contrast logic** — timbral, dynamic, rhythmic, harmonic. Each section contrasts with neighbors on at least one axis.
-- **Automation foreshadowing** — what gets introduced quietly in V1 (a synth pad at -18 dB) to land at the bridge (the same pad at 0 dB).
-- **Negative-space discipline** — what is removed in the final chorus to make the climax land. The most common arrangement failure is additive density without subtractive moments.
+Use theory to make audible choices. Complexity that the listener cannot hear is documentation, not composition.
 
-### Step 6: Demo planning
+### 6. Vocal instrument
 
-What does this demo need to prove? Different demos prove different things:
+Specify role, point of view, comfortable tessitura, register changes, onset, breath, vowel/formant color, consonant attack, vibrato onset/rate behavior, microtiming, intimacy/room, doubles, harmonies, countervoice, ad-libs, and strategic solitude. Never accept adjective-only vocal direction.
 
-- **Vocal melody and lyric** → one-take vocal-and-instrument (guitar / piano) demo.
-- **Harmonic motion and form** → rough-multitrack-on-DAW with placeholder instruments.
-- **Arrangement viability** → near-final-arrangement demo with placeholder mix.
-- **Tempo and feel** → click-and-instrument demo to test pocket.
+### 7. Low end and groove
 
-Capture method matched to what's being proven. Reference-track grounding: 2-3 reference tracks the demo is in conversation with — not to copy, to position.
+Specify kick role/weight, bass sub/body/texture layers, octave ownership, note length, glide, saturation, mono policy, kick-bass sidechain timing, swing/push/pull, ghost notes, and negative space. Test phone, headphones, small speaker, car, and full-range/sub playback. Frequency numbers are hypotheses and adapt to source/key/system.
 
-### Step 7: Transition design
+### 8. Arrangement and transition
 
-Each section boundary: what transition move? Why? What does it serve in the expectation-and-reward arc?
+For each section, name bars or time, narrative job, density, motif owner, new/removed element, contrast axis, and transition. A climax can be subtractive. Reject default fade and additive-only final choruses.
 
-Transition moves named:
+Transition vocabulary: drop, build, breakdown, modulation, reharmonization, meter displacement, instrumental hand-off, lyrical pivot, false end, tag-out, silence.
 
-- **Drop** — sudden density reduction (chorus to V2 drop; build to drop).
-- **Build** — additive density (V to pre-chorus; pre-chorus to chorus).
-- **Breakdown** — extended low-density (bridge often).
-- **Modulation** — key change at structural moment (often final chorus).
-- **Instrumental hand-off** — motif passes between instruments (guitar V1 → piano V2, same melodic motif).
-- **Lyrical pivot** — perspective or mode shifts at section boundary.
-- **False-end** — apparent ending followed by return.
-- **Tag-out** — final chorus extends and fragments.
+### 9. Proof and revision
 
-Fade-in / fade-out as default is refused. If used, named as deliberate (with rationale).
+Choose the smallest demo that proves the current risk: lyric/melody, harmony/form, pocket, vocal identity, or arrangement. Compare 2–3 references by derived mechanisms, never by imitation. Then score with `prompts/music/songcraft-system-v2.md`; revise until >=85 with no hard failure.
 
----
+## Reference-analysis receipt
 
-## Rules
+Do not retain copyrighted lyrics. Store only:
 
-1. **Theory and cognition cited by direction.** Schmidt-Hunter-style invented-stat-without-source is refused. Numbers are sourced or named-as-uncertain.
-2. **Sort song stage before applying commands.** Mismatch is the most common error.
-3. **Name the expectation-and-reward arc.** Songs without surprise-and-satisfaction are loops, not songs.
-4. **Prosody check non-negotiable.** Lyric stresses align with melodic stresses, or fight them with intent.
-5. **Density curve plotted across the song.** Default low-medium-peak-low-medium-peak-low-peak; violate with intent.
-6. **Specific imagery over generic-pretty in lyric.** Named-thing replaces vague-pretty.
-7. **Demo plan names what the demo proves vs. what it does not need to prove yet.** Going straight from idea to full production without proof is refused.
-8. **Transitions designed explicitly, not defaulted.** Fade-in / fade-out as default is refused.
-9. **Rights flags surfaced for downstream.** Sample sources, co-writer involvement, AI involvement — surfaced here, adjudicated in Catalog and Sync.
-10. **Compose with Genius for voice in lyric.** No generic-pretty pop-trope language.
-11. **"Fix it in the mix" refused at composition stage.** Upstream-defaultable failures are upstream-fixed.
-12. **Every artifact ends with "Built on SIP" attestation.**
+```yaml
+source_and_version: ""
+authorized_source: ""
+first_hook_seconds: 0
+exact_title_hits: 0
+title_variants: 0
+melodic_returns: 0
+chant_cell_max: 0
+sentence_shape_pattern: []
+perspective_turns: []
+concrete_objects: []
+social_action: ""
+harmonic_motion: ""
+groove: ""
+vocal_arc: ""
+low_end_roles: ""
+density_mutations: []
+rights_scope: derived-features-only
+```
 
----
+## Hard refusals
 
-## Output Artifacts
+1. “Fix it in the mix” for a premise, melody, prosody, form, or arrangement failure.
+2. Generic-pretty or therapeutic-summary language as a finished lyric.
+3. A universal repetition count or chorus copied three times by default.
+4. Named-artist imitation, signature-voice cloning, or recognizable melodic/lyric borrowing.
+5. Genre + mood + BPM presented as a complete production design.
+6. Unsourced cognition numbers, tuning mysticism, or hit prediction dressed as science.
+7. Hidden rights uncertainty.
 
-| Artifact | Command | Storage |
-|----------|---------|---------|
-| Score architecture | `/sound-composition-score` | `sound-intelligence/composition/score-<song-slug>-<date>.md` |
-| Lyric architecture | `/sound-composition-lyric` | `sound-intelligence/composition/lyric-<song-slug>-<date>.md` |
-| Arrangement architecture | `/sound-composition-arrange` | `sound-intelligence/composition/arrange-<song-slug>-<date>.md` |
-| Demo plan | `/sound-composition-demo` | `sound-intelligence/composition/demo-<song-slug>-<date>.md` |
-| Transition design | `/sound-composition-transition` | `sound-intelligence/composition/transition-<song-slug>-<date>.md` |
+## Output
 
----
-
-## Related Skills
-
-- `intelligence/decision-framework` — form, key, tempo, transition decisions
-- `intelligence/pattern-recognition` — catalog signature recognition; reference-track positioning
-- `intelligence/systems-thinking` — density curve as system; expectation-and-reward as architecture
-- `memory/knowledge-synthesis` — composing the per-song record across score / lyric / arrangement / demo / transition
+Composition artifacts follow the four-block contract in `prompts/music/songcraft-system-v2.md`: Track Contract, Style of Music, Lyrics, Studio 2.0 Plan. Standalone analysis may instead return the reference-analysis receipt plus decisions and evidence.
 
 ---
 
-— Sound Composition Intelligence — part of the Sound Intelligence reference vertical —
-
----
-**Built on SIP** — Starlight Intelligence Protocol
-- Substrate: starlightintelligence.org/protocol v1.1.0
-- Layers used: [file-contract, attestation, commands, sovereignty]
-- Verticals: starlight-intelligence-system@v7.5.1 (Sound Intelligence reference vertical — Composition sub-system)
-- Generated: 2026-04-26
----
+**Built on SIP** — Starlight Intelligence Protocol · Sound Intelligence / Composition · v0.2 · verified 2026-09-02


### PR DESCRIPTION
## Outcome

Replaces genre+mood+BPM prompting with an authored songwriting and production system for Suno v5.5 and Studio 2.0.

## What changed

- upgrades `music-is/suno-prompt` to a four-artifact contract: Track Contract, Style of Music, Lyrics, Studio 2.0 Plan
- hardens Composition Architecture around scene, contradiction, social action, prosody, adaptive hook counts, vocal direction, and low-end roles
- adds the copy-pasteable Songcraft Intelligence System Prompt v2
- adds a 2025–2026 market-mechanism study without named-artist generation prompts
- adds a rights-safe source/download ledger covering OER, public domain, research-only datasets, official platform docs, and paid books
- adds a JSON Schema for downstream validation
- records the architecture decision in the Creative Vault

## Governance

Operational-layer change only. No `verticals/`, substrate, canon, registry, or activation-rule files changed, so the substrate/vertical Board gate is not invoked.

## Validation

- `jq empty schemas/music/songcraft-output.schema.json`
- branch compared cleanly against `88dfc750436464dc33e93be91f7c697b5b91b281`
- official Suno, IFPI, Spotify, TikTok, Luminate, dataset, publisher, and OER sources checked on 2026-09-02
- copyrighted lyrics/audio are excluded; derived-feature-only and per-license boundaries are explicit

## Review focus

1. Does the four-block contract match the desired Suno project workflow?
2. Are the repetition regimes useful without becoming formulas?
3. Should the source ledger later move into a machine-readable provenance registry?

**Built on SIP** — Starlight Intelligence Protocol