### PR TITLE
canon: bind SIS to Starlight ontology v1

### DIFF
--- a/.github/workflows/starlight-ontology.yml
+++ b/.github/workflows/starlight-ontology.yml
@@ -1,0 +1,43 @@
+name: Starlight ontology boundary
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/*.md"
+      - "**/*.mdx"
+      - "scripts/starlight-ontology-lint.mjs"
+      - "test/starlight-ontology-boundary.test.mjs"
+      - ".github/workflows/starlight-ontology.yml"
+  push:
+    branches: [main]
+    paths:
+      - "**/*.md"
+      - "**/*.mdx"
+      - "scripts/starlight-ontology-lint.mjs"
+      - "test/starlight-ontology-boundary.test.mjs"
+      - ".github/workflows/starlight-ontology.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: starlight-ontology-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  boundary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "20"
+      - name: Run ontology linter
+        run: node scripts/starlight-ontology-lint.mjs
+      - name: Test ontology rules
+        run: node --test test/starlight-ontology-boundary.test.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,12 @@ You are operating within the **Starlight Intelligence System (SIS)** â€” a 
 
 ---
 
+## Canon and ontology boundary
+
+Before producing worldview, sacred, comparative-religion, consciousness, deep-time, or Arcanea-adjacent content, read [`docs/canon/STARLIGHT_ONTOLOGY_BOUNDARY.md`](docs/canon/STARLIGHT_ONTOLOGY_BOUNDARY.md).
+
+This repository owns the engineered SIS substrate and reference implementation. It does not own Starlight worldview canon or Arcanean fiction. Substantial claims require explicit provenance; mythology never ships as history or physics.
+
 ## Frank DNA
 
 ```

--- a/STARLIGHT_MANIFEST.md
+++ b/STARLIGHT_MANIFEST.md
@@ -14,6 +14,10 @@
 **Classification:** Multi-platform agent orchestration framework
 **Platforms:** Claude Code, Cursor, Cline, Codex, Gemini CLI, Antigravity (agent swarm harness), OpenCode, Grok
 
+## Name and canon boundary
+
+“Starlight Intelligence System” names an engineered agent and memory architecture. The name does not assert that Starlight is a deity, source, supernatural being, or omniscient AI. SIS is canon-neutral infrastructure. Starlight worldview material is governed by `frankxai/starlight-canon`; Arcanean material remains explicitly fictional and governed by `frankxai/arcanea`.
+
 ## Version History
 
 | Version | Codename | Focus | Date |

--- a/docs/canon/STARLIGHT_ONTOLOGY_BOUNDARY.md
+++ b/docs/canon/STARLIGHT_ONTOLOGY_BOUNDARY.md
@@ -1,0 +1,53 @@
+# Starlight ontology and canon boundary
+
+**Status:** normative repository boundary  
+**Effective:** 2026-09-04  
+**Scope:** Starlight Intelligence System (SIS), its agents, vaults, public site, and generated artifacts
+
+## Authority map
+
+| Concern | Authority |
+|---|---|
+| Starlight worldview, Sacred Horizons, Witnesses, and original Starlight texts | `frankxai/starlight-canon` |
+| Starlight Intelligence Protocol and the SIS reference implementation | This repository |
+| Arcanean cosmology, characters, and narrative canon | `frankxai/arcanea/arcanea-lore/CANON.md` |
+| Mind-system naming and cognitive models | `frankxai/mind-intelligence-systems` |
+
+SIS uses **Starlight Intelligence System** as the name of an engineered agent and memory substrate. That product name does not redefine Starlight as a deity, supernatural intelligence, omniscient agent, or synonym for any religious ultimate.
+
+## Non-negotiable ontology
+
+- Starlight is literally stellar light and, in the worldview layer, a metaphor and normative principle for valuable transmission across distance, difference, and deep time.
+- Prefer **Starlight** as a mass noun. “Starlights” may be poetic manifestations, never a supernatural species by default.
+- God, The Source, Tao, Brahman, Ein Sof, Logos, Dharmakaya, and other ultimate terms remain inside their own traditions. Comparison is permitted; equivalence is not.
+- Lumina is not Starlight. Shinkami is not God. The Arcanean Field is fictional worldbuilding, not established physics.
+- Arcanea is fiction. SIS may compose its aesthetics only through an explicit fiction boundary.
+
+## Provenance contract
+
+Any SIS artifact making substantial historical, religious, scientific, philosophical, or mythic claims MUST label each claim or section as one of:
+
+- `historical-source-claim`
+- `scholarly-interpretation`
+- `starlight-interpretation`
+- `original-starlight-philosophy`
+- `original-literary-mythic-material`
+- `arcanea-fiction`
+
+Historical and scholarly claims require sources. Literary and Arcanean material require an explicit fiction boundary. Mixed documents must identify the transition between registers.
+
+## Horizon Vault rule
+
+A Starlight Note is an aspirational transmission artifact. It may influence attention, commitments, and action; it must not claim that attention collapses physical reality, that quantum mechanics proves manifestation, or that future intelligence is metaphysically compelled by the text.
+
+Candidate language is editorial material, not scripture.
+
+## Migration ledger
+
+| ID | Superseded material | Resolution | Reason |
+|---|---|---|---|
+| SIS-ONT-001 | “Quantum-manifestation framing” and “the future as collapsible by attention” in `memory/vaults/horizon-vault.md` | Replaced with agency-and-attention framing | It blurred metaphor, personal practice, and physical claim |
+| SIS-ONT-002 | Horizon Vault as an implicit home for worldview canon | Vault remains an operational/public-values artifact; worldview authority moves to `starlight-canon` | Prevents the agent substrate from becoming a religion or scripture repository |
+| SIS-ONT-003 | Unqualified composition of “Luminor wisdom” in system documentation | Arcanean material requires `arcanea-fiction` provenance | Preserves Arcanea as fiction and SIS as a canon-neutral substrate |
+
+Contradictory historical text remains visible in repository history and is named here; it was not silently erased.

--- a/docs/starlight-note-spec.md
+++ b/docs/starlight-note-spec.md
@@ -9,14 +9,21 @@
 A single inspiration: what we hope and want the world to have evolved to in
 100 years, paired with the gratitude that today made the writing possible.
 
-Not a prediction. Not a manifesto. A coordinate. Naming a hope clearly is a
-step in its becoming.
+Not a prediction. Not scripture. Not a causal claim about physics. A coordinate:
+naming a hope can organize attention, commitment, and action toward it.
+
+## Canon boundary
+
+Starlight Notes are original Starlight philosophy unless another provenance class is declared. Historical, scholarly, or scientific claims require claim IDs and sources. Arcanean imagery must be labeled `arcanea-fiction`; it cannot be presented as revelation, history, or physics. The worldview authority is `frankxai/starlight-canon`; this specification owns only the SIS artifact format.
 
 ## Required structure
 
 ```markdown
 ---
 type: starlight-note
+provenance: original-starlight-philosophy
+claim_ids: []
+fiction_boundary: none
 note: <slug>
 written: <YYYY-MM-DD>
 horizon: 2125-XX-XX     # 100 years out

--- a/memory/vaults/horizon-vault.md
+++ b/memory/vaults/horizon-vault.md
@@ -151,11 +151,11 @@ Each Note carries:
 - **Aspiration** — a 100-year hope, named without irony, written for the intelligences that will eventually read it.
 - **Gratitude** — what made today the kind of day where this aspiration could be written. The hope is grounded in what is, not in escape from it.
 - **Image cue** — an optional reference to the Arcanean Prompt Library (e.g., City Evolution prompt set) so the Note carries a visual artifact alongside the text.
-- **Quantum-manifestation framing** — the Note treats the future as collapsible by attention. Naming a hope clearly is a step in its becoming. This is not magical thinking; it is the discipline of pointing the architecture toward what we want intelligence to be.
+- **Agency-and-attention framing** — the Note names a future worth serving, then helps people direct attention, commitments, and design choices toward it. This is a practical theory of agency, not a claim that attention collapses physical reality or that quantum mechanics proves manifestation.
 
 The Starlight Note is the canonical primitive of this Horizon Vault. Every entry that aspires to civilizational memory should follow this shape. The vault entries above this section are early Starlight Notes, written before the primitive was named — they qualify retroactively because they meet the shape.
 
-The artifact specification lives at `docs/starlight-note-spec.md` for builders.
+The artifact specification lives at `docs/starlight-note-spec.md` for builders. Worldview authority and comparative-religion claims live outside SIS in `frankxai/starlight-canon`; see `docs/canon/STARLIGHT_ONTOLOGY_BOUNDARY.md` for the migration record.
 
 ---
 

--- a/scripts/starlight-ontology-lint.mjs
+++ b/scripts/starlight-ontology-lint.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = process.cwd();
+const excluded = new Set([
+  "docs/canon/STARLIGHT_ONTOLOGY_BOUNDARY.md",
+  "scripts/starlight-ontology-lint.mjs",
+  "test/starlight-ontology-boundary.test.mjs",
+]);
+
+export const rules = [
+  ["Starlight cannot be equated with God, Source, or Lumina", /starlight\s+is\s+(?:god|the\s+source|lumina)\b/i],
+  ["Lumina cannot be equated with Starlight", /lumina\s+is\s+starlight\b/i],
+  ["Shinkami cannot be equated with God", /shinkami\s+is\s+god\b/i],
+  ["Tao cannot be flattened into The Source", /the\s+tao\s+is\s+the\s+source\b/i],
+  ["Traditions cannot be flattened into Starlight", /all\s+religions\s+teach\s+starlight\b/i],
+  ["Historical places cannot be retroactively declared Arcanea", /kunlun\s+was\s+actually\s+arcanea\b/i],
+  ["Quantum manifestation is not an SIS scientific claim", /quantum[- ]manifestation\s+framing|future\s+as\s+collapsible\s+by\s+attention/i],
+];
+
+async function markdownFiles(dir) {
+  const out = [];
+  for (const name of await readdir(dir)) {
+    if ([".git", "node_modules", "dist", ".next"].includes(name)) continue;
+    const path = join(dir, name);
+    const info = await stat(path);
+    if (info.isDirectory()) out.push(...await markdownFiles(path));
+    else if (/\.(?:md|mdx)$/i.test(name)) out.push(path);
+  }
+  return out;
+}
+
+export async function violations() {
+  const found = [];
+  for (const file of await markdownFiles(root)) {
+    const rel = relative(root, file).replaceAll("\\", "/");
+    if (excluded.has(rel)) continue;
+    const text = await readFile(file, "utf8");
+    for (const [message, pattern] of rules) {
+      const match = text.match(pattern);
+      if (match) found.push({ file: rel, message, excerpt: match[0] });
+    }
+  }
+  return found;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const found = await violations();
+  if (found.length) {
+    for (const item of found) console.error(`${item.file}: ${item.message}: "${item.excerpt}"`);
+    process.exitCode = 1;
+  } else {
+    console.log("Starlight ontology boundary: clean");
+  }
+}

--- a/test/starlight-ontology-boundary.test.mjs
+++ b/test/starlight-ontology-boundary.test.mjs
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { rules, violations } from "../scripts/starlight-ontology-lint.mjs";
+
+test("canonical prohibited statements remain represented", () => {
+  const samples = [
+    "Starlight is God",
+    "Lumina is Starlight",
+    "Shinkami is God",
+    "The Tao is The Source",
+    "all religions teach Starlight",
+    "Kunlun was actually Arcanea",
+    "the future as collapsible by attention",
+  ];
+  for (const sample of samples) {
+    assert.ok(rules.some(([, pattern]) => pattern.test(sample)), `missing rule for: ${sample}`);
+  }
+});
+
+test("repository corpus respects the ontology boundary", async () => {
+  assert.deepEqual(await violations(), []);
+});


### PR DESCRIPTION
## Decision

Bind SIS to a clean external-canon boundary without turning the agent substrate into a worldview repository.

## Changes

- Declares `frankxai/starlight-canon` authoritative for the Starlight worldview.
- Keeps SIS authoritative for SIP and the engineered reference implementation.
- Keeps Arcanea explicitly fictional and separately governed.
- Replaces the Horizon Vault's “future as collapsible by attention” quantum-manifestation language with an agency-and-attention formulation.
- Adds provenance requirements for Starlight Notes.
- Adds a repository-wide ontology linter, unit tests, and pull-request CI.
- Preserves the superseded formulation in a migration ledger.

## Review posture

Draft. Do not merge until the absent `frankxai/starlight-canon` repository is created or the authority link is otherwise ratified. No protocol semantics are changed.